### PR TITLE
Keep caret and anchor position upon indent and unindent

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -4983,20 +4983,20 @@ static void editor_change_line_indent(GeanyEditor *editor, gint line, gboolean i
 void editor_indent(GeanyEditor *editor, gboolean increase)
 {
 	ScintillaObject *sci = editor->sci;
-	/* 0 is caret, 1 is anchor */
-	gint orig_pos[2], orig_line[2], orig_offset[2], orig_indent_pos[2], orig_line_len[2];
+	gint caret_pos, caret_line, caret_offset, caret_indent_pos, caret_line_len;
+	gint anchor_pos, anchor_line, anchor_offset, anchor_indent_pos, anchor_line_len;
 
 	/* backup information needed to restore caret and anchor */
-	orig_pos[0] = sci_get_current_position(sci);
-	orig_pos[1] = SSM(sci, SCI_GETANCHOR, 0, 0);
-	orig_line[0] = sci_get_line_from_position(sci, orig_pos[0]);
-	orig_line[1] = sci_get_line_from_position(sci, orig_pos[1]);
-	orig_offset[0] = orig_pos[0] - sci_get_position_from_line(sci, orig_line[0]);
-	orig_offset[1] = orig_pos[1] - sci_get_position_from_line(sci, orig_line[1]);
-	orig_indent_pos[0] = sci_get_line_indent_position(sci, orig_line[0]);
-	orig_indent_pos[1] = sci_get_line_indent_position(sci, orig_line[1]);
-	orig_line_len[0] = sci_get_line_length(sci, orig_line[0]);
-	orig_line_len[1] = sci_get_line_length(sci, orig_line[1]);
+	caret_pos = sci_get_current_position(sci);
+	anchor_pos = SSM(sci, SCI_GETANCHOR, 0, 0);
+	caret_line = sci_get_line_from_position(sci, caret_pos);
+	anchor_line = sci_get_line_from_position(sci, anchor_pos);
+	caret_offset = caret_pos - sci_get_position_from_line(sci, caret_line);
+	anchor_offset = anchor_pos - sci_get_position_from_line(sci, anchor_line);
+	caret_indent_pos = sci_get_line_indent_position(sci, caret_line);
+	anchor_indent_pos = sci_get_line_indent_position(sci, anchor_line);
+	caret_line_len = sci_get_line_length(sci, caret_line);
+	anchor_line_len = sci_get_line_length(sci, anchor_line);
 
 	if (sci_get_lines_selected(sci) <= 1)
 	{
@@ -5024,13 +5024,13 @@ void editor_indent(GeanyEditor *editor, gboolean increase)
 	}
 
 	/* restore caret and anchor position */
-	if (orig_pos[0] >= orig_indent_pos[0])
-		orig_offset[0] += (sci_get_line_length(sci, orig_line[0]) - orig_line_len[0]);
-	if (orig_pos[1] >= orig_indent_pos[1])
-		orig_offset[1] += (sci_get_line_length(sci, orig_line[1]) - orig_line_len[1]);
+	if (caret_pos >= caret_indent_pos)
+		caret_offset += sci_get_line_length(sci, caret_line) - caret_line_len;
+	if (anchor_pos >= anchor_indent_pos)
+		anchor_offset += sci_get_line_length(sci, anchor_line) - anchor_line_len;
 
-	SSM(sci, SCI_SETCURRENTPOS, sci_get_position_from_line(sci, orig_line[0]) + orig_offset[0], 0);
-	SSM(sci, SCI_SETANCHOR, sci_get_position_from_line(sci, orig_line[1]) + orig_offset[1], 0);
+	SSM(sci, SCI_SETCURRENTPOS, sci_get_position_from_line(sci, caret_line) + caret_offset, 0);
+	SSM(sci, SCI_SETANCHOR, sci_get_position_from_line(sci, anchor_line) + anchor_offset, 0);
 }
 
 


### PR DESCRIPTION
This fixes https://sourceforge.net/tracker/?func=detail&aid=3167355&group_id=153444&atid=787791

However, it seems a little complicated (adds 10 variables), maybe it's overkill, or maybe I overlooked the thing and there is a simpler solution?  Though, note that I also indented some code to move it inside an else, so not _all_ is functional changes -- only the save/restore of the positions.

Algo here is that the new position on the line after (de) indentation is `O + (L' - L)` if `O > I`, else `O` (where `O` is original offset on the line, `L` and `L'` are line length before and after (de)indentation, and `I` is the original offest of the indentation on the line).

What do you guys think?
