### PR TITLE
Move line(s) up/down: properly handle last line without trailing newline

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1924,7 +1924,10 @@ static void sci_deselect_last_newline(ScintillaObject *sci)
 	start = sci_get_selection_start(sci);
 	end = sci_get_selection_end(sci);
 	if (end > start && sci_get_col_from_position(sci, end) == 0)
-		sci_set_selection(sci, start, end-1);
+	{
+		end = sci_get_line_end_position(sci, sci_get_line_from_position(sci, end) - 1);
+		sci_set_selection(sci, start, end);
+	}
 }
 
 


### PR DESCRIPTION
Code inside `editor.c:move_lines()` didn't work correctly if user tried to
- move up the last line without trailing newline;
- **or** move down the line before such the last line.

In those cases two last lines were merged. You can easily check it yourself.

I rewrote the `move_lines` function to correctly handle this situation. As described in the commit message, the solution is to cut moved lines without their surrounding newlines and append necessary newlines after inserting the lines at the new position.

I also created (to be more precise, extracted from another code) function `sci_deselect_last_newline`, because it was useful this time and may be useful in future.
