### PR TITLE
Flexible terminal setting

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2346,7 +2346,8 @@ Tool paths
 ``````````
 
 Terminal
-    The location of your terminal executable.
+    The command to execute a script in a terminal.  If %c exists in the
+    command it is substituted by the run script name.
 
 Browser
     The location of your web browser executable.

--- a/src/build.c
+++ b/src/build.c
@@ -998,25 +998,23 @@ static GPid build_run_cmd(GeanyDocument *doc, guint cmdindex)
 #endif
 	{
 		gchar *locale_term_cmd = NULL;
-		gchar **term_argv = NULL;
-		guint term_argv_len, i;
+		gint argv_len, i;
 		gchar **argv = NULL;
 
 		/* get the terminal path */
 		locale_term_cmd = utils_get_locale_from_utf8(tool_prefs.term_cmd);
 		/* split the term_cmd, so arguments will work too */
-		term_argv = g_strsplit(locale_term_cmd, " ", -1);
-		term_argv_len = g_strv_length(term_argv);
+		g_shell_parse_argv(locale_term_cmd, &argv_len, &argv, NULL);
 
 		/* check that terminal exists (to prevent misleading error messages) */
-		if (term_argv[0] != NULL)
+		if (argv[0] != NULL)
 		{
-			gchar *tmp = term_argv[0];
+			gchar *tmp = argv[0];
 			/* g_find_program_in_path checks whether tmp exists and is executable */
-			term_argv[0] = g_find_program_in_path(tmp);
+			argv[0] = g_find_program_in_path(tmp);
 			g_free(tmp);
 		}
-		if (term_argv[0] == NULL)
+		if (argv[0] == NULL)
 		{
 			ui_set_statusbar(TRUE,
 				_("Could not find terminal \"%s\" "
@@ -1025,28 +1023,10 @@ static GPid build_run_cmd(GeanyDocument *doc, guint cmdindex)
 			goto free_strings;
 		}
 
-		argv = g_new0(gchar *, term_argv_len + 3);
-		for (i = 0; i < term_argv_len; i++)
+		for (i = 0; i < argv_len; i++)
 		{
-			argv[i] = g_strdup(term_argv[i]);
+			utils_str_replace_all(&(argv[i]), "%c", RUN_SCRIPT_CMD);
 		}
-#ifdef G_OS_WIN32
-		/* command line arguments only for cmd.exe */
-		if (strstr(argv[0], "cmd.exe") != NULL)
-		{
-			argv[term_argv_len] = g_strdup("/Q /C");
-			argv[term_argv_len + 1] = g_strdup(RUN_SCRIPT_CMD);
-		}
-		else
-		{
-			argv[term_argv_len] = g_strdup(RUN_SCRIPT_CMD);
-			argv[term_argv_len + 1] = NULL;
-		}
-#else
-		argv[term_argv_len   ]  = g_strdup("-e");
-		argv[term_argv_len + 1] = g_strconcat("/bin/sh ", RUN_SCRIPT_CMD, NULL);
-#endif
-		argv[term_argv_len + 2] = NULL;
 
 		if (! g_spawn_async(working_dir, argv, NULL, G_SPAWN_DO_NOT_REAP_CHILD,
 							NULL, NULL, &(run_info[cmdindex].pid), &error))
@@ -1067,7 +1047,6 @@ static GPid build_run_cmd(GeanyDocument *doc, guint cmdindex)
 		}
 		free_strings:
 		g_strfreev(argv);
-		g_strfreev(term_argv);
 		g_free(locale_term_cmd);
 	}
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -69,9 +69,9 @@
 #define GEANY_DISK_CHECK_TIMEOUT		30
 #define GEANY_DEFAULT_TOOLS_MAKE		"make"
 #ifdef G_OS_WIN32
-#define GEANY_DEFAULT_TOOLS_TERMINAL	"cmd.exe"
+#define GEANY_DEFAULT_TOOLS_TERMINAL	"cmd.exe /Q /C %c"
 #else
-#define GEANY_DEFAULT_TOOLS_TERMINAL	"xterm"
+#define GEANY_DEFAULT_TOOLS_TERMINAL	"xterm -e \"bin/sh %c\""
 #endif
 #define GEANY_DEFAULT_TOOLS_BROWSER		"firefox"
 #define GEANY_DEFAULT_TOOLS_PRINTCMD	"lpr"
@@ -473,7 +473,7 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_string(config, PACKAGE, "pref_template_datetime", template_prefs.datetime_format);
 
 	/* tools settings */
-	g_key_file_set_string(config, "tools", "term_cmd", tool_prefs.term_cmd ? tool_prefs.term_cmd : "");
+	g_key_file_set_string(config, "tools", "term_command", tool_prefs.term_cmd ? tool_prefs.term_cmd : "");
 	g_key_file_set_string(config, "tools", "browser_cmd", tool_prefs.browser_cmd ? tool_prefs.browser_cmd : "");
 	g_key_file_set_string(config, "tools", "grep_cmd", tool_prefs.grep_cmd ? tool_prefs.grep_cmd : "");
 	g_key_file_set_string(config, PACKAGE, "context_action_cmd", tool_prefs.context_action_cmd);
@@ -693,6 +693,7 @@ static void load_dialog_prefs(GKeyFile *config)
 {
 	gchar *tmp_string, *tmp_string2;
 	const gchar *default_charset = NULL;
+	gchar *cmd;
 
 	/* compatibility with Geany 0.20 */
 	if (!g_key_file_has_key(config, PACKAGE, atomic_file_saving_key, NULL))
@@ -882,7 +883,29 @@ static void load_dialog_prefs(GKeyFile *config)
 	template_prefs.datetime_format = utils_get_setting_string(config, PACKAGE, "pref_template_datetime", "%d.%m.%Y %H:%M:%S %Z");
 
 	/* tools */
-	tool_prefs.term_cmd = utils_get_setting_string(config, "tools", "term_cmd", GEANY_DEFAULT_TOOLS_TERMINAL);
+	cmd = utils_get_setting_string(config, "tools", "term_command", "");
+	if (!NZV(cmd))
+	{
+		cmd = utils_get_setting_string(config, "tools", "term_cmd", "");
+		if (NZV(cmd))
+		{
+#ifdef G_OS_WIN32
+			if (g_strstr_len(cmd, -1, "cmd.exe")
+			{
+				tmp_string = cmd;
+				cmd = g_strconcat(cmd, " /Q /C %c", NULL);
+				g_free(tmp_string);
+			}
+#else
+			tmp_string = cmd;
+			cmd = g_strconcat(cmd, " -e \"/bin/sh %c\"", NULL);
+			g_free(tmp_string);
+#endif
+		}
+		else
+			cmd = g_strdup(GEANY_DEFAULT_TOOLS_TERMINAL);
+	}
+	tool_prefs.term_cmd = cmd;
 	tool_prefs.browser_cmd = utils_get_setting_string(config, "tools", "browser_cmd", GEANY_DEFAULT_TOOLS_BROWSER);
 	tool_prefs.grep_cmd = utils_get_setting_string(config, "tools", "grep_cmd", GEANY_DEFAULT_TOOLS_GREP);
 


### PR DESCRIPTION
Previously was hard coded with options to suit xterm.  As this is
being replaced with different terminal programs some do not accept
the same options.  The new setting stores the whole command with
%c to substitute the script name.  Upgrades old settings if a new
one does not exist.

Warning untested on windows.
