### PR TITLE
Disable commenting out blank lines by "Toggle line commentation"

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -3126,8 +3126,7 @@ void editor_do_comment_toggle(GeanyEditor *editor)
 			}
 
 			/* we are still here, so the above lines were not already comments, so comment it */
-			editor_do_comment(editor, i, TRUE, TRUE, TRUE);
-			count_commented++;
+			count_commented += editor_do_comment(editor, i, FALSE, TRUE, TRUE);
 		}
 		/* use multi line comment */
 		else
@@ -3196,12 +3195,13 @@ void editor_do_comment_toggle(GeanyEditor *editor)
 
 
 /* set toggle to TRUE if the caller is the toggle function, FALSE otherwise */
-void editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_lines, gboolean toggle,
+gint editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_lines, gboolean toggle,
 		gboolean single_comment)
 {
 	gint first_line, last_line, eol_char_len;
 	gint x, i, line_start, line_len;
 	gint sel_start, sel_end, co_len;
+	gint count = 0;
 	gchar sel[256];
 	const gchar *co, *cc;
 	gboolean break_loop = FALSE, single_line = FALSE;
@@ -3275,6 +3275,7 @@ void editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_line
 				}
 				else
 					sci_insert_text(editor->sci, start, co);
+				count++;
 			}
 			/* use multi line comment */
 			else
@@ -3287,6 +3288,7 @@ void editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_line
 					continue;
 
 				real_comment_multiline(editor, line_start, last_line);
+				count = 1;
 
 				/* break because we are already on the last line */
 				break_loop = TRUE;
@@ -3303,7 +3305,7 @@ void editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_line
 		if (single_line)
 		{
 			sci_set_selection_start(editor->sci, sel_start + co_len);
-			sci_set_selection_end(editor->sci, sel_end + ((i - first_line) * co_len));
+			sci_set_selection_end(editor->sci, sel_end + (count * co_len));
 		}
 		else
 		{
@@ -3312,6 +3314,7 @@ void editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_line
 			sci_set_selection_end(editor->sci, sel_end + co_len + eol_len);
 		}
 	}
+	return count;
 }
 
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -204,7 +204,7 @@ gboolean editor_show_calltip(GeanyEditor *editor, gint pos);
 
 void editor_do_comment_toggle(GeanyEditor *editor);
 
-void editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_lines, gboolean toggle,
+gint editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_lines, gboolean toggle,
 		gboolean single_comment);
 
 gint editor_do_uncomment(GeanyEditor *editor, gint line, gboolean toggle);


### PR DESCRIPTION
When default comment marker "~ " is used and "Strip trailing spaces and tabs on file saving" is enabled, commented blank lines will not be uncomment after file saving:
![before](https://f.cloud.github.com/assets/1297574/287614/ed71db52-925b-11e2-9bf1-f6cd8109fd69.gif)

**With this patch:**
![after](https://f.cloud.github.com/assets/1297574/287626/3c3e7dda-925c-11e2-83fa-f7fcd160b9d4.gif)
