### PR TITLE
Assign icons to documents, not filetypes

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -111,6 +111,8 @@ struct GeanyDocument
 	 * not be set elsewhere.
 	 * @see file_name. */
 	gchar 			*real_path;
+	/** Icon detected from the mime-type */
+	GdkPixbuf *icon;
 
 	struct GeanyDocumentPrivate *priv;	/* should be last, append fields before this item */
 };

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -767,12 +767,6 @@ void filetypes_init()
 
 	filetypes_init_types();
 
-	/* this has to be here as GTK isn't initialized in filetypes_init_types(). */
-	foreach_slist(node, filetypes_by_title)
-	{
-		GeanyFiletype *ft = node->data;
-		ft->icon = ui_get_mime_icon(ft->mime_type, GTK_ICON_SIZE_MENU);
-	}
 	create_set_filetype_menu();
 	setup_config_file_menus();
 }
@@ -1153,8 +1147,6 @@ static void filetype_free(gpointer data, G_GNUC_UNUSED gpointer user_data)
 	g_free(ft->ftdefcmds);
 	g_free(ft->execcmds);
 	g_free(ft->error_regex_string);
-	if (ft->icon)
-		g_object_unref(ft->icon);
 	g_strfreev(ft->pattern);
 
 	if (ft->priv->error_regex)

--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -139,7 +139,6 @@ struct GeanyFiletype
 	gchar			 *error_regex_string;
 	GeanyFiletype	 *lexer_filetype;
 	gchar			 *mime_type;
-	GdkPixbuf		 *icon;
 	gchar			 *comment_single; /* single-line comment */
 	/* filetype indent settings, -1 if not set */
 	gint			  indent_type;

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -455,7 +455,6 @@ void sidebar_openfiles_add(GeanyDocument *doc)
 	GtkTreeIter *parent = get_doc_parent(doc);
 	gchar *basename;
 	const GdkColor *color = document_get_status_color(doc);
-	static GdkPixbuf *file_icon = NULL;
 
 	gtk_tree_store_append(store_openfiles, iter, parent);
 
@@ -469,12 +468,10 @@ void sidebar_openfiles_add(GeanyDocument *doc)
 		gtk_tree_view_expand_row(GTK_TREE_VIEW(tv.tree_openfiles), path, TRUE);
 		gtk_tree_path_free(path);
 	}
-	if (!file_icon)
-		file_icon = ui_get_mime_icon("text/plain", GTK_ICON_SIZE_MENU);
 
 	basename = g_path_get_basename(DOC_FILENAME(doc));
 	gtk_tree_store_set(store_openfiles, iter,
-		DOCUMENTS_ICON, (doc->file_type && doc->file_type->icon) ? doc->file_type->icon : file_icon,
+		DOCUMENTS_ICON, doc->icon,
 		DOCUMENTS_SHORTNAME, basename, DOCUMENTS_DOCUMENT, doc, DOCUMENTS_COLOR, color,
 		DOCUMENTS_FILENAME, DOC_FILENAME(doc), -1);
 	g_free(basename);
@@ -505,11 +502,12 @@ void sidebar_openfiles_update(GeanyDocument *doc)
 	{
 		/* just update color and the icon */
 		const GdkColor *color = document_get_status_color(doc);
-		GdkPixbuf *icon = doc->file_type->icon;
+		GdkPixbuf *icon = doc->icon;
+		if (!icon) 
+			icon = ui_get_mime_icon(doc->file_type->mime_type, GTK_ICON_SIZE_MENU);
 
 		gtk_tree_store_set(store_openfiles, iter, DOCUMENTS_COLOR, color, -1);
-		if (icon)
-			gtk_tree_store_set(store_openfiles, iter, DOCUMENTS_ICON, icon, -1);
+		gtk_tree_store_set(store_openfiles, iter, DOCUMENTS_ICON, icon, -1);
 	}
 	else
 	{

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2587,7 +2587,7 @@ void ui_menu_add_document_items_sorted(GtkMenu *menu, GeanyDocument *active,
 
 		base_name = g_path_get_basename(DOC_FILENAME(doc));
 		menu_item = gtk_image_menu_item_new_with_label(base_name);
-		image = gtk_image_new_from_pixbuf(doc->file_type->icon);
+		image = gtk_image_new_from_pixbuf(doc->icon);
 		gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menu_item), image);
 
 		gtk_widget_show(menu_item);


### PR DESCRIPTION
Another solution for correct icons of header files. Did not find simple mime type detection for file, but document.c already uses gio.h.

Pros: now showing exactly same icons as file manager.
Cons: may show wrong icon depending on icon theme/OS?
