### PR TITLE
Optionally move cursor while replace all

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2609,6 +2609,9 @@ extract_filetype_regex            Regex to extract filetype name from file     S
                                   via capture group one.
 **Search related**
 find_selection_type               See `Find selection`_.                       0           immediately
+scroll_on_replace_all             Scroll to the last replacement while         true        immediately
+                                  replacing all text. If false, Geany will 
+                                  keep cursor on old position.
 **Build Menu related**
 number_ft_menu_items              The maximum number of menu items in the      2           on restart
                                   filetype section of the Build menu.

--- a/src/document.c
+++ b/src/document.c
@@ -2218,7 +2218,7 @@ gint document_replace_all(GeanyDocument *doc, const gchar *find_text, const gcha
 
 	len = sci_get_length(doc->editor->sci);
 	count = document_replace_range(
-			doc, find_text, replace_text, flags, 0, len, TRUE, NULL);
+			doc, find_text, replace_text, flags, 0, len, search_prefs.move_cursor, NULL);
 
 	show_replace_summary(doc, count, original_find_text, original_replace_text);
 	return count;

--- a/src/search.h
+++ b/src/search.h
@@ -61,6 +61,7 @@ typedef struct GeanySearchPrefs
 	gboolean	use_current_word;		/**< Use current word for default search text */
 	gboolean	use_current_file_dir;	/* find in files directory to use on showing dialog */
 	gboolean	hide_find_dialog;		/* hide the find dialog on next or previous */
+	gboolean	move_cursor;		/* move cursor while replace all */
 	enum GeanyFindSelOptions find_selection_type;
 }
 GeanySearchPrefs;

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2026,6 +2026,8 @@ void ui_init_prefs(void)
 		"msgwin_messages_visible", TRUE);
 	stash_group_add_boolean(group, &interface_prefs.msgwin_scribble_visible,
 		"msgwin_scribble_visible", TRUE);
+	stash_group_add_boolean(group, &search_prefs.move_cursor,
+		"scroll_on_replace_all", TRUE);
 }
 
 


### PR DESCRIPTION
Geany scrolls after "replace_all" action. This behavior is unexpected and makes nervous because user should scroll whole document to find a place he worked on.
