### PR TITLE
Fixed notebook tab switching by keyboard shortcut

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1691,14 +1691,14 @@ static void switch_notebook_page(gint direction)
 	if (direction == GTK_DIR_LEFT)
 	{
 		if (cur_page > 0)
-			gtk_notebook_set_current_page(notebook, cur_page - 1);
+			gtk_notebook_prev_page(notebook);
 		else
-			gtk_notebook_set_current_page(notebook, page_count - 1);
+			gtk_notebook_set_current_page(notebook, -1);
 	}
 	else if (direction == GTK_DIR_RIGHT)
 	{
 		if (cur_page < page_count - 1)
-			gtk_notebook_set_current_page(notebook, cur_page + 1);
+			gtk_notebook_next_page(notebook);
 		else
 			gtk_notebook_set_current_page(notebook, 0);
 	}


### PR DESCRIPTION
When you choose to hide any of the tabs in the various UI components, such as unchecking "Preferences->Interface->Sidebar->Show documents list" or unchecking the various "_visible" preferences in Preferences->Various, the hidden tab prevents the keybindings for "Switch to left document" and "Switch to right document".

This fixes the bug so that it ignores non-visible tabs and still switches with wrapping.

Tested on: 
geany 1.23 (git >= db8e198) (built on Feb 20 2013 with GTK 2.24.4, GLib 2.28.6)
