### PR TITLE
When not sorting the file list, don't preserve read order

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1440,8 +1440,6 @@ GSList *utils_get_file_list_full(const gchar *path, gboolean full_path, gboolean
 	/* sorting last is quicker than on insertion */
 	if (sort)
 		list = g_slist_sort(list, (GCompareFunc) utils_str_casecmp);
-	else
-		list = g_slist_reverse(list);
 	return list;
 }
 


### PR DESCRIPTION
If the caller doesn't want the list to be sorted, there is no need to
preserve the order in which the files were actually read, since that
order is undefined anyway.

This slightly "changes" the plugin API so maybe one wouldn't like it, but IMO since the order isn't guaranteed at any level anyway it should be harmless and would drop a then useless list reversal.
