### PR TITLE
We use fixed colors here because txt2tags has more tags than the default...

### DIFF
--- a/data/filetypes.common
+++ b/data/filetypes.common
@@ -172,3 +172,29 @@ entity=default
 line_added=0x34b034;0xffffff;false;false
 line_removed=0xff2727;0xffffff;false;false
 line_changed=0x7f007f;0xffffff;false;false
+
+# Markup-type languages
+# foreground;background;bold;italic
+#default=false;false;false;false
+strong=0x445675;false;true;false
+emphasis=0x653A39;false;false;true
+underlined=0x386742;false;false;false
+header1=0xE20700;false;true;false
+header2=0xE20700;false;true;false
+header3=0xA81D05;false;true;false
+header4=0x871704;false;true;false
+header5=0x871704;false;true;false
+header6=0x871704;false;true;false
+ulist_item=0xE300EE;false;false;false
+olist_item=0xE300EE;false;false;false
+blockquote=0x015F52;false;false;false
+strikeout=0x644A9B;false;false;false
+hrule=0xff901e;false;false;false
+link=0x0930DE;false;false;true
+code=0x009f00;false;false;false
+codebk=0x005f00;false;false;false
+comment=0x777777;false;false;false
+option=0xC0036E;false;false;true
+preproc=0x848B00;false;false;true
+postproc=0xC05600;false;false;true
+

--- a/data/filetypes.markdown
+++ b/data/filetypes.markdown
@@ -2,22 +2,23 @@
 [styling]
 # Edit these in the colorscheme .conf file instead
 default=default
-strong=string_3
-emphasis=string_4
-header1=keyword_1
-header2=keyword_1
-header3=keyword_1
-header4=keyword_1
-header5=keyword_1
-header6=keyword_1
-ulist_item=tag_unknown
-olist_item=tag_unknown
-blockquote=tag_unknown
-strikeout=tag_unknown
-hrule=tag_unknown
-link=keyword_1
-code=attribute_unknown
-codebk=attribute_unknown
+strong=strong
+emphasis=emphasis
+strikeout=strikeout
+header1=header1
+header2=header2
+header3=header3
+header4=header4
+header5=header5
+header6=header6
+ulist_item=ulist_item
+olist_item=olist_item
+blockquote=blockquote
+hrule=hrule
+link=link
+code=code
+codebk=codebk
+option=option
 
 [settings]
 # default extension used when saving files

--- a/data/filetypes.restructuredtext
+++ b/data/filetypes.restructuredtext
@@ -1,6 +1,23 @@
 # For complete documentation of this file, please see Geany's main documentation
 [styling]
-# no syntax highlighting yet
+default=default
+strong=strong
+emphasis=emphasis
+header1=header1
+header2=header2
+header3=header3
+header4=header4
+header5=header5
+header6=header6
+ulist_item=ulist_item
+olist_item=olist_item
+blockquote=blockquote
+hrule=hrule
+link=link
+code=code
+codebk=codebk
+comment=comment_markup
+option=option
 
 [settings]
 # default extension used when saving files

--- a/data/filetypes.txt2tags
+++ b/data/filetypes.txt2tags
@@ -1,28 +1,27 @@
 # For complete documentation of this file, please see Geany's main documentation
 [styling]
-# We use fixed colors here because txt2tags has more tags than the default ones in geany.
-default=false;false;false;false
-strong=0x445675;false;true;false
-emphasis=0x653A39;false;false;true
-underlined=0x386742;false;false;false
-header1=0xE20700;false;true;false
-header2=0xE20700;false;true;false
-header3=0xA81D05;false;true;false
-header4=0x871704;false;true;false
-header5=0x871704;false;true;false
-header6=0x871704;false;true;false
-ulist_item=0xE300EE;false;false;false
-olist_item=0xE300EE;false;false;false
-blockquote=0x015F52;false;false;false
-strikeout=0x644A9B;false;false;false
-hrule=0xff901e;false;false;false
-link=0x0930DE;false;false;true
-code=0x009f00;false;false;false
-codebk=0x005f00;false;false;false
-comment=0x777777;false;false;false
-option=0xC0036E;false;false;true
-preproc=0x848B00;false;false;true
-postproc=0xC05600;false;false;true
+default=default
+strong=strong
+emphasis=emphasis
+underlined=underlined
+strikeout=strikeout
+header1=header1
+header2=header2
+header3=header3
+header4=header4
+header5=header5
+header6=header6
+ulist_item=ulist_item
+olist_item=olist_item
+blockquote=blockquote
+hrule=hrule
+link=link
+code=code
+codebk=codebk
+comment=comment_markup
+option=option
+preproc=preproc
+postproc=postproc
 
 
 [settings]


### PR DESCRIPTION
Hello,

I worked on the txt2tags syntax highlighter some time ago.
I noticed the color scheme I made (which is similar as the one made for vim, kate, scite) was replaced by this:

https://github.com/geany/geany/blob/7ebdacac2db5271f1f1bdfa3d8b0d41b33ee2a85/data/filetypes.txt2tags

With the advice to edit these in the colorscheme .conf file intead.

I tried to design such a colorscheme file and it worked, but it raises a problem: since it doesn't seem we can call multiple colorschemes togethers (like for css), it means all other colorschemes won't display the txt2tags syntax properly. The default scheme, in the filetype.txt2tags is very limited: strong, emphasis, underligned, headers all get the same "tag", while txt2tags is a lightweight markup language and therefore needs a strict differenciation between all the tags.

So if I publish the colorscheme as it is, it won't be very useful. I'd prefer to keep the colors in the filetypes.txt2tags and choose colors which will be mostly compatibles with light and dark themes.
