### PR TITLE
Distribute `geany.gtkrc` and `geany.css` files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,13 +25,9 @@ SYS_DATA_FILES = \
 	$(srcdir)/data/templates/* \
 	$(srcdir)/data/templates/files/* \
 	$(srcdir)/data/colorschemes/* \
-	$(top_srcdir)/data/geany.glade
-
-if GTK3
-	$(top_srcdir)/data/geany.css
-else
-	$(top_srcdir)/data/geany.gtkrc
-endif
+	$(top_srcdir)/data/geany.glade \
+	data/geany.css \
+	data/geany.gtkrc
 
 EXTRA_DIST = \
 	autogen.sh \


### PR DESCRIPTION
Maybe they aren't dist'ed if they are in Automake conditional?
This probably makes both GTK2 and GTK3 files installed unconditionally.
