### PR TITLE
Speed up loading by skipping unnecessary goto

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -4587,7 +4587,8 @@ gboolean editor_goto_pos(GeanyEditor *editor, gint pos, gboolean mark)
 		sci_set_marker_at_line(editor->sci, line, 0);
 	}
 
-	sci_goto_pos(editor->sci, pos, TRUE);
+	if(pos != sci_get_current_position(editor->sci))
+		sci_goto_pos(editor->sci, pos, TRUE);
 	editor->scroll_percent = 0.25F;
 
 	/* finally switch to the page */


### PR DESCRIPTION
This simple patch will speed up loading by 30% if you open more than 10 documents at once. Idea is simple: sci_goto_pos is very slow function, so just skipping it when we are already at this position will speed up documents opening.
