### PR TITLE
Use Scintilla's buffer directly for parsing tags

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -2252,21 +2252,19 @@ gint document_replace_all(GeanyDocument *doc, const gchar *find_text, const gcha
 
 static gboolean update_tags_from_buffer(GeanyDocument *doc)
 {
-	gboolean result;
-#if 0
-		/* old code */
-		result = tm_source_file_update(doc->tm_file, TRUE, FALSE, TRUE);
-#else
-		gsize len = sci_get_length(doc->editor->sci) + 1;
-		gchar *text = g_malloc(len);
+	guchar *buffer_ptr;
+	gsize len;
 
-		/* we copy the whole text into memory instead using a direct char pointer from
-		 * Scintilla because tm_source_file_buffer_update() does modify the string slightly */
-		sci_get_text(doc->editor->sci, len, text);
-		result = tm_source_file_buffer_update(doc->tm_file, (guchar*) text, len, TRUE);
-		g_free(text);
-#endif
-	return result;
+	len = sci_get_length(doc->editor->sci) + 1;
+
+	/* gets a direct character pointer from Scintilla.
+	 * this is OK because tm_source_file_buffer_update() does not modify the
+	 * buffer, it only requires that buffer doesn't change while it's running,
+	 * which it won't since it runs in this thread (ie. synchronously).
+	 * see tagmanager/read.c:bufferOpen */
+	buffer_ptr = (guchar *) scintilla_send_message(doc->editor->sci, SCI_GETCHARACTERPOINTER, 0, 0);
+
+	return tm_source_file_buffer_update(doc->tm_file, buffer_ptr, len, TRUE);
 }
 
 


### PR DESCRIPTION
Instead of allocating and freeing the whole buffer each time it's parsed, use a direct pointer into Scintilla's buffer.  I think it should be OK since when TagManager/Ctags reads from the memory file it seems [it gets a copy of what's read from the buffer](https://github.com/geany/geany/blob/master/tagmanager/mio/mio-memory.c#L74).

This definitively should get some review before committing though.

Also, is there something we could do to MIO to completely prevent writing to the file, since IIUC we _never_ want this to happen in Geany?
