### PR TITLE
Save settings when plugin manager dialog is closed

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1052,7 +1052,8 @@ void plugins_load_active(void)
 
 
 /* Update the global active plugins list so it's up-to-date when configuration
- * is saved. Called in response to GeanyObject's "save-settings" signal. */
+ * is saved. Called in response to GeanyObject's "save-settings" signal. Also
+ * called directly in response to plugin manager dialog being closed. */
 static void update_active_plugins_pref(void)
 {
 	gint i = 0;
@@ -1387,6 +1388,10 @@ static void pm_dialog_response(GtkDialog *dialog, gint response, gpointer user_d
 		plugin_list = NULL;
 	}
 	gtk_widget_destroy(GTK_WIDGET(dialog));
+
+	/* Update global active plugins list before saving configuration */
+	update_active_plugins_pref();
+	configuration_save();
 }
 
 


### PR DESCRIPTION
Not sure if this is desirable, hence the pull request.

If applied, would close (IIUC) this feature request:
https://sourceforge.net/tracker/?func=detail&atid=787794&aid=3555785&group_id=153444
