### PR TITLE
Preserve empty lines when cleaning files.

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -4552,6 +4552,23 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="check_preserve_empty">
+                                <property name="label" translatable="yes">Preserve whitespace in empty lines</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">Prevents whitespace-only lines from being stripped.</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkCheckButton" id="check_replace_tabs">
                                 <property name="label" translatable="yes">Replace tabs by space</property>
                                 <property name="use_action_appearance">False</property>
@@ -4565,7 +4582,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                           </object>
@@ -7184,6 +7201,22 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="check_preserve_empty1">
+                                <property name="label" translatable="yes">Preserve whitespace in empty lines.</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkCheckButton" id="check_replace_tabs1">
                                 <property name="label" translatable="yes">Replace tabs by space</property>
                                 <property name="use_action_appearance">False</property>
@@ -7196,7 +7229,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                           </object>
@@ -9556,6 +9589,15 @@
                             <property name="label" translatable="yes">_Strip Trailing Spaces</property>
                             <property name="use_underline">True</property>
                             <signal name="activate" handler="on_strip_trailing_spaces1_activate" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuItem" id="strip_preserve_empty1">
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">_Preserve Empty Lines</property>
+                            <property name="use_underline">True</property>
                           </object>
                         </child>
                         <child>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2358,6 +2358,9 @@ Strip trailing spaces
     .. note::
         This does not apply to Diff documents, e.g. patch files.
 
+Preserve Empty Lines
+    Don't change the whitespace in empty lines.
+
 Replace tabs by space
     Replace all tabs in the document with the equivalent number of spaces.
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1848,6 +1848,7 @@ G_MODULE_EXPORT void on_tabs_and_spaces1_activate(GtkCheckMenuItem *menuitem, gp
 G_MODULE_EXPORT void on_strip_trailing_spaces1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	GeanyDocument *doc;
+	const GeanyFilePrefs *fp = project_get_file_prefs();
 
 	if (ignore_callback)
 		return;
@@ -1855,7 +1856,7 @@ G_MODULE_EXPORT void on_strip_trailing_spaces1_activate(GtkMenuItem *menuitem, g
 	doc = document_get_current();
 	g_return_if_fail(doc != NULL);
 
-	editor_strip_trailing_spaces(doc->editor);
+	editor_strip_trailing_spaces(doc->editor, fp->strip_preserve_empty);
 }
 
 

--- a/src/document.c
+++ b/src/document.c
@@ -1722,7 +1722,7 @@ gboolean document_save_file(GeanyDocument *doc, gboolean force)
 		editor_replace_tabs(doc->editor);
 	/* strip trailing spaces */
 	if (fp->strip_trailing_spaces)
-		editor_strip_trailing_spaces(doc->editor);
+		editor_strip_trailing_spaces(doc->editor, fp->strip_preserve_empty);
 	/* ensure the file has a newline at the end */
 	if (fp->final_new_line)
 		editor_ensure_final_newline(doc->editor);

--- a/src/document.h
+++ b/src/document.h
@@ -66,6 +66,7 @@ typedef struct GeanyFilePrefs
 	gboolean		use_gio_unsafe_file_saving; /* whether to use GIO as the unsafe backend */
 	gchar			*extract_filetype_regex;	/* regex to extract filetype on opening */
 	gboolean		tab_close_switch_to_mru;
+	gboolean		strip_preserve_empty;
 }
 GeanyFilePrefs;
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -1255,10 +1255,8 @@ static void on_new_line_added(GeanyEditor *editor)
 
 	if (editor_prefs.newline_strip)
 	{	/* strip the trailing spaces on the previous line */
-
 		const GeanyFilePrefs *fp = project_get_file_prefs();
-
-		editor_strip_line_trailing_spaces(editor, line - 1, FALSE);
+		editor_strip_line_trailing_spaces(editor, line - 1, fp->strip_preserve_empty);
 	}
 }
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -1255,7 +1255,10 @@ static void on_new_line_added(GeanyEditor *editor)
 
 	if (editor_prefs.newline_strip)
 	{	/* strip the trailing spaces on the previous line */
-		editor_strip_line_trailing_spaces(editor, line - 1);
+
+		const GeanyFilePrefs *fp = project_get_file_prefs();
+
+		editor_strip_line_trailing_spaces(editor, line - 1, FALSE);
 	}
 }
 
@@ -4400,13 +4403,12 @@ void editor_replace_spaces(GeanyEditor *editor)
 }
 
 
-void editor_strip_line_trailing_spaces(GeanyEditor *editor, gint line)
+void editor_strip_line_trailing_spaces(GeanyEditor *editor, gint line, gboolean preserve_empty)
 {
 	gint line_start = sci_get_position_from_line(editor->sci, line);
 	gint line_end = sci_get_line_end_position(editor->sci, line);
 	gint i = line_end - 1;
 	gchar ch = sci_get_char_at(editor->sci, i);
-	const GeanyFilePrefs *fp = project_get_file_prefs();
 
 	/* Diff hunks should keep trailing spaces */
 	if (sci_get_lexer(editor->sci) == SCLEX_DIFF)
@@ -4419,7 +4421,7 @@ void editor_strip_line_trailing_spaces(GeanyEditor *editor, gint line)
 	}
 
 	/* Don't modify empty lines if pref is set */
-	if (fp->strip_preserve_empty && i < line_start)
+	if (preserve_empty && i < line_start)
 		return;
 
 	if (i < (line_end - 1))
@@ -4431,7 +4433,7 @@ void editor_strip_line_trailing_spaces(GeanyEditor *editor, gint line)
 }
 
 
-void editor_strip_trailing_spaces(GeanyEditor *editor)
+void editor_strip_trailing_spaces(GeanyEditor *editor, gboolean preserve_empty)
 {
 	gint max_lines = sci_get_line_count(editor->sci);
 	gint line;
@@ -4440,7 +4442,7 @@ void editor_strip_trailing_spaces(GeanyEditor *editor)
 
 	for (line = 0; line < max_lines; line++)
 	{
-		editor_strip_line_trailing_spaces(editor, line);
+		editor_strip_line_trailing_spaces(editor, line, preserve_empty);
 	}
 	sci_end_undo_action(editor->sci);
 }

--- a/src/editor.c
+++ b/src/editor.c
@@ -4406,6 +4406,7 @@ void editor_strip_line_trailing_spaces(GeanyEditor *editor, gint line)
 	gint line_end = sci_get_line_end_position(editor->sci, line);
 	gint i = line_end - 1;
 	gchar ch = sci_get_char_at(editor->sci, i);
+	const GeanyFilePrefs *fp = project_get_file_prefs();
 
 	/* Diff hunks should keep trailing spaces */
 	if (sci_get_lexer(editor->sci) == SCLEX_DIFF)
@@ -4416,6 +4417,11 @@ void editor_strip_line_trailing_spaces(GeanyEditor *editor, gint line)
 		i--;
 		ch = sci_get_char_at(editor->sci, i);
 	}
+	
+	/* Don't modify empty lines if pref is set */
+	if (fp->strip_preserve_empty && i < line_start)
+		return;
+	
 	if (i < (line_end - 1))
 	{
 		sci_set_target_start(editor->sci, i + 1);

--- a/src/editor.c
+++ b/src/editor.c
@@ -4417,11 +4417,11 @@ void editor_strip_line_trailing_spaces(GeanyEditor *editor, gint line)
 		i--;
 		ch = sci_get_char_at(editor->sci, i);
 	}
-	
+
 	/* Don't modify empty lines if pref is set */
 	if (fp->strip_preserve_empty && i < line_start)
 		return;
-	
+
 	if (i < (line_end - 1))
 	{
 		sci_set_target_start(editor->sci, i + 1);

--- a/src/editor.h
+++ b/src/editor.h
@@ -281,9 +281,9 @@ void editor_replace_tabs(GeanyEditor *editor);
 
 void editor_replace_spaces(GeanyEditor *editor);
 
-void editor_strip_line_trailing_spaces(GeanyEditor *editor, gint line);
+void editor_strip_line_trailing_spaces(GeanyEditor *editor, gint line, gboolean preserve_empty);
 
-void editor_strip_trailing_spaces(GeanyEditor *editor);
+void editor_strip_trailing_spaces(GeanyEditor *editor, gboolean preserve_empty);
 
 void editor_ensure_final_newline(GeanyEditor *editor);
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -2103,7 +2103,7 @@ static void join_lines(GeanyEditor *editor)
 	/* remove spaces surrounding the lines so that these spaces
 	 * won't appear within text after joining */
 	for (i = start; i < end; i++)
-		editor_strip_line_trailing_spaces(editor, i);
+		editor_strip_line_trailing_spaces(editor, i, FALSE);
 	for (i = start + 1; i <= end; i++)
 		sci_set_line_indentation(editor->sci, i, 0);
 
@@ -2229,7 +2229,7 @@ static void reflow_lines(GeanyEditor *editor, gint column)
 	if (editor_prefs.newline_strip || file_prefs.strip_trailing_spaces)
 	{
 		for (i = start; i <= start + linescount; i++)
-			editor_strip_line_trailing_spaces(editor, i);
+			editor_strip_line_trailing_spaces(editor, i, FALSE);
 	}
 }
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -2229,7 +2229,7 @@ static void reflow_lines(GeanyEditor *editor, gint column)
 	if (editor_prefs.newline_strip || file_prefs.strip_trailing_spaces)
 	{
 		for (i = start; i <= start + linescount; i++)
-			editor_strip_line_trailing_spaces(editor, i, FALSE);
+			editor_strip_line_trailing_spaces(editor, i, file_prefs.strip_preserve_empty);
 	}
 }
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -453,6 +453,7 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "pref_editor_ensure_convert_line_endings", file_prefs.ensure_convert_new_lines);
 	g_key_file_set_boolean(config, PACKAGE, "pref_editor_replace_tabs", file_prefs.replace_tabs);
 	g_key_file_set_boolean(config, PACKAGE, "pref_editor_trail_space", file_prefs.strip_trailing_spaces);
+	g_key_file_set_boolean(config, PACKAGE, "pref_editor_preserve_empty", file_prefs.strip_preserve_empty);
 
 	/* toolbar */
 	g_key_file_set_boolean(config, PACKAGE, "pref_toolbar_show", toolbar_prefs.visible);
@@ -807,6 +808,7 @@ static void load_dialog_prefs(GKeyFile *config)
 	file_prefs.ensure_convert_new_lines = utils_get_setting_boolean(config, PACKAGE, "pref_editor_ensure_convert_line_endings", FALSE);
 	file_prefs.final_new_line = utils_get_setting_boolean(config, PACKAGE, "pref_editor_new_line", TRUE);
 	file_prefs.strip_trailing_spaces = utils_get_setting_boolean(config, PACKAGE, "pref_editor_trail_space", FALSE);
+	file_prefs.strip_preserve_empty = utils_get_setting_boolean(config, PACKAGE, "pref_editor_preserve_empty", FALSE);
 
 	/* toolbar */
 	toolbar_prefs.visible = utils_get_setting_boolean(config, PACKAGE, "pref_toolbar_show", TRUE);

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -576,6 +576,9 @@ static void prefs_init_dialog(void)
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_trailing_spaces");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.strip_trailing_spaces);
 
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_preserve_empty");
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.strip_preserve_empty);
+
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_new_line");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.final_new_line);
 
@@ -1038,6 +1041,9 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_trailing_spaces");
 		file_prefs.strip_trailing_spaces = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_preserve_empty");
+		file_prefs.strip_preserve_empty = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_new_line");
 		file_prefs.final_new_line = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));

--- a/src/project.c
+++ b/src/project.c
@@ -1220,9 +1220,12 @@ static void init_stash_prefs(void)
 		"ensure_convert_new_lines", file_prefs.ensure_convert_new_lines, "check_ensure_convert_new_lines1");
 	stash_group_add_toggle_button(group, &priv.strip_trailing_spaces,
 		"strip_trailing_spaces", file_prefs.strip_trailing_spaces, "check_trailing_spaces1");
+	stash_group_add_toggle_button(group, &priv.strip_preserve_empty,
+		"strip_preserve_empty", file_prefs.strip_preserve_empty, "check_preserve_empty1");
 	stash_group_add_toggle_button(group, &priv.replace_tabs,
 		"replace_tabs", file_prefs.replace_tabs, "check_replace_tabs1");
 	add_stash_group(group);
+
 	/* apply defaults */
 	kf = g_key_file_new();
 	stash_group_load_from_key_file(group, kf);

--- a/src/project.c
+++ b/src/project.c
@@ -1244,6 +1244,7 @@ const GeanyFilePrefs *project_get_file_prefs(void)
 	COPY_PREF(fp, final_new_line);
 	COPY_PREF(fp, ensure_convert_new_lines);
 	COPY_PREF(fp, strip_trailing_spaces);
+	COPY_PREF(fp, strip_preserve_empty);
 	COPY_PREF(fp, replace_tabs);
 	return &fp;
 }

--- a/src/projectprivate.h
+++ b/src/projectprivate.h
@@ -31,6 +31,7 @@ typedef struct GeanyProjectPrivate
 	gboolean	strip_trailing_spaces;
 	gboolean	replace_tabs;
 	gboolean	ensure_convert_new_lines;
+	gboolean	strip_preserve_empty;
 }
 GeanyProjectPrivate;
 


### PR DESCRIPTION
This was originally submitted for [this feature request](https://sourceforge.net/tracker/index.php?func=detail&aid=3608223&group_id=153444&atid=787794) but I figured a pull request was easier.

More details can be found at that ticket but basically to provides both a global and per-project setting to ignore empty lines when cleaning trailing spaces.  This is because many people prefer their line breaks to be indented at the same level as the code around it.  

So this is a rebased-onto-master version of the original patch, it adds GUI controls in both the global and per-project dialogs and defaults to current default behavior.
