### PR TITLE
Bump GTK2 min. version to 2.24

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -167,16 +167,16 @@ unmanageable diffs.
 
 GTK versions & API documentation
 --------------------------------
-Geany requires GTK >= 2.16 and GLib >= 2.20. API symbols from newer
+Geany requires GTK >= 2.24 and GLib >= 2.28. API symbols from newer
 GTK/GLib versions should be avoided or made optional to keep the source
 code building on older systems.
 
-The official GTK 2.16 API documentation may not be available online
+The official GTK 2.24 API documentation may not be available online
 anymore, so we put it on http://www.geany.org/manual/gtk/. There
 is also a tarball with all available files for download and use with
 devhelp.
 
-Using the 2.16 API documentation of the GTK libs (including GLib, GDK
+Using the 2.24 API documentation of the GTK libs (including GLib, GDK
 and Pango) has the advantages that you don't get confused by any
 newer API additions and you don't have to take care about whether
 you can use them or not.
@@ -187,8 +187,8 @@ Coding
   them down into smaller static functions where possible. This makes code
   much easier to read and maintain.
 * Use GLib types and functions - gint not int, g_free() not free().
-* Your code should build against GLib 2.20 and GTK 2.16. At least for the
-  moment, we want to keep the minimum requirement for GTK at 2.16 (of
+* Your code should build against GLib 2.27.3 and GTK 2.24. At least for the
+  moment, we want to keep the minimum requirement for GTK at 2.24 (of
   course, you can use the GTK_CHECK_VERSION macro to protect code using
   later versions).
 * Variables should be declared before statements. You can use

--- a/README
+++ b/README
@@ -28,8 +28,8 @@ The basic features of Geany are:
 
 Requirements
 ------------
-For compiling Geany yourself, you will need the GTK (>= 2.16.0)
-libraries and header files. You will also need its dependency libraries
+For compiling Geany yourself, you will need the GTK2 (>= 2.24) or
+GTK3 libraries and header files. You will also need its dependency libraries
 and header files, such as Pango, Glib and ATK. All these files are
 available at http://www.gtk.org.
 

--- a/configure.ac
+++ b/configure.ac
@@ -70,12 +70,12 @@ AS_IF([test "x$enable_gtk3" = xyes],
 	  [gtk_package=gtk+-3.0
 	   gtk_min_version=3.0],
 	  [gtk_package=gtk+-2.0
-	   gtk_min_version=2.16])
+	   gtk_min_version=2.24])
 AM_CONDITIONAL([GTK3], [test "x$gtk_package" = "xgtk+-3.0"])
 
 # GTK/GLib/GIO checks
 gtk_modules="$gtk_package >= $gtk_min_version glib-2.0 >= 2.20"
-gtk_modules_private="gio-2.0 >= 2.20 gmodule-no-export-2.0"
+gtk_modules_private="gio-2.0 >= 2.28 gmodule-no-export-2.0"
 PKG_CHECK_MODULES([GTK], [$gtk_modules $gtk_modules_private])
 AC_SUBST([DEPENDENCIES], [$gtk_modules])
 AC_SUBST([GTK_CFLAGS])

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="2.16"/>
+  <requires lib="gtk+" version="2.24"/>
   <!-- interface-naming-policy project-wide -->
   <object class="GtkAccelGroup" id="accelgroup1"/>
   <object class="GtkAdjustment" id="adjustment1">

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -103,7 +103,7 @@ Installation
 Requirements
 ------------
 
-You will need the GTK (>= 2.16.0) libraries and their dependencies
+You will need the GTK (>= 2.24) libraries and their dependencies
 (Pango, GLib and ATK). Your distro should provide packages for these,
 usually installed by default. For Windows, you can download an installer
 from the website which bundles these libraries.
@@ -120,7 +120,7 @@ Source compilation
 ------------------
 
 Compiling Geany is quite easy.
-To do so, you need the GTK (>= 2.16.0) libraries and header files.
+To do so, you need the GTK (>= 2.24) libraries and header files.
 You also need the Pango, GLib and ATK libraries and header files.
 All these files are available at http://www.gtk.org, but very often
 your distro will provide development packages to save the trouble of

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -897,12 +897,8 @@ void dialogs_show_open_font(void)
 		gtk_window_set_type_hint(GTK_WINDOW(ui_widgets.open_fontsel), GDK_WINDOW_TYPE_HINT_DIALOG);
 		gtk_widget_set_name(ui_widgets.open_fontsel, "GeanyDialog");
 
-#if GTK_CHECK_VERSION(2, 20, 0)
-		/* apply button doesn't have a getter and is hidden by default, but we'd like to show it */
 		apply_button = gtk_dialog_get_widget_for_response(GTK_DIALOG(ui_widgets.open_fontsel), GTK_RESPONSE_APPLY);
-#else
-		apply_button = GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel)->apply_button;
-#endif
+
 		if (apply_button)
 			gtk_widget_show(apply_button);
 

--- a/src/gtkcompat.h
+++ b/src/gtkcompat.h
@@ -71,31 +71,6 @@ G_BEGIN_DECLS
 #endif
 
 /* GtkWidget */
-#if ! GTK_CHECK_VERSION(2, 18, 0)
-#  define compat_widget_set_flag(widget, flag, enable) \
-	do { \
-		GtkWidget *set_flag__widget = (widget); \
-		GtkWidgetFlags set_flag__flag = (flag); \
-		if (enable) \
-			GTK_WIDGET_SET_FLAGS(set_flag__widget, set_flag__flag); \
-		else \
-			GTK_WIDGET_UNSET_FLAGS(set_flag__widget, set_flag__flag); \
-	} while (0)
-#	define gtk_widget_set_can_default(widget, can_default) \
-		compat_widget_set_flag((widget), GTK_CAN_DEFAULT, (can_default))
-#	define gtk_widget_is_toplevel(widget)		GTK_WIDGET_TOPLEVEL(widget)
-#	define gtk_widget_is_sensitive(widget)		GTK_WIDGET_IS_SENSITIVE(widget)
-#	define gtk_widget_has_focus(widget)			GTK_WIDGET_HAS_FOCUS(widget)
-#	define gtk_widget_get_sensitive(widget)		GTK_WIDGET_SENSITIVE(widget)
-#	define gtk_widget_get_visible(widget)		GTK_WIDGET_VISIBLE(widget)
-#	define gtk_widget_set_has_window(widget, has_window) \
-		compat_widget_set_flag((widget), GTK_NO_WINDOW, !(has_window))
-#	define gtk_widget_set_can_focus(widget, can_focus) \
-		compat_widget_set_flag((widget), GTK_CAN_FOCUS, (can_focus))
-#endif
-#if ! GTK_CHECK_VERSION(2, 20, 0)
-#	define gtk_widget_get_mapped(widget)	GTK_WIDGET_MAPPED(widget)
-#endif
 #if ! GTK_CHECK_VERSION(3, 0, 0)
 #	define gtk_widget_get_allocated_height(widget)	(((GtkWidget *) (widget))->allocation.height)
 #	define gtk_widget_get_allocated_width(widget)	(((GtkWidget *) (widget))->allocation.width)

--- a/src/printing.c
+++ b/src/printing.c
@@ -523,9 +523,7 @@ static void printing_print_gtk(GeanyDocument *doc)
 
 	gtk_print_operation_set_unit(op, GTK_UNIT_POINTS);
 	gtk_print_operation_set_show_progress(op, TRUE);
-#if GTK_CHECK_VERSION(2, 18, 0)
 	gtk_print_operation_set_embed_page_setup(op, TRUE);
-#endif
 
 	g_signal_connect(op, "begin-print", G_CALLBACK(begin_print), &dinfo);
 	g_signal_connect(op, "end-print", G_CALLBACK(end_print), &dinfo);

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1495,29 +1495,6 @@ GtkWidget *ui_dialog_vbox_new(GtkDialog *dialog)
 }
 
 
-static GtkWidget *dialog_get_widget_for_response(GtkDialog *dialog, gint response_id)
-{
-#if GTK_CHECK_VERSION(2, 20, 0)
-	return gtk_dialog_get_widget_for_response(dialog, response_id);
-#else /* GTK < 2.20 */
-	/* base logic stolen from GTK */
-	GtkWidget *action_area = gtk_dialog_get_action_area(dialog);
-	GtkWidget *widget = NULL;
-	GList *children, *node;
-
-	children = gtk_container_get_children(GTK_CONTAINER(action_area));
-	for (node = children; node && ! widget; node = node->next)
-	{
-		if (gtk_dialog_get_response_for_widget(dialog, node->data) == response_id)
-			widget = node->data;
-	}
-	g_list_free(children);
-
-	return widget;
-#endif
-}
-
-
 /* Reorders a dialog's buttons
  * @param dialog A dialog
  * @param response First response ID to reorder
@@ -1541,7 +1518,7 @@ void ui_dialog_set_primary_button_order(GtkDialog *dialog, gint response, ...)
 	va_start(ap, response);
 	for (position = 0; response != -1; position++)
 	{
-		GtkWidget *child = dialog_get_widget_for_response(dialog, response);
+		GtkWidget *child = gtk_dialog_get_widget_for_response(dialog, response);
 		if (child)
 			gtk_box_reorder_child(GTK_BOX(action_area), child, position);
 		else

--- a/wscript
+++ b/wscript
@@ -54,9 +54,9 @@ from waflib.Tools.compiler_cxx import cxx_compiler
 APPNAME = 'geany'
 VERSION = '1.25'
 LINGUAS_FILE = os.path.join('po', 'LINGUAS')
-MINIMUM_GTK_VERSION = '2.16.0'
+MINIMUM_GTK_VERSION = '2.24.0'
 MINIMUM_GTK3_VERSION = '3.0.0'
-MINIMUM_GLIB_VERSION = '2.20.0'
+MINIMUM_GLIB_VERSION = '2.28.0'
 
 GEANY_LIB_VERSION = '0.0.0'
 


### PR DESCRIPTION
Bump the minimum GTK2 dependency version to 2.24, last supported GTK2 version.

TODO:
- [x] Do we want to use `2.24.0` or some later more stable version? (use: 2.24)
- [x] Should we use exact GLib version from the GTK+ `configure.in` version? (use next even version)
- [x] Test Waf build system.
- [x] Update or remove version checks from nightly build setup.
- [x] Create and test new GTK bundle for Win32 and fresh installers.
- [x] Do we need to care about Geany-Plugins stuff such as [this](https://github.com/geany/geany-plugins/blob/87f4b402965a079da1c1b2aac793c517a221518e/wscript#L84)?
- [ ] Remove or update [archived GTK+ reference manuals](http://www.geany.org/manual/gtk/), 2.24 documentation is [still available upstream](https://developer.gnome.org/gtk2/2.24/), so we probably don't need to host it ourselves yet, but we might want to remove the [reference in the HACKING file](https://github.com/codebrainz/geany/commit/11c67aa7a89572bbffbbb2db70a84ddef988a6ca#diff-884b897f0b13c2d7044127cda8920c82L162) if we don't update.