### PR TITLE
Make win32_get_installation_dir() return a static/const path

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -373,12 +373,9 @@ static void setup_paths(void)
 #ifdef G_OS_WIN32
 	/* use the installation directory(the one where geany.exe is located) as the base for the
 	 * documentation and data files */
-	gchar *install_dir = win32_get_installation_dir();
-
+	const gchar *install_dir = win32_get_installation_dir();
 	data_dir = g_build_filename(install_dir, "data", NULL); /* e.g. C:\Program Files\geany\data */
 	doc_dir = g_build_filename(install_dir, "doc", NULL);
-
-	g_free(install_dir);
 #else
 	data_dir = g_build_filename(GEANY_DATADIR, "geany", NULL); /* e.g. /usr/share/geany */
 	doc_dir = g_build_filename(GEANY_DOCDIR, "html", NULL);
@@ -446,12 +443,8 @@ void main_locale_init(const gchar *locale_dir, const gchar *package)
 #endif
 
 #ifdef G_OS_WIN32
-	{
-		gchar *install_dir = win32_get_installation_dir();
-		/* e.g. C:\Program Files\geany\lib\locale */
-		l_locale_dir = g_build_filename(install_dir, "share", "locale", NULL);
-		g_free(install_dir);
-	}
+	/* e.g. C:\Program Files\geany\lib\locale */
+	l_locale_dir = g_build_filename(win32_get_installation_dir(), "share", "locale", NULL);
 #else
 	l_locale_dir = g_strdup(locale_dir);
 #endif
@@ -1138,14 +1131,9 @@ gint main(gint argc, gchar **argv)
 #endif
 
 #ifdef G_OS_WIN32
-	{
-		gchar *dir;
-		/* On Windows, change the working directory to the Geany installation path to not lock
-		 * the directory of a file passed as command line argument (see bug #2626124). */
-		dir = win32_get_installation_dir();
-		win32_set_working_directory(dir);
-		g_free(dir);
-	}
+	/* On Windows, change the working directory to the Geany installation path to not lock
+	 * the directory of a file passed as command line argument (see bug #2626124). */
+	win32_set_working_directory(win32_get_installation_dir());
 #endif
 
 	/* when we are really done with setting everything up and the main event loop is running,

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -959,13 +959,7 @@ load_plugins_from_path(const gchar *path)
 static gchar *get_plugin_path(void)
 {
 #ifdef G_OS_WIN32
-	gchar *path;
-	gchar *install_dir = win32_get_installation_dir();
-
-	path = g_build_filename(install_dir, "lib", NULL);
-	g_free(install_dir);
-
-	return path;
+	return g_build_filename(win32_get_installation_dir(), "lib", NULL);
 #else
 	return g_build_filename(GEANY_LIBDIR, "geany", NULL);
 #endif

--- a/src/win32.c
+++ b/src/win32.c
@@ -1295,9 +1295,14 @@ void win32_set_working_directory(const gchar *dir)
 }
 
 
-gchar *win32_get_installation_dir(void)
+const gchar *win32_get_installation_dir(void)
 {
-	return g_win32_get_package_installation_directory_of_module(NULL);
+	static gchar *install_dir = NULL; /* pointer is leaked */
+
+	if (install_dir == NULL)
+		install_dir = g_win32_get_package_installation_directory_of_module(NULL);
+
+	return (const gchar *) install_dir;
 }
 
 

--- a/src/win32.h
+++ b/src/win32.h
@@ -61,7 +61,7 @@ gboolean win32_spawn(const gchar *dir, gchar **argv, gchar **env, GSpawnFlags fl
 
 gchar *win32_get_shortcut_target(const gchar *file_name);
 
-gchar *win32_get_installation_dir(void);
+const gchar *win32_get_installation_dir(void);
 
 gchar *win32_expand_environment_variables(const gchar *str);
 


### PR DESCRIPTION
Avoids some allocating/freeing in exchange for leaking some memory back to the OS when closed.

Note: Not tested on Windows
