### PR TITLE
Prevent double free in filetypes_detect_from_file_internal().

### DIFF
--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -985,7 +985,7 @@ static GeanyFiletype *filetypes_detect_from_file_internal(const gchar *utf8_file
 							&regerr);
 	if (regerr == NULL)
 	{
-		for (i = 0; i < GEANY_FILETYPE_SEARCH_LINES; i++)
+		for (i = 0; i < GEANY_FILETYPE_SEARCH_LINES && NZV(lines[i]); i++)
 		{
 			if (g_regex_match(ft_regex, lines[i], 0, &match))
 			{


### PR DESCRIPTION
Some glib versions (e.g. 2.28.8) don't actually create a GMatchInfo
in g_regex_match() if it retuns false (the documentation states it does).
This leads to a double free since the match_info paramter is unchanged,
and passed to g_match_info_free() (as according to the docs).

Set the match to NULL to prevent double free which also works with non-broken
glib.
