### PR TITLE
Update HTML file template to HTML5

### DIFF
--- a/data/templates/files/file.html
+++ b/data/templates/files/file.html
@@ -1,11 +1,10 @@
 {fileheader}
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 
 <head>
+	<meta charset="utf-8" />
 	<title>{untitled}</title>
-	<meta http-equiv="content-type" content="text/html;charset=utf-8" />
 	<meta name="generator" content="{geanyversion}" />
 </head>
 


### PR DESCRIPTION
HTML5 is everywhere, XHTML is kind of out.

The children at our local CoderDojo class open up a new file from template (by themselves), and then the first thing we do, we have to tell them to edit bits they don't understand because all new tutorials are HTML5. This file was last updated 4 yours ago. Let's have Geany forward-compatible?

This is a very minimal change although I'd prefer to include some more common elements for convenience, like:
- `<meta name="description" contents="" />` and
- `<link rel="stylesheet" href="style.css" />` and
- `<link rel="canonical" href="" />` in the `<head>`,
- `<script></script>` block just before closing `</body>`,
- possibly `<script src="{CDN URL to jQuery}"></script>`, same place.

But that would be pushing it. :smiley: 
