### PR TITLE
Apply Geany encoding handling to files when making tags

### DIFF
--- a/tagmanager/src/Makefile.am
+++ b/tagmanager/src/Makefile.am
@@ -2,6 +2,7 @@ AM_CPPFLAGS = \
 	-I$(srcdir) \
 	-I$(srcdir)/.. \
 	-I$(srcdir)/../ctags \
+	-I$(top_srcdir) \
 	-DG_LOG_DOMAIN=\"Tagmanager\"
 AM_CFLAGS = \
 	$(GTK_CFLAGS)


### PR DESCRIPTION
geany -g stores symbols in the encoding of the source file.  But
the in-memory encoding is always UTF-8 so the tags should be stored
in UTF-8. This applies Geany's standard encoding handling to the
files before they are parsed for symbols.
