### PR TITLE
Add Unity Quicklist shortcut

### DIFF
--- a/geany.desktop.in
+++ b/geany.desktop.in
@@ -10,9 +10,8 @@ Terminal=false
 Categories=GTK;Development;IDE;
 MimeType=text/plain;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;text/x-java;text/x-dsrc;text/x-pascal;text/x-perl;text/x-python;application/x-php;application/x-httpd-php3;application/x-httpd-php4;application/x-httpd-php5;application/xml;text/html;text/css;text/x-sql;text/x-diff;
 StartupNotify=true
-Actions=New
+Actions=New;
 
 [Desktop Action New]
 _Name=Open a New Instance
 Exec=geany --new-instance
-TargetEnvironment=Unity


### PR DESCRIPTION
This adds a static Unity Quicklist shortcut to geany's .desktop file. It will appear as an option on the right-click context menu for the Geany icon in Unity's launcher.
