### PR TITLE
A few status-bar additions

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2625,7 +2625,7 @@ Statusbar Templates
 
 The default statusbar template is (note ``\t`` = tab):
 
-``line: %l / %L\t col: %c\t sel: %s\t %w      %t      %mmode: %M      encoding: %e      filetype: %f      scope: %S``
+``line: %l / %L\t col: %c\t ch: %h\t sel: %s\t %w      %t      %mmode: %M      encoding: %e      filetype: %f      scope: %S``
 
 Settings the preference to an empty string will also cause Geany to use this
 internal default.

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2657,6 +2657,7 @@ Placeholder   Description
   ``%r``      Shows whether the document is read-only (RO) or nothing.
   ``%Y``      The Scintilla style number at the caret position. This is
               useful if you're debugging color schemes or related code.
+  ``%T``      A single tab character.
 ============  ===========================================================
 
 Terminal (VTE) preferences

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2625,7 +2625,7 @@ Statusbar Templates
 
 The default statusbar template is:
 
-``line: %l / %L%T col: %c%T ch: %h%T sel: %s%T %w      %t      %mmode: %M      encoding: %e      filetype: %f      scope: %S``
+``line: %l / %L%T col: %C%T ch: %H%T sel: %s%T %w      %t      %mmode: %M      encoding: %e      filetype: %f      scope: %S``
 
 Settings the preference to an empty string will also cause Geany to use this
 internal default.

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2639,6 +2639,8 @@ Placeholder   Description
   ``%L``      The total number of lines
   ``%c``      The current column number starting at 0
   ``%C``      The current column number starting at 1
+  ``%h``      The current character number starting at 0
+  ``%H``      The current character number starting at 1
   ``%s``      The number of selected characters or if only whole lines
               selected, the number of selected lines.
   ``%w``      Shows ``RO`` when the document is in read-only mode,

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2623,9 +2623,9 @@ The extract_filetype_regex has the default value GEANY_DEFAULT_FILETYPE_REGEX.
 Statusbar Templates
 ```````````````````
 
-The default statusbar template is (note ``\t`` = tab):
+The default statusbar template is:
 
-``line: %l / %L\t col: %c\t ch: %h\t sel: %s\t %w      %t      %mmode: %M      encoding: %e      filetype: %f      scope: %S``
+``line: %l / %L%T col: %c%T ch: %h%T sel: %s%T %w      %t      %mmode: %M      encoding: %e      filetype: %f      scope: %S``
 
 Settings the preference to an empty string will also cause Geany to use this
 internal default.

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -61,6 +61,7 @@
 #define DEFAULT_STATUSBAR_TEMPLATE N_(\
 	"line: %l / %L\t "   \
 	"col: %c\t "         \
+	"ch: %h\t "          \
 	"sel: %s\t "         \
 	"%w      %t      %m" \
 	"mode: %M      "     \

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -220,6 +220,14 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 			case 'C':
 				g_string_append_printf(stats_str, "%d", col + 1);
 				break;
+			case 'h':
+				g_string_append_printf(stats_str, "%d",
+					pos - sci_get_position_from_line(doc->editor->sci, line));
+				break;
+			case 'H':
+				g_string_append_printf(stats_str, "%d",
+					pos - sci_get_position_from_line(doc->editor->sci, line) + 1);
+				break;
 			case 'p':
 				g_string_append_printf(stats_str, "%u", pos);
 				break;

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -60,8 +60,8 @@
 
 #define DEFAULT_STATUSBAR_TEMPLATE N_(\
 	"line: %l / %L%T "   \
-	"col: %c%T "         \
-	"ch: %h%T "          \
+	"col: %C%T "         \
+	"ch: %H%T "          \
 	"sel: %s%T "         \
 	"%w      %t      %m" \
 	"mode: %M      "     \

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -59,10 +59,10 @@
 
 
 #define DEFAULT_STATUSBAR_TEMPLATE N_(\
-	"line: %l / %L\t "   \
-	"col: %c\t "         \
-	"ch: %h\t "          \
-	"sel: %s\t "         \
+	"line: %l / %L%T "   \
+	"col: %c%T "         \
+	"ch: %h%T "          \
+	"sel: %s%T "         \
 	"%w      %t      %m" \
 	"mode: %M      "     \
 	"encoding: %e      " \

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -306,6 +306,9 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 				g_string_append_printf(stats_str, "%d",
 					sci_get_style_at(doc->editor->sci, pos));
 				break;
+			case 'T':
+				g_string_append_c(stats_str, '\t');
+				break;
 			default:
 				g_string_append_len(stats_str, expos, 1);
 		}


### PR DESCRIPTION
Adds character-number format-specifier to the status-bar template (counts tabs as single characters).
Shows character-number on the status-bar by default.
Adds tab character format-specifier to the status-bar template (as a replacement for `\t`).
Displays column and character numbers as one-based by default.
