### PR TITLE
Added copying GTK dll's to installed geany.exe folder

### DIFF
--- a/makefile.win32
+++ b/makefile.win32
@@ -14,6 +14,7 @@
 WINDRES = windres.exe
 CC = gcc
 CXX = g++
+PREFIX = C:/libs
 CP = copy /y
 RM = del
 MKDIR = mkdir
@@ -64,6 +65,11 @@ install:
 	-$(MKDIR) "$(DESTDIR)/lib"
 	$(CP) plugins$/*.dll "$(DESTDIR)/lib"
 	-$(MKDIR) "$(DESTDIR)/data"
+
+ifdef PREFIX
+	$(CP) $(PREFIX)/bin/*.dll "$(DESTDIR)/bin"
+endif
+
 ifdef MSYS
 	cp -r data "$(DESTDIR)"
 else


### PR DESCRIPTION
Hi, 

After installing my first geany's build on Windows I was faced with GTK's dll loading issues while runing geany.exe. Just installing of GTK runtime did not help, so I have thought that maybe it is not bad to just copy all needed GTK dlls to installed geany bin folder in makefile.win32.

P.S.
Sorry for mistakes - my first try on github community.
