### PR TITLE
Prompt before overwriting files in the Windows Save As dialog

### DIFF
--- a/src/win32.c
+++ b/src/win32.c
@@ -452,7 +452,7 @@ gchar *win32_show_document_save_as_dialog(GtkWindow *parent, const gchar *title,
 	of.lpstrFileTitle = NULL;
 	of.lpstrTitle = w_title;
 	of.lpstrDefExt = L"";
-	of.Flags = OFN_FILEMUSTEXIST | OFN_EXPLORER;
+	of.Flags = OFN_OVERWRITEPROMPT | OFN_EXPLORER;
 	retval = GetSaveFileNameW(&of);
 
 	if (! retval)


### PR DESCRIPTION
Add OFN_OVERWRITEPROMPT so the dialog will prompt before overwriting an existing file.
Remove the OFN_FILEMUSTEXIST flag, which works only with Open dialogs.
