### PR TITLE
filetypes.Go.conf: minor improvements

### DIFF
--- a/data/filetypes.Go.conf
+++ b/data/filetypes.Go.conf
@@ -4,8 +4,8 @@
 
 [keywords]
 # all items must be in one line
-primary=break case chan const continue default defer else fallthrough for func go goto if import interface map package range return select struct switch type var
-secondary=byte bool rune int int8 int16 int32 int64 uint uint8 uint16 uint32 uint64 float32 float64 complex64 complex128 uintptr string
+primary=break case chan const continue default defer else fallthrough for func go goto if import interface map package range return select struct switch type var make len new append
+secondary=byte bool rune int int8 int16 int32 int64 uint uint8 uint16 uint32 uint64 float32 float64 complex64 complex128 uintptr string true false nil
 
 # these are the Doxygen keywords
 docComment=a addindex addtogroup anchor arg attention author authors b brief bug c callergraph callgraph category cite class code cond copybrief copydetails copydoc copyright date def defgroup deprecated details dir dontinclude dot dotfile e else elseif em endcode endcond enddot endhtmlonly endif endinternal endlatexonly endlink endmanonly endmsc endrtfonly endverbatim endxmlonly enum example exception extends file fn headerfile hideinitializer htmlinclude htmlonly if ifnot image implements include includelineno ingroup interface internal invariant latexonly li line link mainpage manonly memberof msc mscfile n name namespace nosubgrouping note overload p package page par paragraph param post pre private privatesection property protected protectedsection protocol public publicsection ref related relatedalso relates relatesalso remark remarks result return returns retval rtfonly sa section see short showinitializer since skip skipline snippet struct subpage subsection subsubsection tableofcontents test throw throws todo tparam typedef union until var verbatim verbinclude version warning weakgroup xmlonly xrefitem
@@ -15,7 +15,7 @@ docComment=a addindex addtogroup anchor arg attention author authors b brief bug
 [settings]
 # default extension used when saving files
 extension=go
-lexer_filetype=C
+lexer_filetype=D
 
 # the following characters are these which a "word" can contains, see documentation
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789


### PR DESCRIPTION
Changed lexer_filetype from 'C' to 'D'. (multi-line strings (`...`) are now supported)
Added 7 more keywords: (make len new append true false nil)