### PR TITLE
Reload document configuration on tab page switch

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -632,6 +632,7 @@ void on_notebook1_switch_page_after(GtkNotebook *notebook, GtkNotebookPage *page
 		ui_document_show_hide(doc); /* update the document menu */
 		build_menu_update(doc);
 		sidebar_update_tag_list(doc, FALSE);
+		document_update_highlighting(doc);
 
 		/* We delay the check to avoid weird fast, unintended switching of notebook pages when
 		 * the 'file has changed' dialog is shown while the switch event is not yet completely

--- a/src/document.c
+++ b/src/document.c
@@ -2447,6 +2447,34 @@ static gboolean update_type_keywords(GeanyDocument *doc, gint lang)
 	return ret;
 }
 
+/*
+ * Updates the keywords in a document and re-colourizes it.
+ *
+ * @param doc The document
+ */
+void document_update_highlighting(GeanyDocument *doc)
+{
+	const GString *s = NULL;
+	ScintillaObject *sci;
+	gint keyword_idx;
+
+	g_return_if_fail(DOC_VALID(doc));
+	g_return_if_fail(IS_SCINTILLA(doc->editor->sci));
+
+	sci = doc->editor->sci;
+
+	/* get possibly cached list of keywords for the current language.
+	 * we don't care whether the cached keywords have changed. */
+	(void) get_project_typenames(&s, doc->file_type->lang);
+
+	if (s)
+	{
+		keyword_idx = editor_lexer_get_type_keyword_idx(sci_get_lexer(sci));
+		sci_set_keywords(sci, keyword_idx, s->str);
+		queue_colourise(doc);
+	}
+}
+
 
 static void document_load_config(GeanyDocument *doc, GeanyFiletype *type,
 		gboolean filetype_changed)

--- a/src/document.h
+++ b/src/document.h
@@ -235,6 +235,8 @@ void document_update_tag_list(GeanyDocument *doc, gboolean update);
 
 void document_update_tag_list_in_idle(GeanyDocument *doc);
 
+void document_update_highlighting(GeanyDocument *doc);
+
 void document_set_encoding(GeanyDocument *doc, const gchar *new_encoding);
 
 gboolean document_check_disk_status(GeanyDocument *doc, gboolean force);


### PR DESCRIPTION
I'm posting as a pull request because I'm not 100% sure this is the "correct" fix so I was hoping someone would review it.  I've tested with all Geany's c/h files open and various Vala files and it fixes the highlighting issue and doesn't add any noticeable delay.

This closes [this bug here](https://sourceforge.net/tracker/index.php?func=detail&aid=3388212&group_id=153444&atid=787791) (and maybe others) and stops it from annoying me while I'm working on C and Vala at the same time :)
