### PR TITLE
Read filetype's mime type from the configuration files

### DIFF
--- a/data/filetypes.Go.conf
+++ b/data/filetypes.Go.conf
@@ -13,9 +13,13 @@ docComment=a addindex addtogroup anchor arg attention author authors b brief bug
 [lexer_properties=C]
 
 [settings]
+lexer_filetype=C
+
 # default extension used when saving files
 extension=go
-lexer_filetype=C
+
+# MIME type
+mime_type=text/x-go
 
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789

--- a/data/filetypes.Graphviz.conf
+++ b/data/filetypes.Graphviz.conf
@@ -18,6 +18,9 @@ lexer_filetype=C
 # default extension used when saving files
 extension=gv
 
+# MIME type
+mime_type=text/vnd.graphviz
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.Scala.conf
+++ b/data/filetypes.Scala.conf
@@ -18,6 +18,9 @@ lexer_filetype=C
 # default extension used when saving files
 extension=scala
 
+# MIME type
+mime_type=text/x-scala
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.abc
+++ b/data/filetypes.abc
@@ -6,4 +6,6 @@
 # default extension used when saving files
 extension=abc
 
+# MIME type
+mime_type=text/vnd.abc
 

--- a/data/filetypes.actionscript
+++ b/data/filetypes.actionscript
@@ -11,6 +11,9 @@ classes=ArgumentError Array Boolean Class Date DefinitionError Error EvalError F
 # default extension used when saving files
 extension=as
 
+# MIME type
+mime_type=application/ecmascript
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.ada
+++ b/data/filetypes.ada
@@ -23,6 +23,9 @@ primary=abort abs abstract accept access aliased all and array at begin body cas
 # default extension used when saving files
 extension=adb
 
+# MIME type
+mime_type=text/x-adasrc
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.c
+++ b/data/filetypes.c
@@ -47,6 +47,9 @@ preprocessor.end.$(file.patterns.cpp)=endif
 # default extension used when saving files
 extension=c
 
+# MIME type
+mime_type=text/x-csrc
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.caml
+++ b/data/filetypes.caml
@@ -28,6 +28,9 @@ keywords_optional=option Some None ignore ref
 # default extension used when saving files
 extension=ml
 
+# MIME type
+mime_type=text/x-ocaml
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.cmake
+++ b/data/filetypes.cmake
@@ -28,6 +28,9 @@ userdefined=
 # default extension used when saving files
 extension=cmake
 
+# MIME type
+mime_type=text/x-cmake
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.cobol
+++ b/data/filetypes.cobol
@@ -22,6 +22,9 @@ keywords=accept access add address advancing after alphabet alphabetic alphabeti
 # default extension used when saving files
 extension=cob
 
+# MIME type
+mime_type=text/x-cobol
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.cpp
+++ b/data/filetypes.cpp
@@ -22,6 +22,9 @@ lexer_filetype=C
 # default extension used when saving files
 extension=cpp
 
+# MIME type
+mime_type=text/x-c++src
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.cs
+++ b/data/filetypes.cs
@@ -22,6 +22,9 @@ lexer_filetype=C
 # default extension used when saving files
 extension=cs
 
+# MIME type
+mime_type=text/x-csharp
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.css
+++ b/data/filetypes.css
@@ -43,6 +43,9 @@ browser_pseudo_elements=^-ms- ^-apple- ^-epub- ^-moz- ^-o- ^-wap- ^-webkit- ^-xv
 # default extension used when saving files
 extension=css
 
+# MIME type
+mime_type=text/css
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.d
+++ b/data/filetypes.d
@@ -35,6 +35,9 @@ fold.d.comment.explicit=0
 # default extension used when saving files
 extension=d
 
+# MIME type
+mime_type=text/x-dsrc
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.diff
+++ b/data/filetypes.diff
@@ -15,6 +15,9 @@ changed=line_changed
 # default extension used when saving files
 extension=diff
 
+# MIME type
+mime_type=text/x-patch
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.docbook
+++ b/data/filetypes.docbook
@@ -45,6 +45,9 @@ fold.html.preprocessor=1
 # default extension used when saving files
 extension=docbook
 
+# MIME type
+mime_type=application/docbook+xml
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.erlang
+++ b/data/filetypes.erlang
@@ -45,6 +45,9 @@ doc_macro=@date @docRoot @link @module @package @section @time @type @version
 # default extension used when saving files
 extension=erl
 
+# MIME type
+mime_type=text/x-erlang
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.f77
+++ b/data/filetypes.f77
@@ -28,6 +28,9 @@ user_functions=cdabs cdcos cdexp cdlog cdsin cdsqrt cotan cotand dcmplx dconjg d
 # default extension used when saving files
 extension=f
 
+# MIME type
+mime_type=text/x-fortran
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.fortran
+++ b/data/filetypes.fortran
@@ -12,6 +12,9 @@ user_functions=cdabs cdcos cdexp cdlog cdsin cdsqrt cotan cotand dcmplx dconjg d
 # default extension used when saving files
 extension=f90
 
+# MIME type
+mime_type=text/x-fortran
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.haskell
+++ b/data/filetypes.haskell
@@ -44,6 +44,9 @@ fold.haskell.imports=0
 # default extension used when saving files
 extension=hs
 
+# MIME type
+mime_type=text/x-haskell
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.html
+++ b/data/filetypes.html
@@ -96,6 +96,9 @@ sgml=ELEMENT DOCTYPE ATTLIST ENTITY NOTATION
 # default extension used when saving files
 extension=html
 
+# MIME type
+mime_type=text/html
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.java
+++ b/data/filetypes.java
@@ -13,6 +13,9 @@ typedefs=
 # default extension used when saving files
 extension=java
 
+# MIME type
+mime_type=text/x-java
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.javascript
+++ b/data/filetypes.javascript
@@ -10,6 +10,9 @@ secondary=Array Boolean Date Function Math Number Object String RegExp EvalError
 # default extension used when saving files
 extension=js
 
+# MIME type
+mime_type=application/javascript
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.latex
+++ b/data/filetypes.latex
@@ -25,6 +25,9 @@ primary=above abovedisplayshortskip abovedisplayskip abovewithdelims accent adjd
 # default extension used when saving files
 extension=tex
 
+# MIME type
+mime_type=text/x-tex
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.lua
+++ b/data/filetypes.lua
@@ -42,6 +42,9 @@ user4=
 # default extension used when saving files
 extension=lua
 
+# MIME type
+mime_type=text/x-lua
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.makefile
+++ b/data/filetypes.makefile
@@ -13,6 +13,9 @@ ideol=type
 # default extension used when saving files
 extension=mak
 
+# MIME type
+mime_type=text/x-makefile
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.markdown
+++ b/data/filetypes.markdown
@@ -23,6 +23,9 @@ codebk=attribute_unknown
 # default extension used when saving files
 extension=mdml
 
+# MIME type
+mime_type=text/x-markdown
+
 # sort tags by appearance
 symbol_list_sort_mode=1
 

--- a/data/filetypes.matlab
+++ b/data/filetypes.matlab
@@ -19,6 +19,9 @@ primary=break case catch classdef continue else elseif end enumeration events fo
 # default extension used when saving files
 extension=m
 
+# MIME type
+mime_type=text/x-matlab
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.objectivec
+++ b/data/filetypes.objectivec
@@ -14,6 +14,9 @@ docComment=attention author brief bug class code date def enum example exception
 # default extension used when saving files
 extension=m
 
+# MIME type
+mime_type=text/x-objc
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.pascal
+++ b/data/filetypes.pascal
@@ -30,6 +30,9 @@ lexer.pascal.smart.highlighting=1
 # default extension used when saving files
 extension=pas
 
+# MIME type
+mime_type=text/x-pascal
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.perl
+++ b/data/filetypes.perl
@@ -61,6 +61,9 @@ styling.within.preprocessor=1
 # default extension used when saving files
 extension=pl
 
+# MIME type
+mime_type=application/x-perl
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.php
+++ b/data/filetypes.php
@@ -10,6 +10,9 @@ phpscript.mode=1
 # default extension used when saving files
 extension=php
 
+# MIME type
+mime_type=application/x-php
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.po
+++ b/data/filetypes.po
@@ -22,6 +22,9 @@ error=error
 # default extension used when saving files
 extension=po
 
+# MIME type
+mime_type=text/x-gettext-translation
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.python
+++ b/data/filetypes.python
@@ -33,6 +33,9 @@ fold.quotes.python=1
 # default extension used when saving files
 extension=py
 
+# MIME type
+mime_type=text/x-python
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.restructuredtext
+++ b/data/filetypes.restructuredtext
@@ -6,6 +6,9 @@
 # default extension used when saving files
 extension=rst
 
+# MIME type
+mime_type=text/x-rst
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.ruby
+++ b/data/filetypes.ruby
@@ -45,6 +45,9 @@ primary=__FILE__ load define_method attr_accessor attr_writer attr_reader and de
 # default extension used when saving files
 extension=rb
 
+# MIME type
+mime_type=application/x-ruby
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.sh
+++ b/data/filetypes.sh
@@ -24,6 +24,9 @@ primary=break case continue do done elif else esac eval exit export fi for funct
 # default extension used when saving files
 extension=sh
 
+# MIME type
+mime_type=application/x-shellscript
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.sql
+++ b/data/filetypes.sql
@@ -29,6 +29,9 @@ keywords=absolute action add admin after aggregate alias all allocate alter and 
 # default extension used when saving files
 extension=sql
 
+# MIME type
+mime_type=text/x-sql
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.tcl
+++ b/data/filetypes.tcl
@@ -33,6 +33,9 @@ expand=
 # default extension used when saving files
 extension=tcl
 
+# MIME type
+mime_type=text/x-tcl
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.txt2tags
+++ b/data/filetypes.txt2tags
@@ -28,6 +28,9 @@ postproc=preprocessor
 # default extension used when saving files
 extension=txt2tags
 
+# MIME type
+mime_type=text/x-txt2tags
+
 # sort tags by appearance
 symbol_list_sort_mode=1
 

--- a/data/filetypes.vala
+++ b/data/filetypes.vala
@@ -23,6 +23,9 @@ lexer_filetype=C
 # default extension used when saving files
 extension=vala
 
+# MIME type
+mime_type=text/x-vala
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.verilog
+++ b/data/filetypes.verilog
@@ -26,6 +26,9 @@ word3=real integer time reg wire input output inout
 # default extension used when saving files
 extension=v
 
+# MIME type
+mime_type=text/x-verilog
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.vhdl
+++ b/data/filetypes.vhdl
@@ -31,6 +31,9 @@ userwords=
 # default extension used when saving files
 extension=vhd
 
+# MIME type
+mime_type=text/x-vhdl
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.xml
+++ b/data/filetypes.xml
@@ -7,6 +7,9 @@
 # default extension used when saving files
 extension=xml
 
+# MIME type
+mime_type=application/xml
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/data/filetypes.yaml
+++ b/data/filetypes.yaml
@@ -21,6 +21,9 @@ keywords=true false yes no
 # default extension used when saving files
 extension=yaml
 
+# MIME type
+mime_type=application/x-yaml
+
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -4204,6 +4204,10 @@ xml_indent_tags
     to filetypes for which the HTML or XML lexer is used. Such filetypes have
     this setting in their system configuration files.
 
+mime_type
+    The MIME type for this file type, e.g. "text/x-csrc".  This is used
+    for example to chose the icon to display for this file type.
+
 
 [indentation] section
 `````````````````````

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -107,7 +107,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 0;
 	ft->name = g_strdup("C");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-csrc");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define CPP
@@ -115,7 +114,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 1;
 	ft->name = g_strdup("C++");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-c++src");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define OBJECTIVEC
@@ -123,7 +121,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 42;
 	ft->name = g_strdup("Objective-C");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-objc");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define CS
@@ -131,7 +128,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 25;
 	ft->name = g_strdup("C#");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-csharp");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define VALA
@@ -139,7 +135,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 33;
 	ft->name = g_strdup("Vala");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-vala");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define D
@@ -147,7 +142,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 17;
 	ft->name = g_strdup("D");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-dsrc");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define JAVA
@@ -155,7 +149,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 2;
 	ft->name = g_strdup("Java");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-java");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define PAS /* to avoid warnings when building under Windows, the symbol PASCAL is there defined */
@@ -163,7 +156,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 4;
 	ft->name = g_strdup("Pascal");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-pascal");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define ASM
@@ -185,7 +177,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 18;
 	ft->name = g_strdup("Fortran");
 	ft->title = g_strdup_printf(_("%s source file"), "Fortran (F90)");
-	ft->mime_type = g_strdup("text/x-fortran");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define F77
@@ -193,7 +184,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 30;
 	ft->name = g_strdup("F77");
 	ft->title = g_strdup_printf(_("%s source file"), "Fortran (F77)");
-	ft->mime_type = g_strdup("text/x-fortran");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define GLSL
@@ -207,7 +197,6 @@ static void init_builtin_filetypes(void)
 	ft = filetypes[GEANY_FILETYPES_CAML];
 	ft->name = g_strdup("CAML");
 	ft->title = g_strdup_printf(_("%s source file"), "(O)Caml");
-	ft->mime_type = g_strdup("text/x-ocaml");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define PERL
@@ -215,7 +204,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 5;
 	ft->name = g_strdup("Perl");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("application/x-perl");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define PHP
@@ -223,7 +211,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 6;
 	ft->name = g_strdup("PHP");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("application/x-php");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define JAVASCRIPT
@@ -231,7 +218,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 23;
 	ft->name = g_strdup("Javascript");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("application/javascript");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define PYTHON
@@ -239,7 +225,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 7;
 	ft->name = g_strdup("Python");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-python");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define RUBY
@@ -247,7 +232,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 14;
 	ft->name = g_strdup("Ruby");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("application/x-ruby");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define TCL
@@ -255,7 +239,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 15;
 	ft->name = g_strdup("Tcl");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-tcl");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define LUA
@@ -263,7 +246,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 22;
 	ft->name = g_strdup("Lua");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-lua");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define FERITE
@@ -278,7 +260,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 24;
 	ft->name = g_strdup("Haskell");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-haskell");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define MARKDOWN
@@ -286,7 +267,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 36;
 	ft->name = g_strdup("Markdown");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-markdown");
 	ft->group = GEANY_FILETYPE_GROUP_MARKUP;
 
 #define TXT2TAGS
@@ -294,7 +274,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 37;
 	ft->name = g_strdup("Txt2tags");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-txt2tags");
 	ft->group = GEANY_FILETYPE_GROUP_MARKUP;
 
 #define ABC
@@ -309,7 +288,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 16;
 	ft->name = g_strdup("Sh");
 	ft->title = g_strdup(_("Shell script"));
-	ft->mime_type = g_strdup("application/x-shellscript");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define MAKE
@@ -317,14 +295,12 @@ static void init_builtin_filetypes(void)
 	ft->lang = 3;
 	ft->name = g_strdup("Make");
 	ft->title = g_strdup(_("Makefile"));
-	ft->mime_type = g_strdup("text/x-makefile");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define XML
 	ft = filetypes[GEANY_FILETYPES_XML];
 	ft->name = g_strdup("XML");
 	ft->title = g_strdup(_("XML document"));
-	ft->mime_type = g_strdup("application/xml");
 	ft->group = GEANY_FILETYPE_GROUP_MARKUP;
 
 #define DOCBOOK
@@ -332,7 +308,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 12;
 	ft->name = g_strdup("Docbook");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("application/docbook+xml");
 	ft->group = GEANY_FILETYPE_GROUP_MARKUP;
 
 #define HTML
@@ -340,7 +315,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 29;
 	ft->name = g_strdup("HTML");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/html");
 	ft->group = GEANY_FILETYPE_GROUP_MARKUP;
 
 #define CSS
@@ -348,7 +322,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 13;
 	ft->name = g_strdup("CSS");
 	ft->title = g_strdup(_("Cascading StyleSheet"));
-	ft->mime_type = g_strdup("text/css");
 	ft->group = GEANY_FILETYPE_GROUP_MARKUP;	/* not really markup but fit quite well to HTML */
 
 #define SQL
@@ -356,7 +329,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 11;
 	ft->name = g_strdup("SQL");
 	filetype_make_title(ft, TITLE_FILE);
-	ft->mime_type = g_strdup("text/x-sql");
 	ft->group = GEANY_FILETYPE_GROUP_MISC;
 
 #define COBOL
@@ -364,7 +336,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 41;
 	ft->name = g_strdup("COBOL");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-cobol");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define LATEX
@@ -372,7 +343,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 8;
 	ft->name = g_strdup("LaTeX");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-tex");
 	ft->group = GEANY_FILETYPE_GROUP_MARKUP;
 
 #define VHDL
@@ -380,7 +350,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 21;
 	ft->name = g_strdup("VHDL");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-vhdl");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define VERILOG
@@ -388,7 +357,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 39;
 	ft->name = g_strdup("Verilog");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-verilog");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define DIFF
@@ -396,7 +364,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 20;
 	ft->name = g_strdup("Diff");
 	filetype_make_title(ft, TITLE_FILE);
-	ft->mime_type = g_strdup("text/x-patch");
 	ft->group = GEANY_FILETYPE_GROUP_MISC;
 
 #define LISP
@@ -409,7 +376,6 @@ static void init_builtin_filetypes(void)
 	ft = filetypes[GEANY_FILETYPES_ERLANG];
 	ft->name = g_strdup("Erlang");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-erlang");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define CONF
@@ -423,7 +389,6 @@ static void init_builtin_filetypes(void)
 	ft = filetypes[GEANY_FILETYPES_PO];
 	ft->name = g_strdup("Po");
 	ft->title = g_strdup(_("Gettext translation file"));
-	ft->mime_type = g_strdup("text/x-gettext-translation");
 	ft->group = GEANY_FILETYPE_GROUP_MISC;
 
 #define HAXE
@@ -438,7 +403,6 @@ static void init_builtin_filetypes(void)
 	ft->lang = 34;
 	ft->name = g_strdup("ActionScript");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("application/ecmascript");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define R
@@ -460,21 +424,18 @@ static void init_builtin_filetypes(void)
 	ft->lang = 32;
 	ft->name = g_strdup("Matlab/Octave");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-matlab");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define YAML
 	ft = filetypes[GEANY_FILETYPES_YAML];
 	ft->name = g_strdup("YAML");
 	filetype_make_title(ft, TITLE_FILE);
-	ft->mime_type = g_strdup("application/x-yaml");
 	ft->group = GEANY_FILETYPE_GROUP_MISC;
 
 #define CMAKE
 	ft = filetypes[GEANY_FILETYPES_CMAKE];
 	ft->name = g_strdup("CMake");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-cmake");
 	ft->group = GEANY_FILETYPE_GROUP_SCRIPT;
 
 #define NSIS
@@ -488,7 +449,6 @@ static void init_builtin_filetypes(void)
 	ft = filetypes[GEANY_FILETYPES_ADA];
 	ft->name = g_strdup("Ada");
 	filetype_make_title(ft, TITLE_SOURCE_FILE);
-	ft->mime_type = g_strdup("text/x-adasrc");
 	ft->group = GEANY_FILETYPE_GROUP_COMPILED;
 
 #define FORTH
@@ -591,9 +551,6 @@ static void filetype_add(GeanyFiletype *ft)
 
 	/* list will be sorted later */
 	filetypes_by_title = g_slist_prepend(filetypes_by_title, ft);
-
-	if (!ft->mime_type)
-		ft->mime_type = g_strdup("text/plain");
 }
 
 
@@ -763,16 +720,7 @@ static void create_set_filetype_menu(void)
 
 void filetypes_init()
 {
-	GSList *node;
-
 	filetypes_init_types();
-
-	/* this has to be here as GTK isn't initialized in filetypes_init_types(). */
-	foreach_slist(node, filetypes_by_title)
-	{
-		GeanyFiletype *ft = node->data;
-		ft->icon = ui_get_mime_icon(ft->mime_type, GTK_ICON_SIZE_MENU);
-	}
 	create_set_filetype_menu();
 	setup_config_file_menus();
 }
@@ -1212,6 +1160,10 @@ static void load_settings(guint ft_id, GKeyFile *config, GKeyFile *configh)
 		SETPTR(filetypes[ft_id]->extension, result);
 	}
 
+	/* MIME type */
+	result = utils_get_setting(string, configh, config, "settings", "mime_type", "text/plain");
+	SETPTR(filetypes[ft_id]->mime_type, result);
+
 	/* read comment notes */
 	result = utils_get_setting(string, configh, config, "settings", "comment_open", NULL);
 	if (result != NULL)
@@ -1431,6 +1383,12 @@ void filetypes_load_config(guint ft_id, gboolean reload)
 
 	load_settings(ft_id, config, config_home);
 	highlighting_init_styles(ft_id, config, config_home);
+
+	if (reload && ft->icon)
+	{
+		g_object_unref(ft->icon);
+		ft->icon = NULL;
+	}
 
 	g_key_file_free(config);
 	g_key_file_free(config_home);
@@ -1839,4 +1797,21 @@ gboolean filetype_get_comment_open_close(const GeanyFiletype *ft, gboolean singl
 	}
 
 	return !EMPTY(*co);
+}
+
+
+/* gets the filetype icon, possibly rendering it if not yet done
+ * Returns the filetype's icon, should not be freed
+ * 
+ * This requires the mime_type setting so has to be done after the filetype
+ * is loaded, but we don't necessarily have GTK in filetypes_load_config(),
+ * so use a helper function that renders the icon if needed */
+GdkPixbuf *filetype_get_icon(GeanyFiletype *ft)
+{
+	g_return_val_if_fail(ft != NULL, NULL);
+
+	if (! ft->icon)
+		ft->icon = ui_get_mime_icon(ft->mime_type, GTK_ICON_SIZE_MENU);
+
+	return ft->icon;
 }

--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -218,6 +218,8 @@ gboolean filetypes_parse_error_message(GeanyFiletype *ft, const gchar *message,
 gboolean filetype_get_comment_open_close(const GeanyFiletype *ft, gboolean single_first,
 		const gchar **co, const gchar **cc);
 
+GdkPixbuf *filetype_get_icon(GeanyFiletype *ft);
+
 G_END_DECLS
 
 #endif

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -456,6 +456,7 @@ void sidebar_openfiles_add(GeanyDocument *doc)
 	gchar *basename;
 	const GdkColor *color = document_get_status_color(doc);
 	static GdkPixbuf *file_icon = NULL;
+	GdkPixbuf *ft_icon = doc->file_type ? filetype_get_icon(doc->file_type) : NULL;
 
 	gtk_tree_store_append(store_openfiles, iter, parent);
 
@@ -474,7 +475,7 @@ void sidebar_openfiles_add(GeanyDocument *doc)
 
 	basename = g_path_get_basename(DOC_FILENAME(doc));
 	gtk_tree_store_set(store_openfiles, iter,
-		DOCUMENTS_ICON, (doc->file_type && doc->file_type->icon) ? doc->file_type->icon : file_icon,
+		DOCUMENTS_ICON, ft_icon ? ft_icon : file_icon,
 		DOCUMENTS_SHORTNAME, basename, DOCUMENTS_DOCUMENT, doc, DOCUMENTS_COLOR, color,
 		DOCUMENTS_FILENAME, DOC_FILENAME(doc), -1);
 	g_free(basename);
@@ -505,7 +506,7 @@ void sidebar_openfiles_update(GeanyDocument *doc)
 	{
 		/* just update color and the icon */
 		const GdkColor *color = document_get_status_color(doc);
-		GdkPixbuf *icon = doc->file_type->icon;
+		GdkPixbuf *icon = filetype_get_icon(doc->file_type);
 
 		gtk_tree_store_set(store_openfiles, iter, DOCUMENTS_COLOR, color, -1);
 		if (icon)

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2587,7 +2587,7 @@ void ui_menu_add_document_items_sorted(GtkMenu *menu, GeanyDocument *active,
 
 		base_name = g_path_get_basename(DOC_FILENAME(doc));
 		menu_item = gtk_image_menu_item_new_with_label(base_name);
-		image = gtk_image_new_from_pixbuf(doc->file_type->icon);
+		image = gtk_image_new_from_pixbuf(filetype_get_icon(doc->file_type));
 		gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menu_item), image);
 
 		gtk_widget_show(menu_item);


### PR DESCRIPTION
This allows custom filetypes to define a mime type, hence the icon displayed for this filetype;  as well as moving ones for built-in filetypes out of the code to the configuration files.

This replaces PRs #178 and #173 (yet to have an actual header icon one has to add the header filtypes).

---

This maybe is considered to break the plugin API because now `file_type->icon` maybe be `NULL`, so should be accessed using `filetype_get_icon()`, but this field isn't documented so we advertize it's not part of the API.  In practice, from GP, only GeanyPy "uses" it, and properly checks for NULL, so I don't know.

BTW, `filetype_get_icon()` seems needed because now the mime-type is loaded dynamically in `filetypes_load_config()`, which unfortunately can be called before GTK is initialized when generating tag files, so we can't call `ui_get_mime_icon()` from there.

Also, a small bug I don't know how to fix: when reloading a configuration that changed the `mime_type` setting the icons aren't updated in the sidebar until the documents in question changes (so it calls `sidebar_openfiles_add()`).
