### PR TITLE
Improve Rust lifetime & attribute syntax highlighting

### DIFF
--- a/data/filetypes.Rust.conf
+++ b/data/filetypes.Rust.conf
@@ -1,6 +1,7 @@
 # For complete documentation of this file, please see Geany's main documentation
 [styling]
 # Edit these in the colorscheme .conf file instead
+# Note: Copied from C file & edited
 default=default
 comment=comment
 commentline=comment_line
@@ -17,7 +18,7 @@ uuid=other
 preprocessor=preprocessor
 operator=operator
 identifier=identifier_1
-# ignore 'lifetime syntax (disables highlighting for rest of line)
+# ignore 'lifetime syntax (workaround, disables highlighting for rest of line)
 stringeol=default
 #stringeol=string_eol
 verbatim=string_2
@@ -38,13 +39,9 @@ secondary=
 docComment=a addindex addtogroup anchor arg attention author authors b brief bug c callergraph callgraph category cite class code cond copybrief copydetails copydoc copyright date def defgroup deprecated details dir dontinclude dot dotfile e else elseif em endcode endcond enddot endhtmlonly endif endinternal endlatexonly endlink endmanonly endmsc endrtfonly endverbatim endxmlonly enum example exception extends file fn headerfile hideinitializer htmlinclude htmlonly if ifnot image implements include includelineno ingroup interface internal invariant latexonly li line link mainpage manonly memberof msc mscfile n name namespace nosubgrouping note overload p package page par paragraph param post pre private privatesection property protected protectedsection protocol public publicsection ref related relatedalso relates relatesalso remark remarks result return returns retval rtfonly sa section see short showinitializer since skip skipline snippet struct subpage subsection subsubsection tableofcontents test throw throws todo tparam typedef union until var verbatim verbinclude version warning weakgroup xmlonly xrefitem
 
 [lexer_properties]
-# preprocessor properties - possibly useful for tweaking #[attribute] highlighting
-#styling.within.preprocessor=1
-#lexer.cpp.track.preprocessor=0
-#preprocessor.symbol.$(file.patterns.cpp)=#
-#preprocessor.start.$(file.patterns.cpp)=if ifdef ifndef
-#preprocessor.middle.$(file.patterns.cpp)=else elif
-#preprocessor.end.$(file.patterns.cpp)=endif
+# lex attributes (after first space), e.g.
+#[license = "BSD"];
+styling.within.preprocessor=1
 
 [settings]
 # default extension used when saving files


### PR DESCRIPTION
@dobkeratops:

> if you display rust code in geany it shows the pointer lifetimes as error strings

This fixes the error string highlighting from an unmatched `'` quote char, e.g.:

``` rust
pub fn explore() -> &'static str { "world" }
```

This is just a workaround, so `"world"` doesn't get lexed as a string, only as the default style. But this is much less awkward than lexing as `string_eol` with a pink background for the remainder of the line.

See also: https://github.com/geany/geany/pull/165#issuecomment-24584521

This also tweaks attribute highlighting to stop at the first space. Also a workaround.
