### PR TITLE
New --read-only commandline option.

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -362,6 +362,11 @@ Short option  Long option              Function
                                        stdout, one line each. This is mainly intended for plugin
                                        authors to detect installation paths.
 
+-r            --read-only              Open all files given on the command line in read-only mode.
+									   This only applies to files opened explicitly from the command
+									   line, so files from previous sessions or project files are
+									   unaffected.
+
 -s            --no-session             Do not load the previous session's files.
 
 -t            --no-terminal            Do not load terminal support. Use this option if you do

--- a/src/document.c
+++ b/src/document.c
@@ -1162,7 +1162,7 @@ GeanyDocument *document_open_file_full(GeanyDocument *doc, const gchar *filename
 		doc->has_bom = filedata.bom;
 		store_saved_encoding(doc);	/* store the opened encoding for undo/redo */
 
-		doc->readonly = readonly || filedata.readonly;
+		doc->readonly = readonly || filedata.readonly || cl_options.readonly;
 		sci_set_readonly(doc->editor->sci, doc->readonly);
 
 		/* update line number margin width */

--- a/src/main.c
+++ b/src/main.c
@@ -140,6 +140,7 @@ static GOptionEntry entries[] =
 	{ "no-plugins", 'p', 0, G_OPTION_ARG_NONE, &no_plugins, N_("Don't load plugins"), NULL },
 #endif
 	{ "print-prefix", 0, 0, G_OPTION_ARG_NONE, &print_prefix, N_("Print Geany's installation prefix"), NULL },
+	{ "read-only", 'r', 0, G_OPTION_ARG_NONE, &cl_options.readonly, N_("Open all FILES in read-only mode (see documention)"), NULL },
 	{ "no-session", 's', G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &cl_options.load_session, N_("Don't load the previous session's files"), NULL },
 #ifdef HAVE_VTE
 	{ "no-terminal", 't', 0, G_OPTION_ARG_NONE, &no_vte, N_("Don't load terminal support"), NULL },
@@ -886,13 +887,19 @@ void main_load_project_from_command_line(const gchar *locale_filename, gboolean 
 static void load_startup_files(gint argc, gchar **argv)
 {
 	gboolean load_project_from_cl = FALSE;
+	gboolean cl_files_opened = FALSE;
 
 	/* ATM when opening a project file any other filenames are ignored */
 	load_project_from_cl = (argc > 1) && g_str_has_suffix(argv[1], ".geany");
 	if (load_project_from_cl && argc > 2)
 		g_print("Ignoring extra filenames after %s", argv[1]);
 
-	if (load_project_from_cl || ! open_cl_files(argc, argv))
+	if (!load_project_from_cl)
+		cl_files_opened = open_cl_files(argc, argv);
+	/* switch readonly mode off for session files, future files and projects */
+	cl_options.readonly = FALSE;
+
+	if (! cl_files_opened)
 	{
 		if (prefs.load_session)
 		{

--- a/src/main.h
+++ b/src/main.h
@@ -32,6 +32,7 @@ typedef struct
 	gint		goto_column;
 	gboolean	ignore_global_tags;
 	gboolean	list_documents;
+	gboolean 	readonly;
 }
 CommandLineOptions;
 


### PR DESCRIPTION
This adds a new commandline option --read-only (or -r). It's implemented
according to the behavior agreed on on the mailing list:

--read-only applies to all files on the command line
irrespective of positioning and has no effect on any other files
opened by session or menu (...)

Current behaviour on attempting to re-open a file with different
read-only status is that nothing happens, the already open
file is raised but not changed. (...)
