### PR TITLE
nicer "find in files" output, using pango markup

### DIFF
--- a/src/msgwindow.h
+++ b/src/msgwindow.h
@@ -82,6 +82,11 @@ void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *
 
 void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const gchar *string);
 
+void msgwin_msg_add_markup(gint line, GeanyDocument *doc, const gchar *markup);
+
+void msgwin_msg_add_markup_no_validate(gint line, GeanyDocument *doc, const gchar *doc_filename,
+												const gchar *markup);
+
 void msgwin_compiler_add(gint msg_color, const gchar *format, ...) G_GNUC_PRINTF (2, 3);
 
 void msgwin_compiler_add_string(gint msg_color, const gchar *msg);

--- a/src/utils.c
+++ b/src/utils.c
@@ -2111,3 +2111,76 @@ gchar *utils_parse_and_format_build_date(const gchar *input)
 
 	return g_strdup(input);
 }
+
+/*
+ * taken from glib and renamed so that it does not clash
+ * (looks like this is private api...)
+ */
+static gchar *
+_g_utf8_make_valid2 (const gchar *name)
+{
+	GString *string;
+	const gchar *remainder, *invalid;
+	gint remaining_bytes, valid_bytes;
+
+	g_return_val_if_fail (name != NULL, NULL);
+
+	string = NULL;
+	remainder = name;
+	remaining_bytes = strlen (name);
+
+	while (remaining_bytes != 0)
+	{
+		if (g_utf8_validate (remainder, remaining_bytes, &invalid))
+			break;
+		valid_bytes = invalid - remainder;
+
+		if (string == NULL)
+			string = g_string_sized_new (remaining_bytes);
+
+		g_string_append_len (string, remainder, valid_bytes);
+		/* append U+FFFD REPLACEMENT CHARACTER */
+		g_string_append (string, "\357\277\275");
+
+		remaining_bytes -= valid_bytes + 1;
+		remainder = invalid + 1;
+	}
+
+	if (string == NULL)
+		return g_strdup (name);
+
+	g_string_append (string, remainder);
+
+	g_assert (g_utf8_validate (string->str, -1, NULL));
+
+	return g_string_free (string, FALSE);
+}
+
+/**
+ * Turns an invalid utf8 string into a valid one.
+ * Only use if g_utf8_validate() returned FALSE.
+ * This loses some information of course but is needed for some function
+ * that require a valid utf8 string (like g_markup_escape_text for an example)
+ *
+ * @param text
+ * @param from_codeset: a codeset to try to convert from (can be NULL)
+ *
+ * @return a valid utf8 string.
+ **/
+gchar *utils_utf8_make_valid(const gchar * text, const char *from_codeset)
+{
+	gchar *utf8 = NULL;
+	
+	if (from_codeset)
+		utf8 = g_convert(text, -1, "UTF-8", from_codeset, NULL, NULL, NULL);
+
+	if (utf8 != NULL)
+		return utf8;
+
+	utf8 = g_locale_to_utf8(text, -1, NULL, NULL, NULL);
+	if (utf8 != NULL)
+		return utf8;
+	
+	return _g_utf8_make_valid2(text);
+}
+

--- a/src/utils.h
+++ b/src/utils.h
@@ -281,6 +281,8 @@ GDate *utils_parse_date(const gchar *input);
 
 gchar *utils_parse_and_format_build_date(const gchar *input);
 
+gchar *utils_utf8_make_valid(const gchar * text, const char *from_codeset);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
- highlights grep matches and also groups results by files.
- msgwin_msg_add() api is unchanged but text is converted to markup
  internally.
- added msgwin_msg_add_markup() and msgwin_msg_add_markup_no_validate().
- added utils_utf8_make_valid() and force valid utf8 in the GTK
  widgets, fixes some warnings.
- do not process too many grep results at once to give a chance
  to the UI to handle some events sometimes.

before:
![before](https://f.cloud.github.com/assets/3974977/820404/d756524c-efc3-11e2-9ba3-91c0daf0049b.png)

after:
![after](https://f.cloud.github.com/assets/3974977/820406/dffd035a-efc3-11e2-992a-ce1f6b75cb7e.png)
