### PR TITLE
Add keywords

### DIFF
--- a/geany.desktop.in
+++ b/geany.desktop.in
@@ -10,5 +10,4 @@ Terminal=false
 Categories=GTK;Development;IDE;
 MimeType=text/plain;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;text/x-java;text/x-dsrc;text/x-pascal;text/x-perl;text/x-python;application/x-php;application/x-httpd-php3;application/x-httpd-php4;application/x-httpd-php5;application/xml;text/html;text/css;text/x-sql;text/x-diff;
 StartupNotify=true
-TargetEnvironment=Unity
 _Keywords=Code;Editor;Programming


### PR DESCRIPTION
Adds searchable keywords to geany's .desktop file, used by Unity and Gnome-Shell.
