### PR TITLE
Base path fixes

### DIFF
--- a/plugins/geanyfunctions.h
+++ b/plugins/geanyfunctions.h
@@ -430,5 +430,7 @@
 	geany_functions->p_build->build_set_menu_item
 #define build_get_group_count \
 	geany_functions->p_build->build_get_group_count
+#define project_get_base_path \
+	geany_functions->p_project->project_get_base_path
 
 #endif

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -53,7 +53,7 @@
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 214
+#define GEANY_API_VERSION 215
 
 /** The Application Binary Interface (ABI) version, incremented whenever
  * existing fields in the plugin data types have to be changed or reordered.
@@ -276,6 +276,7 @@ typedef struct GeanyFunctions
 	struct StashFuncs			*p_stash;			/**< See stash.h */
 	struct SymbolsFuncs			*p_symbols;			/**< See symbols.h */
 	struct BuildFuncs			*p_build;			/**< See build.h */
+	struct ProjectFuncs			*p_project;			/**< See project.h */
 }
 GeanyFunctions;
 
@@ -723,6 +724,13 @@ typedef struct BuildFuncs
 	guint (*build_get_group_count)(const GeanyBuildGroup grp);
 }
 BuildFuncs;
+
+/* See project.h */
+typedef struct ProjectFuncs
+{
+	gchar *(*project_get_base_path)(void);
+}
+ProjectFuncs;
 
 /* Deprecated aliases */
 #ifndef GEANY_DISABLE_DEPRECATED

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -59,6 +59,7 @@
 #include "keyfile.h"
 #include "win32.h"
 #include "pluginutils.h"
+#include "project.h"
 #include "pluginprivate.h"
 
 
@@ -361,6 +362,10 @@ static BuildFuncs build_funcs = {
 	&build_get_group_count
 };
 
+static ProjectFuncs project_funcs = {
+	&project_get_base_path
+};
+
 static GeanyFunctions geany_functions = {
 	&doc_funcs,
 	&sci_funcs,
@@ -384,7 +389,8 @@ static GeanyFunctions geany_functions = {
 	&msgwin_funcs,
 	&stash_funcs,
 	&symbols_funcs,
-	&build_funcs
+	&build_funcs,
+	&project_funcs
 };
 
 static GeanyData geany_data;

--- a/src/project.c
+++ b/src/project.c
@@ -1077,11 +1077,17 @@ static gboolean write_config(gboolean emit_signal)
 }
 
 
-/* Constructs the project's base path which is used for "Make all" and "Execute".
- * The result is an absolute string in UTF-8 encoding which is either the same as
- * base path if it is absolute or it is built out of project file name's dir and base_path.
- * If there is no project or project's base_path is invalid, NULL will be returned.
- * The returned string should be freed when no longer needed. */
+/**
+ * Constructs the project's base path. The result is an absolute string in UTF-8
+ * encoding which is either the same as base path if it is absolute or it is 
+ * built out of project file name's dir and base_path. If there is no project or
+ * project's base_path is invalid, NULL will be returned. The returned string 
+ * should be freed when no longer needed.
+ *
+ * @return Absolute base path or NULL on error.
+ *
+ * @since 1.22
+ **/
 gchar *project_get_base_path(void)
 {
 	GeanyProject *project = app->project;

--- a/src/search.c
+++ b/src/search.c
@@ -1064,8 +1064,10 @@ void search_show_find_in_files_dialog(const gchar *dir)
 	 * (in create_fif_dialog() it would fail if a project is opened after dialog creation) */
 	if (app->project != NULL && NZV(app->project->base_path))
 	{
+		gchar *base_path = project_get_base_path();
 		ui_combo_box_prepend_text_once(GTK_COMBO_BOX(fif_dlg.dir_combo),
-			app->project->base_path);
+			base_path);
+		g_free(base_path);
 	}
 
 	entry = gtk_bin_get_child(GTK_BIN(fif_dlg.dir_combo));
@@ -1082,7 +1084,7 @@ void search_show_find_in_files_dialog(const gchar *dir)
 			/* use default_open_path if no directory could be determined
 			 * (e.g. when no files are open) */
 			if (!cur_dir)
-				cur_dir = g_strdup(utils_get_default_dir_utf8());
+				cur_dir = utils_get_default_dir_utf8();
 			if (!cur_dir)
 				cur_dir = g_get_current_dir();
 		}

--- a/src/utils.c
+++ b/src/utils.c
@@ -1635,16 +1635,16 @@ guint utils_string_regex_replace_all(GString *haystack, GRegex *regex,
 
 
 /* Get project or default startup directory (if set), or NULL. */
-const gchar *utils_get_default_dir_utf8(void)
+gchar *utils_get_default_dir_utf8(void)
 {
 	if (app->project && NZV(app->project->base_path))
 	{
-		return app->project->base_path;
+		return project_get_base_path();
 	}
 
 	if (NZV(prefs.default_open_path))
 	{
-		return prefs.default_open_path;
+		return g_strdup(prefs.default_open_path);
 	}
 	return NULL;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -207,7 +207,7 @@ gchar *utils_get_hex_from_color(GdkColor *color);
 
 guint utils_invert_color(guint color);
 
-const gchar *utils_get_default_dir_utf8(void);
+gchar *utils_get_default_dir_utf8(void);
 
 gchar *utils_get_current_file_dir_utf8(void);
 


### PR DESCRIPTION
Because app->project->base_path can be relative, its direct use leads to resolving the directory which is relative to the directory where Geany was started instead of the project directory. Using project_get_base_path() everywhere fixes the problem.

I've also added this function to API so it can be used by the plugins. Once it's in, I'll submit a patch for geany-plugins.

The app->project->base_path member is a bit dangerous because it's tempting to use but in most cases you want the absolute path. Maybe it could be moved to projectprivate.h once all the plugins are fixed. 