### PR TITLE
Maintain edit history on document reload

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2604,6 +2604,9 @@ use_gio_unsafe_file_saving        Whether to use GIO as the unsafe file        t
                                   correctly on some complex setups.
 gio_unsafe_save_backup            Make a backup when using GIO unsafe file     false       immediately
                                   saving. Backup is named `filename~`.
+keep_edit_history_on_reload       Whether to maintain the edit history when    true        immediately
+                                  reloading a file, and allow the operation
+                                  to be reverted.
 **Filetype related**
 extract_filetype_regex            Regex to extract filetype name from file     See below.  immediately
                                   via capture group one.
@@ -3306,8 +3309,7 @@ Close all                       Ctrl-Shift-W              Closes all open files.
 
 Close                           Ctrl-W  (C)               Closes the current file.
 
-Reload file                     Ctrl-R  (C)               Reloads the current file. All unsaved changes
-                                                          will be lost.
+Reload file                     Ctrl-R  (C)               Reloads the current file.
 
 Print                           Ctrl-P  (C)               Prints the current file.
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -428,8 +428,9 @@ G_MODULE_EXPORT void on_reload_as_activate(GtkMenuItem *menuitem, gpointer user_
 		charset = doc->encoding;
 
 	base_name = g_path_get_basename(doc->file_name);
-	/* don't prompt if file hasn't been edited at all */
-	if ((!doc->changed && !document_can_undo(doc) && !document_can_redo(doc)) ||
+	/* don't prompt if edit history is maintained, or if file hasn't been edited at all. */
+	if (file_prefs.keep_edit_history_on_reload ||
+		(!doc->changed && !document_can_undo(doc) && !document_can_redo(doc)) ||
 		dialogs_show_question_full(NULL, _("_Reload"), GTK_STOCK_CANCEL,
 		_("Any unsaved changes will be lost."),
 		_("Are you sure you want to reload '%s'?"), base_name))

--- a/src/document.h
+++ b/src/document.h
@@ -66,6 +66,7 @@ typedef struct GeanyFilePrefs
 	gboolean		use_gio_unsafe_file_saving; /* whether to use GIO as the unsafe backend */
 	gchar			*extract_filetype_regex;	/* regex to extract filetype on opening */
 	gboolean		tab_close_switch_to_mru;
+	gboolean		keep_edit_history_on_reload; /* Keep undo stack upon, and allow undoing of, document reloading. */
 }
 GeanyFilePrefs;
 

--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -31,8 +31,16 @@ enum
 	UNDO_SCINTILLA = 0,
 	UNDO_ENCODING,
 	UNDO_BOM,
+	UNDO_RELOAD,
 	UNDO_ACTIONS_MAX
 };
+
+typedef struct UndoReloadData
+{
+	guint actions_count; /* How many following undo/redo actions need to be applied. */
+	gint eol_mode;       /* End-Of-Line mode before/after reloading. */
+}
+UndoReloadData;
 
 typedef enum
 {

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -220,6 +220,8 @@ static void init_pref_groups(void)
 		"gio_unsafe_save_backup", FALSE);
 	stash_group_add_boolean(group, &file_prefs.use_gio_unsafe_file_saving,
 		"use_gio_unsafe_file_saving", TRUE);
+	stash_group_add_boolean(group, &file_prefs.keep_edit_history_on_reload,
+		"keep_edit_history_on_reload", TRUE);
 	/* for backwards-compatibility */
 	stash_group_add_integer(group, &editor_prefs.indentation->hard_tab_width,
 		"indent_hard_tab_width", 8);


### PR DESCRIPTION
This branch adds an support for maintaining the undo history when reloading a document, as well as allowing the reload operation to be reverted. This behavior is controlled by the `keep_edit_history_on_reload` option, which is on by default.

Note that this branch is based off `bug/clear-redo-on-edit` from PR #187