### PR TITLE
Add the choice to use Windows or Gtk color chooser dialog

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1282,12 +1282,12 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckButton" id="check_native_windows_dialogs">
-                                    <property name="label" translatable="yes">Use Windows File Open/Save dialogs</property>
+                                    <property name="label" translatable="yes">Use Windows native dialogs</property>
                                     <property name="use_action_appearance">False</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Defines whether to use the native Windows File Open/Save dialogs or whether to use the GTK default dialogs</property>
+                                    <property name="tooltip_text" translatable="yes">Defines whether to use the Windows native dialogs or whether to use the GTK default dialogs</property>
                                     <property name="use_underline">True</property>
                                     <property name="draw_indicator">True</property>
                                   </object>

--- a/src/tools.c
+++ b/src/tools.c
@@ -946,7 +946,6 @@ void tools_word_count(void)
 /*
  * color dialog callbacks
  */
-#ifndef G_OS_WIN32
 static void on_color_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 {
 	switch (response)
@@ -976,17 +975,21 @@ static void on_color_dialog_response(GtkDialog *dialog, gint response, gpointer 
 			gtk_widget_hide(ui_widgets.open_colorsel);
 	}
 }
-#endif
 
 
 /* This shows the color selection dialog to choose a color. */
 void tools_color_chooser(const gchar *color)
 {
-#ifdef G_OS_WIN32
-	win32_show_color_dialog(color);
-#else
 	GdkColor gc;
 	GtkWidget *colorsel;
+
+#ifdef G_OS_WIN32
+	if (interface_prefs.use_native_windows_dialogs)
+	{
+		win32_show_color_dialog(color);
+		return;
+	}
+#endif
 
 	if (ui_widgets.open_colorsel == NULL)
 	{
@@ -1015,5 +1018,4 @@ void tools_color_chooser(const gchar *color)
 
 	/* We make sure the dialog is visible. */
 	gtk_window_present(GTK_WINDOW(ui_widgets.open_colorsel));
-#endif
 }


### PR DESCRIPTION
- Add the choice to use Windows or Gtk color chooser dialog.
- Modification of the string "Use Windows File Open/Save dialogs" to "Use Windows native dialogs".
