### PR TITLE
Allow to choose the VTE cursor shape

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -5946,6 +5946,20 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkLabel" id="terminal_cursor_shape_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">Cursor shape:</property>
+                              </object>
+                              <packing>
+                                <property name="top_attach">6</property>
+                                <property name="bottom_attach">7</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkColorButton" id="color_fore">
                                 <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
@@ -6085,6 +6099,28 @@
                                 <property name="right_attach">3</property>
                                 <property name="top_attach">5</property>
                                 <property name="bottom_attach">6</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="combo_cursor_shape">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="tooltip_text" translatable="yes">Sets the cursor shape of the terminal widget</property>
+                                <property name="model">vte_cursor_shape_list</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="cellrenderertext8"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">3</property>
+                                <property name="top_attach">6</property>
+                                <property name="bottom_attach">7</property>
                                 <property name="x_options">GTK_FILL</property>
                                 <property name="y_options">GTK_FILL</property>
                               </packing>
@@ -7873,6 +7909,23 @@
       </row>
       <row>
         <col id="0" translatable="yes">Bottom</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="vte_cursor_shape_list">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Block</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">I-Beam</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Underline</col>
       </row>
     </data>
   </object>

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -513,6 +513,7 @@ static void save_dialog_prefs(GKeyFile *config)
 		g_key_file_set_boolean(config, "VTE", "run_in_vte", vc->run_in_vte);
 		g_key_file_set_boolean(config, "VTE", "skip_run_script", vc->skip_run_script);
 		g_key_file_set_boolean(config, "VTE", "cursor_blinks", vc->cursor_blinks);
+		g_key_file_set_integer(config, "VTE", "cursor_shape", vc->cursor_shape);
 		g_key_file_set_integer(config, "VTE", "scrollback_lines", vc->scrollback_lines);
 		g_key_file_set_string(config, "VTE", "font", vc->font);
 		g_key_file_set_string(config, "VTE", "image", vc->image);
@@ -853,6 +854,7 @@ static void load_dialog_prefs(GKeyFile *config)
 		vc->run_in_vte = utils_get_setting_boolean(config, "VTE", "run_in_vte", FALSE);
 		vc->skip_run_script = utils_get_setting_boolean(config, "VTE", "skip_run_script", FALSE);
 		vc->cursor_blinks = utils_get_setting_boolean(config, "VTE", "cursor_blinks", FALSE);
+		vc->cursor_shape = utils_get_setting_integer(config, "VTE", "cursor_shape", 0 /* BLOCK */);
 		vc->scrollback_lines = utils_get_setting_integer(config, "VTE", "scrollback_lines", 500);
 		vc->colour_fore = g_new0(GdkColor, 1);
 		vc->colour_back = g_new0(GdkColor, 1);

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -803,6 +803,9 @@ static void prefs_init_dialog(void)
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_cursor_blinks");
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), vc->cursor_blinks);
+
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_cursor_shape");
+		gtk_combo_box_set_active(GTK_COMBO_BOX(widget), vc->cursor_shape);
 	}
 #endif
 }
@@ -1269,6 +1272,9 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 			widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_cursor_blinks");
 			vc->cursor_blinks = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+			widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_cursor_shape");
+			vc->cursor_shape = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
 
 			vte_apply_user_settings();
 		}

--- a/src/vte.h
+++ b/src/vte.h
@@ -50,6 +50,7 @@ typedef struct
 	gboolean skip_run_script;
 	gboolean enable_bash_keys;
 	gboolean cursor_blinks;
+	gint cursor_shape;
 	gboolean send_selection_unsafe;
 	gint scrollback_lines;
 	gchar *emulation;


### PR DESCRIPTION
A user on IRC asked for the possibility to choose the VTE cursor shape, so here's a implementation.

I'm not 100% sure we want to, or how to support that since the feature is only available in VTE 0.20 and we currently depend on some version earlier than 0.17.  What I did here is to make the setting insensitive if not supported, but maybe we would rather hide it completely, or simply not support this feature -- or only support it as a hidden preference?

So I'm making a PR for you to give your opinion on this.
