### PR TITLE
added keywords for Matlab classes syntax highlight

### DIFF
--- a/data/filetypes.matlab
+++ b/data/filetypes.matlab
@@ -13,7 +13,7 @@ doublequotedstring=string_2
 
 [keywords]
 # all items must be in one line
-primary=break case catch continue else elseif end for function global if otherwise persistent return switch try while
+primary=break case catch classdef continue else elseif end enumeration events for function global if methods otherwise persistent properties return switch try while
 
 [settings]
 # default extension used when saving files


### PR DESCRIPTION
added missing keywords for Matlab classes highlight, namely:
- classdef
- properties
- methods
- events
- enumeration

reference: http://www.mathworks.nl/help/matlab/ref/classdef.html
