### PR TITLE
Feature request #683 : autosave when the editor lose focus

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -5068,6 +5068,14 @@ configure a keybinding for the plugin.
 Save Actions
 ------------
 
+Save on focus out
+^^^^^^^^^^^^^^^^^
+
+You can save the current document when the editor's focus goes out.
+Every pop-up, menu dialogs, or anything else that can make the editor lose the focus,
+will make the current document to be saved.
+
+
 Instant Save
 ^^^^^^^^^^^^
 This plugin sets on every new file (*File->New* or *File->New (with template)*)

--- a/plugins/saveactions.c
+++ b/plugins/saveactions.c
@@ -32,6 +32,7 @@
 #include <glib/gstdio.h>
 
 
+GeanyPlugin		*geany_plugin;
 GeanyData		*geany_data;
 GeanyFunctions	*geany_functions;
 
@@ -52,6 +53,7 @@ enum
 static struct
 {
 	GtkWidget *checkbox_enable_autosave;
+	GtkWidget *checkbox_enable_autosave_losing_focus;
 	GtkWidget *checkbox_enable_instantsave;
 	GtkWidget *checkbox_enable_backupcopy;
 
@@ -70,6 +72,7 @@ pref_widgets;
 
 
 static gboolean enable_autosave;
+static gboolean enable_autosave_losing_focus;
 static gboolean enable_instantsave;
 static gboolean enable_backupcopy;
 
@@ -273,10 +276,51 @@ static void instantsave_document_new_cb(GObject *obj, GeanyDocument *doc, gpoint
 }
 
 
+/* Save when focus out
+ *
+ * @param pointer ref to the current doc (struct GeanyDocument *)
+ *
+ * @return always FALSE = Just a one shot execution
+ *
+ */
+static gboolean save_on_focus_out_idle(gpointer p_cur_doc)
+{
+	GeanyDocument *cur_doc = p_cur_doc;
+
+	if (DOC_VALID(cur_doc) && (cur_doc->file_name != NULL))
+		document_save_file(cur_doc, FALSE);
+
+	return FALSE;
+}
+
+
+/* Autosave the current file when the focus out of the _editor_
+ *
+ * Get the SCN_FOCUSOUT signal, and then ask plugin_idle_add()
+ * to save the current doc when idle
+ *
+ * @return always FALSE = Non block signals
+ *
+ */
+static gboolean on_document_focus_out(GObject *object, GeanyEditor *editor,
+								 SCNotification *nt, gpointer data)
+{
+	if (nt->nmhdr.code == SCN_FOCUSOUT
+		&& enable_autosave_losing_focus
+		&& editor->document->file_name != NULL)
+	{
+		plugin_idle_add(geany_plugin, save_on_focus_out_idle, editor->document);
+	}
+
+	return FALSE;
+}
+
+
 PluginCallback plugin_callbacks[] =
 {
 	{ "document-new", (GCallback) &instantsave_document_new_cb, FALSE, NULL },
 	{ "document-save", (GCallback) &backupcopy_document_save_cb, FALSE, NULL },
+	{ "editor-notify", (GCallback) &on_document_focus_out, FALSE, NULL },
 	{ NULL, NULL, FALSE, NULL }
 };
 
@@ -342,6 +386,8 @@ void plugin_init(GeanyData *data)
 
 	enable_autosave = utils_get_setting_boolean(
 		config, "saveactions", "enable_autosave", FALSE);
+	enable_autosave_losing_focus = utils_get_setting_boolean(
+		config, "saveactions", "enable_autosave_losing_focus", FALSE);
 	enable_instantsave = utils_get_setting_boolean(
 		config, "saveactions", "enable_instantsave", FALSE);
 	enable_backupcopy = utils_get_setting_boolean(
@@ -418,6 +464,8 @@ static void configure_response_cb(GtkDialog *dialog, gint response, G_GNUC_UNUSE
 
 		enable_autosave = gtk_toggle_button_get_active(
 			GTK_TOGGLE_BUTTON(pref_widgets.checkbox_enable_autosave));
+		enable_autosave_losing_focus = gtk_toggle_button_get_active(
+			GTK_TOGGLE_BUTTON(pref_widgets.checkbox_enable_autosave_losing_focus));
 		enable_instantsave = gtk_toggle_button_get_active(
 			GTK_TOGGLE_BUTTON(pref_widgets.checkbox_enable_instantsave));
 		enable_backupcopy = gtk_toggle_button_get_active(
@@ -443,6 +491,7 @@ static void configure_response_cb(GtkDialog *dialog, gint response, G_GNUC_UNUSE
 		g_key_file_load_from_file(config, config_file, G_KEY_FILE_NONE, NULL);
 
 		g_key_file_set_boolean(config, "saveactions", "enable_autosave", enable_autosave);
+		g_key_file_set_boolean(config, "saveactions", "enable_autosave_losing_focus", enable_autosave_losing_focus);
 		g_key_file_set_boolean(config, "saveactions", "enable_instantsave", enable_instantsave);
 		g_key_file_set_boolean(config, "saveactions", "enable_backupcopy", enable_backupcopy);
 
@@ -539,7 +588,7 @@ GtkWidget *plugin_configure(GtkDialog *dialog)
 	 * Auto Save
 	 */
 	{
-		GtkWidget *spin, *hbox, *checkbox, *radio1, *radio2;
+		GtkWidget *spin, *hbox, *checkbox, *checkbox_enable_as_lf, *radio1, *radio2;
 
 		notebook_vbox = gtk_vbox_new(FALSE, 2);
 		inner_vbox = gtk_vbox_new(FALSE, 5);
@@ -547,6 +596,12 @@ GtkWidget *plugin_configure(GtkDialog *dialog)
 		gtk_box_pack_start(GTK_BOX(notebook_vbox), inner_vbox, TRUE, TRUE, 5);
 		gtk_notebook_insert_page(GTK_NOTEBOOK(notebook),
 			notebook_vbox, gtk_label_new(_("Auto Save")), NOTEBOOK_PAGE_AUTOSAVE);
+
+		checkbox_enable_as_lf = gtk_check_button_new_with_mnemonic(_("Enable save when losing _focus"));
+		gtk_button_set_focus_on_click(GTK_BUTTON(checkbox_enable_as_lf), FALSE);
+		pref_widgets.checkbox_enable_autosave_losing_focus = checkbox_enable_as_lf;
+		gtk_box_pack_start(GTK_BOX(inner_vbox), checkbox_enable_as_lf, FALSE, FALSE, 6);
+		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(checkbox_enable_as_lf), enable_autosave_losing_focus);
 
 		checkbox_enable = gtk_check_button_new_with_mnemonic(_("_Enable"));
 		gtk_button_set_focus_on_click(GTK_BUTTON(checkbox_enable), FALSE);


### PR DESCRIPTION
Add a new feature : auto-save when the editor lose focus

Warn: Will save the current file at _all_ editor focus out event.
