### PR TITLE
New hidden preference: max_interface_tab_width

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2558,6 +2558,8 @@ statusbar_template                The status bar statistics line format.       S
                                   (See `Statusbar Templates`_ for details).
 new_document_after_close          Whether to open a new document after all     false       immediately
                                   documents have been closed.
+max_notebook_tab_width            The maximum width of the notebook tabs       30          on restart
+                                  before the label texts are ellipsized.
 msgwin_status_visible             Whether to show the Status tab in the        true        immediately
                                   Messages Window
 msgwin_compiler_visible           Whether to show the Compiler tab in the      true        immediately

--- a/src/document.c
+++ b/src/document.c
@@ -376,7 +376,7 @@ void document_update_tab_label(GeanyDocument *doc)
 
 	g_return_if_fail(doc != NULL);
 
-	short_name = document_get_basename_for_display(doc, -1);
+	short_name = document_get_basename_for_display(doc, interface_prefs.max_notebook_tab_width);
 
 	/* we need to use the event box for the tooltip, labels don't get the necessary events */
 	parent = gtk_widget_get_parent(doc->priv->tab_label);

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 218
+#define GEANY_API_VERSION 219
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2119,6 +2119,8 @@ void ui_init_prefs(void)
 		"msgwin_messages_visible", TRUE);
 	stash_group_add_boolean(group, &interface_prefs.msgwin_scribble_visible,
 		"msgwin_scribble_visible", TRUE);
+	stash_group_add_integer(group, &interface_prefs.max_notebook_tab_width,
+		"max_notebook_tab_width", 30);
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -68,6 +68,7 @@ typedef struct GeanyInterfacePrefs
 	/** whether compiler messages window is automatically scrolled to show new messages */
 	gboolean		compiler_tab_autoscroll;
 	gint			msgwin_orientation;			/**< orientation of the message window */
+	gint			max_notebook_tab_width;		/**< max width of notebook tabs in characters */
 }
 GeanyInterfacePrefs;
 


### PR DESCRIPTION
The hidden option controls the maximum width of the document tabs before the label texts are ellipsized (30 characters by default).

This should close a feature request from 2009 with some implied support by @Enrix835 : http://sourceforge.net/p/geany/feature-requests/321/
