### PR TITLE
plugin cleanup: Fix glib warning about unconnected signal handler.

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -777,8 +777,11 @@ static void remove_callbacks(Plugin *plugin)
 	if (signal_ids == NULL)
 		return;
 
-	foreach_array(SignalConnection, sc, signal_ids)
-		g_signal_handler_disconnect(sc->object, sc->handler_id);
+	foreach_array(SignalConnection, sc, signal_ids) {
+		/* The plugin might have disconnected the signal already */
+		if (g_signal_handler_is_connected(sc->object, sc->handler_id))
+			g_signal_handler_disconnect(sc->object, sc->handler_id);
+	}
 
 	g_array_free(signal_ids, TRUE);
 }


### PR DESCRIPTION
The warning looks like this: (geany:6315): GLib-GObject-WARNING *_:
gsignal.c:2593: instance 'XXX' has no handler with id 'NNN'. It appears when
the plugin cleanup code tries to disconnect a signal that the plugin connected
with plugin_signal_connect() and already disconnected on its own with
g_signal_handler_disconnect_ (Because there is no plugin api for disconnecting
signal). In this case the handler id becomes stale.

The fix is either to check if the handler id is still valid (connected) or to
provide a plugin_signal_disconnect(), or most preferably both. This commit
implements the former.
