### PR TITLE
Unsorted tags files

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1842,10 +1842,10 @@ static void init_user_tags(void)
 	{
 		utils_mkdir(dir, FALSE);
 	}
-	file_list = utils_get_file_list_full(dir, TRUE, TRUE, NULL);
+	file_list = utils_get_file_list_full(dir, TRUE, FALSE, NULL);
 
 	SETPTR(dir, g_build_filename(app->datadir, "tags", NULL));
-	list = utils_get_file_list_full(dir, TRUE, TRUE, NULL);
+	list = utils_get_file_list_full(dir, TRUE, FALSE, NULL);
 	g_free(dir);
 
 	file_list = g_slist_concat(file_list, list);


### PR DESCRIPTION
I think there is no need to load tags files in alphabetical order (nor in any particular order), so avoid useless sortings and order preserving for performances.

Am I wrong and the order in which tags files are loaded really matters for some reason?
