### PR TITLE
Correction bug #1021 Windows File Dialog doesn't append file extension

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -665,7 +665,7 @@ gboolean dialogs_show_save_as(void)
 	if (interface_prefs.use_native_windows_dialogs)
 	{
 		gchar *utf8_name = win32_show_document_save_as_dialog(GTK_WINDOW(main_widgets.window),
-						_("Save File"), DOC_FILENAME(doc));
+						_("Save File"), doc);
 		if (utf8_name != NULL)
 			result = handle_save_as(utf8_name, FALSE);
 	}

--- a/src/win32.c
+++ b/src/win32.c
@@ -419,18 +419,25 @@ gboolean win32_show_document_open_dialog(GtkWindow *parent, const gchar *title, 
 
 
 gchar *win32_show_document_save_as_dialog(GtkWindow *parent, const gchar *title,
-										  const gchar *initial_file)
+										  GeanyDocument *doc)
 {
 	OPENFILENAMEW of;
 	gint retval;
 	gchar tmp[MAX_PATH];
 	wchar_t w_file[MAX_PATH];
 	wchar_t w_title[512];
+	wchar_t w_file_type[16];
 
 	w_file[0] = '\0';
+	w_file_type[0] = '\0';
 
-	if (initial_file != NULL)
-		MultiByteToWideChar(CP_UTF8, 0, initial_file, -1, w_file, G_N_ELEMENTS(w_file));
+	/* Convert the name of the file for of.lpstrFile */
+	MultiByteToWideChar(CP_UTF8, 0, DOC_FILENAME(doc), -1, w_file, G_N_ELEMENTS(w_file));
+
+	/* Convert the extension for of.lpstrDefExt */
+	if ((doc->file_type != NULL) && (doc->file_type->extension != NULL))
+		MultiByteToWideChar(CP_UTF8, 0, doc->file_type->extension, -1, w_file_type,
+				G_N_ELEMENTS(w_file_type));
 
 	MultiByteToWideChar(CP_UTF8, 0, title, -1, w_title, G_N_ELEMENTS(w_title));
 
@@ -451,7 +458,7 @@ gchar *win32_show_document_save_as_dialog(GtkWindow *parent, const gchar *title,
 	of.nMaxFile = 2048;
 	of.lpstrFileTitle = NULL;
 	of.lpstrTitle = w_title;
-	of.lpstrDefExt = L"";
+	of.lpstrDefExt = w_file_type;
 	of.Flags = OFN_FILEMUSTEXIST | OFN_EXPLORER;
 	retval = GetSaveFileNameW(&of);
 

--- a/src/win32.h
+++ b/src/win32.h
@@ -30,7 +30,7 @@ gchar *win32_show_file_dialog(GtkWindow *parent, const gchar *title, const gchar
 gboolean win32_show_document_open_dialog(GtkWindow *parent, const gchar *title, const gchar *initial_dir);
 
 gchar *win32_show_document_save_as_dialog(GtkWindow *parent, const gchar *title,
-										  const gchar *initial_file);
+										  GeanyDocument *doc);
 
 void win32_show_font_dialog(void);
 


### PR DESCRIPTION
Correction bug #1021 Windows File Dialog doesn't append file extension.

bug ref : https://sourceforge.net/p/geany/bugs/1021/

Signed-off-by: bestel steven.valsesia@gmail.com
