### PR TITLE
Add compatibility wrappers to geany.h for newer GTK+ functions

### DIFF
--- a/plugins/splitwindow.c
+++ b/plugins/splitwindow.c
@@ -301,8 +301,12 @@ static void split_view(gboolean horizontal)
 	GtkWidget *parent = gtk_widget_get_parent(notebook);
 	GtkWidget *pane, *toolbar, *box;
 	GeanyDocument *doc = document_get_current();
-	gint width = notebook->allocation.width / 2;
-	gint height = notebook->allocation.height / 2;
+	GtkAllocation nb_alloc = { 0 };
+	gint width, height;
+
+	gtk_widget_get_allocation(notebook, &nb_alloc);
+	width = nb_alloc.width / 2;
+	height = nb_alloc.height / 2;
 
 	g_return_if_fail(doc);
 	g_return_if_fail(edit_window.editor == NULL);

--- a/src/about.c
+++ b/src/about.c
@@ -178,7 +178,8 @@ static GtkWidget *create_dialog(void)
 	header_label_style_set(header_label);
 	g_signal_connect_after(header_eventbox, "style-set", G_CALLBACK(header_eventbox_style_set), NULL);
 	g_signal_connect_after(header_label, "style-set", G_CALLBACK(header_label_style_set), NULL);
-	gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog)->vbox), header_eventbox, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))),
+		header_eventbox, FALSE, FALSE, 0);
 
 	/* set image */
 	icon = ui_new_pixbuf_from_inline(GEANY_IMAGE_LOGO);
@@ -190,7 +191,8 @@ static GtkWidget *create_dialog(void)
 	notebook = gtk_notebook_new();
 	gtk_widget_show(notebook);
 	gtk_container_set_border_width(GTK_CONTAINER(notebook), 2);
-	gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog)->vbox), notebook, TRUE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))),
+		notebook, TRUE, TRUE, 0);
 
 	/* create "Info" tab */
 	info_box = gtk_vbox_new(FALSE, 0);

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1769,7 +1769,7 @@ void on_back_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 gboolean on_motion_event(GtkWidget *widget, GdkEventMotion *event, gpointer user_data)
 {
-	if (prefs.auto_focus && ! GTK_WIDGET_HAS_FOCUS(widget))
+	if (prefs.auto_focus && ! gtk_widget_has_focus(widget))
 		gtk_widget_grab_focus(widget);
 
 	return FALSE;

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -868,7 +868,7 @@ gboolean dialogs_show_unsaved_file(GeanyDocument *doc)
 
 #ifndef G_OS_WIN32
 static void
-on_font_apply_button_clicked(GtkButton *button, gpointer user_data)
+on_font_ok_button_clicked(GtkButton *button, gpointer user_data)
 {
 	gchar *fontname;
 
@@ -876,14 +876,7 @@ on_font_apply_button_clicked(GtkButton *button, gpointer user_data)
 		GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel));
 	ui_set_editor_font(fontname);
 	g_free(fontname);
-}
 
-
-static void
-on_font_ok_button_clicked(GtkButton *button, gpointer user_data)
-{
-	/* We do the same thing as apply, but we close the dialog after. */
-	on_font_apply_button_clicked(button, NULL);
 	gtk_widget_hide(ui_widgets.open_fontsel);
 }
 
@@ -902,6 +895,7 @@ void dialogs_show_open_font()
 #ifdef G_OS_WIN32
 	win32_show_font_dialog();
 #else
+	GtkWidget *ok_button, *cancel_button;
 
 	if (ui_widgets.open_fontsel == NULL)
 	{
@@ -913,16 +907,12 @@ void dialogs_show_open_font()
 		gtk_window_set_type_hint(GTK_WINDOW(ui_widgets.open_fontsel), GDK_WINDOW_TYPE_HINT_DIALOG);
 		gtk_widget_set_name(ui_widgets.open_fontsel, "GeanyDialog");
 
-		gtk_widget_show(GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel)->apply_button);
+		ok_button = gtk_font_selection_dialog_get_ok_button(GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel));
+		cancel_button = gtk_font_selection_dialog_get_cancel_button(GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel));
 
-		g_signal_connect(ui_widgets.open_fontsel,
-					"delete-event", G_CALLBACK(gtk_widget_hide_on_delete), NULL);
-		g_signal_connect(GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel)->ok_button,
-					"clicked", G_CALLBACK(on_font_ok_button_clicked), NULL);
-		g_signal_connect(GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel)->cancel_button,
-					"clicked", G_CALLBACK(on_font_cancel_button_clicked), NULL);
-		g_signal_connect(GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel)->apply_button,
-					"clicked", G_CALLBACK(on_font_apply_button_clicked), NULL);
+		g_signal_connect(ui_widgets.open_fontsel, "delete-event", G_CALLBACK(gtk_widget_hide_on_delete), NULL);
+		g_signal_connect(ok_button, "clicked", G_CALLBACK(on_font_ok_button_clicked), NULL);
+		g_signal_connect(cancel_button, "clicked", G_CALLBACK(on_font_cancel_button_clicked), NULL);
 
 		gtk_font_selection_dialog_set_font_name(
 			GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel), interface_prefs.editor_font);

--- a/src/editor.c
+++ b/src/editor.c
@@ -197,7 +197,7 @@ static void on_snippet_keybinding_activate(gchar *key)
 	const gchar *s;
 	GHashTable *specials;
 
-	if (!doc || !GTK_WIDGET_HAS_FOCUS(doc->editor->sci))
+	if (!doc || !gtk_widget_has_focus(GTK_WIDGET(doc->editor->sci)))
 		return;
 
 	s = snippets_find_completion_by_name(doc->file_type->name, key);

--- a/src/gb.c
+++ b/src/gb.c
@@ -159,7 +159,7 @@ static GtkWidget *create_help_dialog(GtkWindow *parent)
 	gtk_window_set_modal(GTK_WINDOW(help_dialog), TRUE);
 	gtk_window_set_transient_for(GTK_WINDOW(help_dialog), parent);
 
-	dialog_vbox1 = GTK_DIALOG(help_dialog)->vbox;
+	dialog_vbox1 = gtk_dialog_get_content_area(GTK_DIALOG(help_dialog));
 	gtk_widget_show(dialog_vbox1);
 
 	scrolledwindow1 = gtk_scrolled_window_new(NULL, NULL);
@@ -184,14 +184,14 @@ static GtkWidget *create_help_dialog(GtkWindow *parent)
 	gtk_text_view_set_left_margin(GTK_TEXT_VIEW(textview1), 1);
 	gtk_text_view_set_right_margin(GTK_TEXT_VIEW(textview1), 1);
 
-	dialog_action_area1 = GTK_DIALOG(help_dialog)->action_area;
+	dialog_action_area1 = gtk_dialog_get_action_area(GTK_DIALOG(help_dialog));
 	gtk_widget_show(dialog_action_area1);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(dialog_action_area1), GTK_BUTTONBOX_END);
 
 	okbutton1 = gtk_button_new_from_stock(GTK_STOCK_OK);
 	gtk_widget_show(okbutton1);
 	gtk_dialog_add_action_widget(GTK_DIALOG(help_dialog), okbutton1, GTK_RESPONSE_OK);
-	GTK_WIDGET_SET_FLAGS(okbutton1, GTK_CAN_DEFAULT);
+	gtk_widget_set_can_default(okbutton1, TRUE);
 
 	return help_dialog;
 }

--- a/src/geany.h
+++ b/src/geany.h
@@ -93,4 +93,49 @@ void geany_debug(gchar const *format, ...) G_GNUC_PRINTF (1, 2);
 #define G_GNUC_WARN_UNUSED_RESULT
 #endif
 
+
+/* These functions aren't available until GTK+ 2.18.
+ * Delete them when we require that as a minimum version. */
+#if !GTK_CHECK_VERSION(2, 18, 0)
+#define gtk_widget_get_allocation(widget, alloc) (*(alloc) = (widget)->allocation)
+#define gtk_widget_set_can_default(widget, can_default) \
+	{ \
+		if (can_default) \
+			GTK_WIDGET_SET_FLAGS(widget, GTK_WIDGET_CAN_DEFAULT); \
+		else \
+			GTK_WIDGET_UNSET_FLAGS(widget, GTK_WIDGET_CAN_DEFAULT); \
+	}
+#define gtk_widget_set_can_focus(widget, can_focus) \
+	{ \
+		if (can_focus) \
+			GTK_WIDGET_SET_FLAGS(widget, GTK_WIDGET_CAN_FOCUS); \
+		else \
+			GTK_WIDGET_UNSET_FLAGS(widget, GTK_WIDGET_CAN_FOCUS); \
+	}
+#define gtk_widget_has_focus(widget) GTK_WIDGET_HAS_FOCUS(widget)
+#define gtk_widget_get_sensitive(widget) GTK_WIDGET_SENSITIVE(widget)
+#define gtk_widget_is_sensitive(widget) GTK_WIDGET_IS_SENSITIVE(widget)
+#define gtk_widget_set_has_window(widget, has_window) \
+	{ \
+		if (has_window) \
+			GTK_WIDGET_UNSET_FLAGS(widget, GTK_NO_WINDOW); \
+		else \
+			GTK_WIDGET_SET_FLAGS(widget, GTK_NO_WINDOW); \
+	}
+#define gtk_widget_get_visible(widget) GTK_WIDGET_VISIBLE(widget)
 #endif
+
+/* These functions aren't available until GTK+ 2.20.
+ * Delete them when we require that as a minimum version. */
+#if !GTK_CHECK_VERSION(2, 20, 0)
+#define gtk_widget_get_mapped(widget) GTK_WIDGET_MAPPED(widget)
+#endif
+
+/* These functions aren't available until GTK+ 2.22.
+ * Delete them when we require taht as a minum version. */
+#if !GTK_CHECK_VERSION(2, 22, 0)
+#define gdk_drag_context_get_selected_action(ctx) (ctx)->action
+#endif
+
+
+#endif /* GEANY_H */

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -3604,7 +3604,7 @@ on_color_scheme_clicked(GtkMenuItem *menuitem, gpointer user_data)
 	gchar *path;
 
 	/* prevent callback on setting initial value */
-	if (!GTK_WIDGET_MAPPED(menuitem))
+	if (!gtk_widget_get_mapped(GTK_WIDGET(menuitem)))
 		return;
 
 	/* check if default item */

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1078,7 +1078,7 @@ static gboolean check_menu_key(GeanyDocument *doc, guint keyval, guint state, gu
 static gboolean on_menu_expose_event(GtkWidget *widget, GdkEventExpose *event,
 		gpointer user_data)
 {
-	if (!GTK_WIDGET_SENSITIVE(widget))
+	if (!gtk_widget_get_sensitive(widget))
 		gtk_widget_set_sensitive(GTK_WIDGET(widget), TRUE);
 	return FALSE;
 }
@@ -1518,7 +1518,7 @@ static gboolean cb_func_build_action(guint key_id)
 	if (doc == NULL)
 		return TRUE;
 
-	if (!GTK_WIDGET_IS_SENSITIVE(ui_lookup_widget(main_widgets.window, "menu_build1")))
+	if (!gtk_widget_get_sensitive(ui_lookup_widget(main_widgets.window, "menu_build1")))
 		return TRUE;
 
 	menu_items = build_get_menu_items(doc->file_type->id);
@@ -1558,7 +1558,7 @@ static gboolean cb_func_build_action(guint key_id)
 	/* Note: For Build menu items it's OK (at the moment) to assume they are in the correct
 	 * sensitive state, but some other menus don't update the sensitive status until
 	 * they are redrawn. */
-	if (item && GTK_WIDGET_IS_SENSITIVE(item))
+	if (item && gtk_widget_is_sensitive(item))
 		gtk_menu_item_activate(GTK_MENU_ITEM(item));
 	return TRUE;
 }
@@ -1641,7 +1641,7 @@ static gboolean cb_func_switch_action(guint key_id)
 			if (doc != NULL)
 			{
 				GtkWidget *sci = GTK_WIDGET(doc->editor->sci);
-				if (GTK_WIDGET_HAS_FOCUS(sci))
+				if (gtk_widget_has_focus(sci))
 					ui_update_statusbar(doc, -1);
 				else
 					gtk_widget_grab_focus(sci);
@@ -1992,7 +1992,7 @@ static gboolean cb_func_goto_action(guint key_id)
 				GtkWidget *wid = toolbar_get_widget_child_by_name("GotoEntry");
 
 				/* use toolbar item if shown & not in the drop down overflow menu */
-				if (wid && GTK_WIDGET_MAPPED(wid))
+				if (wid && gtk_widget_get_mapped(wid))
 				{
 					gtk_widget_grab_focus(wid);
 					return TRUE;

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -183,11 +183,11 @@ static void kb_tree_view_change_button_clicked_cb(GtkWidget *button, gpointer da
 					_("Press the combination of the keys you want to use for \"%s\"."), name);
 			label = gtk_label_new(str);
 			gtk_misc_set_padding(GTK_MISC(label), 5, 10);
-			gtk_container_add(GTK_CONTAINER(GTK_DIALOG(dialog)->vbox), label);
+			gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), label);
 
 			dialog_label = gtk_label_new("");
 			gtk_misc_set_padding(GTK_MISC(dialog_label), 5, 10);
-			gtk_container_add(GTK_CONTAINER(GTK_DIALOG(dialog)->vbox), dialog_label);
+			gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), dialog_label);
 
 			g_signal_connect(dialog, "key-press-event",
 								G_CALLBACK(kb_grab_key_dialog_key_press_cb), NULL);

--- a/src/search.c
+++ b/src/search.c
@@ -539,7 +539,7 @@ static void create_find_dialog(void)
 	gtk_button_box_set_child_secondary(GTK_BUTTON_BOX(bbox), check_close, TRUE);
 
 	ui_hbutton_box_copy_layout(
-		GTK_BUTTON_BOX(GTK_DIALOG(find_dlg.dialog)->action_area),
+		GTK_BUTTON_BOX(gtk_dialog_get_content_area(GTK_DIALOG(find_dlg.dialog))),
 		GTK_BUTTON_BOX(bbox));
 	gtk_container_add(GTK_CONTAINER(exp), bbox);
 	gtk_container_add(GTK_CONTAINER(vbox), exp);
@@ -575,7 +575,7 @@ void search_show_find_dialog(void)
 	else
 	{
 		/* only set selection if the dialog is not already visible */
-		if (! GTK_WIDGET_VISIBLE(find_dlg.dialog) && sel)
+		if (! gtk_widget_get_visible(find_dlg.dialog) && sel)
 			gtk_entry_set_text(GTK_ENTRY(find_dlg.entry), sel);
 		gtk_widget_grab_focus(find_dlg.entry);
 		set_dialog_position(find_dlg.dialog, find_dlg.position);
@@ -721,7 +721,7 @@ static void create_replace_dialog(void)
 	gtk_button_box_set_child_secondary(GTK_BUTTON_BOX(bbox), check_close, TRUE);
 
 	ui_hbutton_box_copy_layout(
-		GTK_BUTTON_BOX(GTK_DIALOG(replace_dlg.dialog)->action_area),
+		GTK_BUTTON_BOX(gtk_dialog_get_action_area(GTK_DIALOG(replace_dlg.dialog))),
 		GTK_BUTTON_BOX(bbox));
 	gtk_container_add(GTK_CONTAINER(exp), bbox);
 	gtk_container_add(GTK_CONTAINER(vbox), exp);
@@ -751,7 +751,7 @@ void search_show_replace_dialog(void)
 	else
 	{
 		/* only set selection if the dialog is not already visible */
-		if (! GTK_WIDGET_VISIBLE(replace_dlg.dialog) && sel)
+		if (! gtk_widget_get_visible(replace_dlg.dialog) && sel)
 			gtk_entry_set_text(GTK_ENTRY(replace_dlg.find_entry), sel);
 		if (sel != NULL) /* when we have a selection, reset the entry widget's background colour */
 			ui_set_search_entry_background(replace_dlg.find_entry, TRUE);
@@ -1052,7 +1052,7 @@ void search_show_find_in_files_dialog(const gchar *dir)
 	stash_group_display(fif_prefs, fif_dlg.dialog);
 
 	/* only set selection if the dialog is not already visible, or has just been created */
-	if (doc && ! sel && ! GTK_WIDGET_VISIBLE(fif_dlg.dialog))
+	if (doc && ! sel && ! gtk_widget_get_visible(fif_dlg.dialog))
 		sel = editor_get_default_selection(doc->editor, search_prefs.use_current_word, NULL);
 
 	entry = gtk_bin_get_child(GTK_BIN(fif_dlg.search_combo));

--- a/src/stash.c
+++ b/src/stash.c
@@ -538,7 +538,7 @@ lookup_widget(GtkWidget *widget, const gchar *widget_name)
 			if (GTK_IS_MENU (widget))
 				parent = gtk_menu_get_attach_widget (GTK_MENU (widget));
 			else
-				parent = widget->parent;
+				parent = gtk_widget_get_parent(widget);
 			if (!parent)
 				parent = (GtkWidget*) g_object_get_data (G_OBJECT (widget), "GladeParentKey");
 			if (parent == NULL)

--- a/src/toolbar.c
+++ b/src/toolbar.c
@@ -809,12 +809,13 @@ static void tb_editor_drag_data_rcvd_cb(GtkWidget *widget, GdkDragContext *conte
 	GtkTreeView *tree = GTK_TREE_VIEW(widget);
 	gboolean del = FALSE;
 
-	if (data->length >= 0 && data->format == 8)
+	if (gtk_selection_data_get_length(data) >= 0 &&
+		gtk_selection_data_get_format(data) == 8)
 	{
 		gboolean is_sep;
 		gchar *text = NULL;
 
-		text = (gchar*) data->data;
+		text = (gchar*) gtk_selection_data_get_data(data);
 		is_sep = utils_str_equal(text, TB_EDITOR_SEPARATOR);
 		/* If the source of the action is equal to the target, we do just re-order and so need
 		 * to delete the separator to get it moved, not just copied. */

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1383,7 +1383,7 @@ GtkWidget *ui_dialog_vbox_new(GtkDialog *dialog)
 	GtkWidget *vbox = gtk_vbox_new(FALSE, 12);	/* need child vbox to set a separate border. */
 
 	gtk_container_set_border_width(GTK_CONTAINER(vbox), 6);
-	gtk_container_add(GTK_CONTAINER(GTK_DIALOG(dialog)->vbox), vbox);
+	gtk_container_add(GTK_CONTAINER(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), vbox);
 	return vbox;
 }
 
@@ -1992,6 +1992,7 @@ void ui_swap_sidebar_pos(void)
 	GtkWidget *left = gtk_paned_get_child1(GTK_PANED(pane));
 	GtkWidget *right = gtk_paned_get_child2(GTK_PANED(pane));
 	GtkWidget *box = ui_lookup_widget(main_widgets.window, "vbox1");
+	GtkAllocation pane_alloc = { 0 };
 
 	/* reparenting avoids scintilla problem with middle click paste */
 	gtk_widget_reparent(left, box);
@@ -1999,8 +2000,10 @@ void ui_swap_sidebar_pos(void)
 	gtk_widget_reparent(right, pane);
 	gtk_widget_reparent(left, pane);
 
-	gtk_paned_set_position(GTK_PANED(pane), pane->allocation.width
-		- gtk_paned_get_position(GTK_PANED(pane)));
+	gtk_widget_get_allocation(pane, &pane_alloc);
+
+	gtk_paned_set_position(GTK_PANED(pane),
+		pane_alloc.width - gtk_paned_get_position(GTK_PANED(pane)));
 }
 
 
@@ -2172,7 +2175,7 @@ static void on_auto_separator_item_show_hide(GtkWidget *widget, gpointer user_da
 {
 	GeanyAutoSeparator *autosep = user_data;
 
-	if (GTK_WIDGET_VISIBLE(widget))
+	if (gtk_widget_get_visible(widget))
 		autosep->ref_count++;
 	else
 		autosep->ref_count--;
@@ -2203,7 +2206,7 @@ void ui_auto_separator_add_ref(GeanyAutoSeparator *autosep, GtkWidget *item)
 		g_signal_connect(autosep->widget, "destroy",
 			G_CALLBACK(gtk_widget_destroyed), &autosep->widget);
 
-	if (GTK_WIDGET_VISIBLE(item))
+	if (gtk_widget_get_visible(item))
 	{
 		autosep->ref_count++;
 		auto_separator_update(autosep);
@@ -2252,7 +2255,7 @@ GtkWidget *ui_lookup_widget(GtkWidget *widget, const gchar *widget_name)
 		if (GTK_IS_MENU(widget))
 			parent = gtk_menu_get_attach_widget(GTK_MENU(widget));
 		else
-			parent = widget->parent;
+			parent = gtk_widget_get_parent(widget);
 		if (parent == NULL)
 			parent = (GtkWidget*) g_object_get_data(G_OBJECT(widget), "GladeParentKey");
 		if (parent == NULL)

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -34,7 +34,6 @@
 	g_object_set_data_full(G_OBJECT(owner), widget_name, \
 		g_object_ref(widget), (GDestroyNotify)g_object_unref);
 
-
 /** Interface preferences */
 typedef struct GeanyInterfacePrefs
 {

--- a/src/vte.c
+++ b/src/vte.c
@@ -244,7 +244,7 @@ static void create_vte(void)
 
 	vc->vte = vte = vf->vte_terminal_new();
 	scrollbar = gtk_vscrollbar_new(GTK_ADJUSTMENT(VTE_TERMINAL(vte)->adjustment));
-	GTK_WIDGET_UNSET_FLAGS(scrollbar, GTK_CAN_FOCUS);
+	gtk_widget_set_can_focus(scrollbar, FALSE);
 
 	/* create menu now so copy/paste shortcuts work */
 	vc->menu = vte_create_popup_menu();
@@ -681,9 +681,13 @@ static void vte_drag_data_received(GtkWidget *widget, GdkDragContext *drag_conte
 {
 	if (info == TARGET_TEXT_PLAIN)
 	{
-		if (data->format == 8 && data->length > 0)
+		if (gtk_selection_data_get_length(data) > 0 &&
+			gtk_selection_data_get_format(data) == 8)
+		{
 			vf->vte_terminal_feed_child(VTE_TERMINAL(widget),
-				(const gchar*) data->data, data->length);
+				(const gchar*) gtk_selection_data_get_data(data),
+				gtk_selection_data_get_length(data));
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Does this look like a reasonable way to support building with `-DGSEAL_ENABLE` while still working with older versions of GTK?

I removed `interface.c` from the build system while checking the build errors for `-DGSEAL_ENABLE`, and wherever there was an error I either used the equivalent GTK+ 2.16+ function(s) or added a wrapper in `geany.h` and used that.

There at least one `-DGSEAL_ENABLE` failing usage in `notebook.c:267` where I added a `FIXME` comment because I'm unsure how to fix it.
