### PR TITLE
Fixed ruby lexer to correctly handle '=begin' comments at start of file.

### DIFF
--- a/scintilla/lexers/LexRuby.cxx
+++ b/scintilla/lexers/LexRuby.cxx
@@ -788,13 +788,13 @@ static void ColouriseRbDoc(unsigned int startPos, int length, int initStyle,
 				state = SCE_RB_COMMENTLINE;
 			} else if (ch == '=') {
 				// =begin indicates the start of a comment (doc) block
-                if (i == 0 || (isEOLChar(chPrev)
+                if ((i == 0 || isEOLChar(chPrev))
                     && chNext == 'b'
                     && styler.SafeGetCharAt(i + 2) == 'e'
                     && styler.SafeGetCharAt(i + 3) == 'g'
                     && styler.SafeGetCharAt(i + 4) == 'i'
                     && styler.SafeGetCharAt(i + 5) == 'n'
-                    && !isSafeWordcharOrHigh(styler.SafeGetCharAt(i + 6)))) {
+                    && !isSafeWordcharOrHigh(styler.SafeGetCharAt(i + 6))) {
                     styler.ColourTo(i - 1, state);
                     state = SCE_RB_POD;
 				} else {


### PR DESCRIPTION
Any '=' at the start of a file would incorrectly trigger the comment state.
It wasn't properly grouping && and || conditions.
