### PR TITLE
Relative project path

### DIFF
--- a/plugins/geanyfunctions.h
+++ b/plugins/geanyfunctions.h
@@ -264,6 +264,8 @@
 	geany_functions->p_utils->utils_find_open_xml_tag
 #define utils_find_open_xml_tag_pos \
 	geany_functions->p_utils->utils_find_open_xml_tag_pos
+#define utils_relpath \
+	geany_functions->p_utils->utils_relpath
 #define ui_dialog_vbox_new \
 	geany_functions->p_ui->ui_dialog_vbox_new
 #define ui_frame_new_with_alignment \

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -1138,7 +1138,7 @@ void configuration_open_files(void)
 	main_status.opening_session_files = TRUE;
 
 	i = file_prefs.tab_order_ltr ? 0 : (session_files->len - 1);
-	while (TRUE)
+	while (i >= 0 && i < (gint)session_files->len)
 	{
 		gchar **tmp = g_ptr_array_index(session_files, i);
 		guint len;
@@ -1151,17 +1151,9 @@ void configuration_open_files(void)
 		g_strfreev(tmp);
 
 		if (file_prefs.tab_order_ltr)
-		{
 			i++;
-			if (i >= (gint)session_files->len)
-				break;
-		}
 		else
-		{
 			i--;
-			if (i < 0)
-				break;
-		}
 	}
 
 	g_ptr_array_free(session_files, TRUE);

--- a/src/keyfile.h
+++ b/src/keyfile.h
@@ -49,7 +49,7 @@ void configuration_save_default_session(void);
 
 void configuration_load_session_files(GKeyFile *config, gboolean read_recent_files);
 
-void configuration_save_session_files(GKeyFile *config);
+void configuration_save_session_files(GKeyFile *config, gboolean relative);
 
 /* set some settings which are already read from the config file, but need other things, like the
  * realisation of the main window */

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -440,6 +440,7 @@ typedef struct UtilsFuncs
 	gchar**		(*utils_copy_environment)(const gchar **exclude_vars, const gchar *first_varname, ...);
 	gchar*		(*utils_find_open_xml_tag) (const gchar sel[], gint size);
 	const gchar*	(*utils_find_open_xml_tag_pos) (const gchar sel[], gint size);
+	gchar*		(*utils_relpath)(const gchar *origin, const gchar *dest);
 }
 UtilsFuncs;
 

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -225,7 +225,8 @@ static UtilsFuncs utils_funcs = {
 	&utils_get_file_list_full,
 	&utils_copy_environment,
 	&utils_find_open_xml_tag,
-	&utils_find_open_xml_tag_pos
+	&utils_find_open_xml_tag_pos,
+	&utils_relpath
 };
 
 static UIUtilsFuncs uiutils_funcs = {

--- a/src/project.c
+++ b/src/project.c
@@ -1059,7 +1059,11 @@ static gboolean write_config(gboolean emit_signal)
 
 	/* store the session files into the project too */
 	if (project_prefs.project_session)
-		configuration_save_session_files(config);
+	{
+		/* save both absolute and relative paths for open files */
+		configuration_save_session_files(config, FALSE);
+		configuration_save_session_files(config, TRUE);
+	}
 	build_save_menu(config, (gpointer)p, GEANY_BCS_PROJ);
 	if (emit_signal)
 	{

--- a/src/utils.c
+++ b/src/utils.c
@@ -2094,3 +2094,55 @@ gchar **utils_strv_join(gchar **first, gchar **second)
 	g_free(second);
 	return strv;
 }
+
+
+/**
+ * Generates relative path from the origin directory to the destination directory.
+ *
+ * @param origin_dir The origin directory.
+ * @param dest_dir The destination directory.
+ *
+ * @return The relative path or NULL when not successful.
+ **/
+gchar *utils_relpath(const gchar *origin_dir, const gchar *dest_dir)
+{
+	gchar *origin, *dest;
+	gchar **originv, **destv;
+	gchar *ret = NULL;
+	guint i, j;
+
+	origin = tm_get_real_path(origin_dir);
+	dest = tm_get_real_path(dest_dir);
+
+	if (!NZV(origin) || !NZV(dest) || origin[0] != dest[0])
+	{
+		g_free(origin);
+		g_free(dest);
+		return NULL;
+	}
+
+	originv = g_strsplit_set(g_path_skip_root(origin), "/\\", -1);
+	destv = g_strsplit_set(g_path_skip_root(dest), "/\\", -1);
+
+	for (i = 0; originv[i] != NULL && destv[i] != NULL; i++)
+		if (g_strcmp0(originv[i], destv[i]) != 0)
+			break;
+
+	ret = g_strdup("");
+
+	for (j = i; originv[j] != NULL; j++)
+		setptr(ret, g_build_filename(ret, "..", NULL));
+
+	for (j = i; destv[j] != NULL; j++)
+		setptr(ret, g_build_filename(ret, destv[j], NULL));
+
+	if (strlen(ret) == 0)
+		setptr(ret, g_strdup("./"));
+
+	g_free(origin);
+	g_free(dest);
+	g_strfreev(originv);
+	g_strfreev(destv);
+	
+	return ret;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -276,4 +276,6 @@ gchar *utils_str_remove_chars(gchar *string, const gchar *chars);
 
 gchar **utils_copy_environment(const gchar **exclude_vars, const gchar *first_varname, ...) G_GNUC_NULL_TERMINATED;
 
+gchar *utils_relpath(const gchar *origin, const gchar *dest);
+
 #endif


### PR DESCRIPTION
OK, this is the last of my 1.5-year-old patches. In addition to absolute path this patch also saves relative path for every open file in the project. When loading, it first reads the absolute paths and if the file isn't found (e.g. the whole project directory was moved), it reads the relative path and tries to open the file relatively to the project file.