### PR TITLE
Make prompt dialogs explicitly modal

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -1324,7 +1324,7 @@ static gint show_prompt(GtkWidget *parent,
 		parent = main_widgets.window;
 
 	dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
-		GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
+		GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
 		GTK_BUTTONS_NONE, "%s", question_text);
 	gtk_widget_set_name(dialog, "GeanyDialog");
 	gtk_window_set_title(GTK_WINDOW(dialog), _("Question"));


### PR DESCRIPTION
dialogs.c:show_prompt() uses dialog_run which acts as modal on GTK
based window systems because it uses a recursive mainloop, but
appears to not do so on KDE or Unity window systems. See [Bug #976](https://sourceforge.net/p/geany/bugs/976/).
Explicitly setting the modal flag as well may be honoured by those
systems.

This PR is to let the OP test it first on KDE and Unity.
