### PR TITLE
Get MacOS socket working (replace '/' with '_' in $DISPLAY)

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -283,6 +283,9 @@ gint socket_init(gint argc, gchar **argv)
 		*p = '\0';
 	while ((p = strchr(display_name, ':')) != NULL)
 		*p = '_';
+	/* strip out any backslashes (mac has them in DISPLAY) */
+	while ((p = strchr(display_name, '/')) != NULL)
+		*p = '_';
 
 	if (socket_info.file_name == NULL)
 		socket_info.file_name = g_strdup_printf("%s%cgeany_socket_%s_%s",


### PR DESCRIPTION
The Mac has '/' characters in the DISPLAY variable which prevented geany's socket from opening, replacing them with underscores '_' is probably a smart thing to do for all platforms.
