### PR TITLE
Allow VTE to be switched off of by using Notebook Left/Right keybindings

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1637,8 +1637,7 @@ static void focus_msgwindow(void)
 	{
 		gint page_num = gtk_notebook_get_current_page(GTK_NOTEBOOK(msgwindow.notebook));
 		GtkWidget *page = gtk_notebook_get_nth_page(GTK_NOTEBOOK(msgwindow.notebook), page_num);
-
-		gtk_widget_grab_focus(gtk_bin_get_child(GTK_BIN(page)));
+		msgwin_switch_tab(page_num, TRUE);
 	}
 }
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1122,6 +1122,15 @@ static gboolean check_vte(GdkModifierType state, guint keyval)
 			return FALSE;
 	}
 
+	kb = keybindings_lookup_item(GEANY_KEY_GROUP_NOTEBOOK, GEANY_KEYS_NOTEBOOK_SWITCHTABLEFT);
+	if(kb != NULL && state == kb->mods && keyval == kb->key) {
+		return FALSE;
+	}
+	kb = keybindings_lookup_item(GEANY_KEY_GROUP_NOTEBOOK, GEANY_KEYS_NOTEBOOK_SWITCHTABRIGHT);
+	if(kb != NULL && state == kb->mods && keyval == kb->key) {
+		return FALSE;
+	}
+
 	/* Temporarily disable the menus to prevent conflicting menu accelerators
 	 * from overriding the VTE bash shortcuts.
 	 * Note: maybe there's a better way of doing this ;-) */

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1121,21 +1121,15 @@ static gboolean check_vte(GdkModifierType state, guint keyval)
 		if (state == kb->mods && keyval == kb->key)
 			return FALSE;
 	}
-
-	kb = keybindings_lookup_item(GEANY_KEY_GROUP_NOTEBOOK, GEANY_KEYS_NOTEBOOK_SWITCHTABLEFT);
-	if(kb != NULL && state == kb->mods && keyval == kb->key) {
-		return FALSE;
-	}
-	kb = keybindings_lookup_item(GEANY_KEY_GROUP_NOTEBOOK, GEANY_KEYS_NOTEBOOK_SWITCHTABRIGHT);
-	if(kb != NULL && state == kb->mods && keyval == kb->key) {
-		return FALSE;
-	}
-	kb = keybindings_lookup_item(GEANY_KEY_GROUP_NOTEBOOK, GEANY_KEYS_NOTEBOOK_SWITCHTABLASTUSED);
-	if(kb != NULL && state == kb->mods && keyval == kb->key) {
-		return FALSE;
+	group = keybindings_get_core_group(GEANY_KEY_GROUP_NOTEBOOK);
+	foreach_ptr_array(kb, i, group->key_items)
+	{
+		if (state == kb->mods && keyval == kb->key)
+			return FALSE;
 	}
 	kb = keybindings_lookup_item(GEANY_KEY_GROUP_VIEW, GEANY_KEYS_VIEW_MESSAGEWINDOW);
-	if(kb != NULL && state == kb->mods && keyval == kb->key) {
+	if (kb != NULL && state == kb->mods && keyval == kb->key)
+	{
 		return FALSE;
 	}
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1130,6 +1130,14 @@ static gboolean check_vte(GdkModifierType state, guint keyval)
 	if(kb != NULL && state == kb->mods && keyval == kb->key) {
 		return FALSE;
 	}
+	kb = keybindings_lookup_item(GEANY_KEY_GROUP_NOTEBOOK, GEANY_KEYS_NOTEBOOK_SWITCHTABLASTUSED);
+	if(kb != NULL && state == kb->mods && keyval == kb->key) {
+		return FALSE;
+	}
+	kb = keybindings_lookup_item(GEANY_KEY_GROUP_VIEW, GEANY_KEYS_VIEW_MESSAGEWINDOW);
+	if(kb != NULL && state == kb->mods && keyval == kb->key) {
+		return FALSE;
+	}
 
 	/* Temporarily disable the menus to prevent conflicting menu accelerators
 	 * from overriding the VTE bash shortcuts.


### PR DESCRIPTION
This fixes an issue with the embedded terminal not allowing you to use your shortcuts to switch tabs on the Message Pane.

As per Lex's suggestion, I have it key off of the user defined keybindings instead of hard coded ones.
See https://github.com/geany/geany/pull/107 for some history.
