### PR TITLE
Tagmanger: recognize Fortran procedure pointers as variables

### DIFF
--- a/tagmanager/ctags/fortran.c
+++ b/tagmanager/ctags/fortran.c
@@ -107,6 +107,7 @@ typedef enum eKeywordId {
 	KEYWORD_pointer,
 	KEYWORD_precision,
 	KEYWORD_private,
+	KEYWORD_procedure,
 	KEYWORD_program,
 	KEYWORD_public,
 	KEYWORD_pure,
@@ -272,6 +273,7 @@ static const keywordDesc FortranKeywordTable [] = {
 	{ "pointer",        KEYWORD_pointer      },
 	{ "precision",      KEYWORD_precision    },
 	{ "private",        KEYWORD_private      },
+	{ "procedure",      KEYWORD_procedure    },
 	{ "program",        KEYWORD_program      },
 	{ "public",         KEYWORD_public       },
 	{ "pure",           KEYWORD_pure         },
@@ -1123,6 +1125,7 @@ static boolean isTypeSpec (tokenInfo *const token)
 		case KEYWORD_logical:
 		case KEYWORD_record:
 		case KEYWORD_type:
+		case KEYWORD_procedure:
 			result = TRUE;
 			break;
 		default:
@@ -1185,6 +1188,7 @@ static void parseTypeSpec (tokenInfo *const token)
 		case KEYWORD_integer:
 		case KEYWORD_logical:
 		case KEYWORD_real:
+		case KEYWORD_procedure:
 			readToken (token);
 			if (isType (token, TOKEN_PAREN_OPEN))
 				skipOverParens (token);  /* skip kind-selector */


### PR DESCRIPTION
Add a keyword for procedure pointers and treat declarations such as
'procedure(subprogram_to_point_to), pointer :: my_pointer' just like
declarations of real or integer variables.
