### PR TITLE
Search matching brace

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1815,8 +1815,8 @@ static void cb_func_move_tab(guint key_id)
 
 static void goto_matching_brace(GeanyDocument *doc)
 {
-	gint pos, new_pos;
-	gint after_brace;
+	gint pos = -1, new_pos= -1;
+	gint after_brace = 0;
 
 	g_return_if_fail(DOC_VALID(doc));
 
@@ -1829,6 +1829,31 @@ static void goto_matching_brace(GeanyDocument *doc)
 	{	/* set the cursor at/after the brace */
 		sci_set_current_position(doc->editor->sci, new_pos + (!after_brace), FALSE);
 		editor_display_current_line(doc->editor, 0.5F);
+	}
+	else
+	{	/* search backwards for a solitary opening brace */
+		pos = sci_get_current_position(doc->editor->sci);
+
+		gint dismiss_braces_cnt = 0;
+		while (pos > 0)
+		{
+			pos--;
+			if (utils_is_closing_brace(sci_get_char_at(doc->editor->sci, pos), FALSE))
+			{
+				dismiss_braces_cnt++;  /*  count closing braces */
+			}
+			else if (utils_is_opening_brace(sci_get_char_at(doc->editor->sci, pos), FALSE))
+			{
+				if (dismiss_braces_cnt == 0) break;
+				dismiss_braces_cnt--;  /* count opening braces */
+			}
+		}
+
+		if (utils_is_opening_brace(sci_get_char_at(doc->editor->sci, pos), FALSE))
+		{
+			sci_set_current_position(doc->editor->sci, pos + 1, FALSE);
+			editor_display_current_line(doc->editor, 0.5F);
+		}
 	}
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -194,6 +194,21 @@ gboolean utils_is_opening_brace(gchar c, gboolean include_angles)
 }
 
 
+gboolean utils_is_closing_brace(gchar c, gboolean include_angles)
+{
+	switch (c)
+	{
+		case '>':
+		return include_angles;
+
+		case ')':
+		case '}':
+		case ']':  return TRUE;
+		default:  return FALSE;
+	}
+}
+
+
 /**
  * Writes @a text into a file named @a filename.
  * If the file doesn't exist, it will be created.

--- a/src/utils.h
+++ b/src/utils.h
@@ -155,6 +155,8 @@ gboolean utils_isbrace(gchar c, gboolean include_angles);
 
 gboolean utils_is_opening_brace(gchar c, gboolean include_angles);
 
+gboolean utils_is_closing_brace(gchar c, gboolean include_angles);
+
 gint utils_write_file(const gchar *filename, const gchar *text);
 
 gchar *utils_find_open_xml_tag(const gchar sel[], gint size);


### PR DESCRIPTION
The keybinding for searching matching braces is only useful, when the cursor is located close to a brace. If the cursor is in the middle of a block the keybinding is useless. I've changed the behaviour in order to go to the start of the current block. It is given by a solitary opening brace.
