### PR TITLE
Select matching brace

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3468,6 +3468,12 @@ Select current word             Alt-Shift-W               Selects the current wo
 Select current paragraph        Alt-Shift-P               Selects the current paragraph under the cursor
                                                           which is defined by two empty lines around it.
 
+Select to matching brace        Ctrl-Shift-B              If the cursor is ahead or behind a brace, then the
+                                                          text in between both braces is selected. The cursor
+                                                          is moved to the brace which belongs to the current
+                                                          one. If this keyboard shortcut is pressed again,
+                                                          the cursor is moved back to the first brace.
+
 Select current line(s)          Alt-Shift-L               Selects the current line under the cursor (and any
                                                           partially selected lines).
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -3771,6 +3771,30 @@ void editor_select_paragraph(GeanyEditor *editor)
 }
 
 
+void editor_select_matching_brace(GeanyEditor *editor)
+{
+	gint pos, match;
+	gint after_brace;
+
+	g_return_if_fail(editor != NULL);
+
+	pos = sci_get_current_position(editor->sci);
+	after_brace = pos > 0 && utils_isbrace(sci_get_char_at(editor->sci, pos - 1), TRUE);
+	pos -= after_brace;	/* set pos to the brace */
+
+	match = sci_find_matching_brace(editor->sci, pos);
+
+	if (match != -1 && match != pos)
+	{	/* select text in between braces */
+		if (match > pos)
+			pos   += 1;
+		else
+			match += 1;
+		sci_set_selection(editor->sci, pos, match);
+	}
+}
+
+
 /* Returns first line of block for GTK_DIR_UP, line after block
  * ends for GTK_DIR_DOWN or -1 if called on an empty line. */
 static gint find_block_stop(GeanyEditor *editor, gint line, gint direction)

--- a/src/editor.h
+++ b/src/editor.h
@@ -259,6 +259,8 @@ void editor_select_lines(GeanyEditor *editor, gboolean extra_line);
 
 void editor_select_paragraph(GeanyEditor *editor);
 
+void editor_select_matching_brace(GeanyEditor *editor);
+
 void editor_select_indent_block(GeanyEditor *editor);
 
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -360,6 +360,9 @@ static void init_default_kb(void)
 	add_kb(group, GEANY_KEYS_SELECT_PARAGRAPH, NULL,
 		GDK_p, GDK_SHIFT_MASK | GDK_MOD1_MASK, "edit_selectparagraph", _("Se_lect Current Paragraph"),
 		"select_current_paragraph1");
+	add_kb(group, GEANY_KEYS_SELECT_TO_MATCHINGBRACE, NULL,
+		GDK_b, GDK_SHIFT_MASK | GDK_CONTROL_MASK, "edit_select_tomatchingbrace",
+		_("Select to matching brace"), NULL);
 	add_kb(group, GEANY_KEYS_SELECT_WORDPARTLEFT, NULL,
 		0, 0, "edit_selectwordpartleft", _("Select to previous word part"), NULL);
 	add_kb(group, GEANY_KEYS_SELECT_WORDPARTRIGHT, NULL,
@@ -2420,6 +2423,9 @@ static gboolean cb_func_select_action(guint key_id)
 			break;
 		case GEANY_KEYS_SELECT_PARAGRAPH:
 			editor_select_paragraph(doc->editor);
+			break;
+		case GEANY_KEYS_SELECT_TO_MATCHINGBRACE:
+			editor_select_matching_brace(doc->editor);
 			break;
 		case GEANY_KEYS_SELECT_WORDPARTLEFT:
 			sci_send_command(sci, SCI_WORDPARTLEFTEXTEND);

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -109,6 +109,7 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_EDITOR_SCROLLTOLINE,				/**< Keybinding. */
 	GEANY_KEYS_DOCUMENT_UNFOLDALL,				/**< Keybinding. */
 	GEANY_KEYS_GOTO_MATCHINGBRACE,				/**< Keybinding. */
+	GEANY_KEYS_SELECT_TO_MATCHINGBRACE,			/**< Keybinding. */
 	GEANY_KEYS_SEARCH_FINDDOCUMENTUSAGE,		/**< Keybinding. */
 	GEANY_KEYS_CLIPBOARD_PASTE,					/**< Keybinding. */
 	GEANY_KEYS_BUILD_MAKE,						/**< Keybinding. */


### PR DESCRIPTION
The feature of jumping in between braces is really useful. Often I find me wanting to select the text in between braces. So I added the feature to geany.

The default keybinding I used is Ctrl-Shift-B because Ctrl-B goes to the matching brace.

geany.txt is updated for documentation.

How does translation work ? Which files do I have to edit ? 
