### PR TITLE
Use rst2pdf instead of rst2latex and pdflatex to generate PDF manual

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -69,27 +69,15 @@ clean-html-local:;
 endif
 
 # PDF user manual
-if WITH_LATEXPDF
+if WITH_RST2PDF
 
-# FIXME: - grep hack because pdflatex barfs all kinds of crazy info besides warnings/errors
-#        - images in output PDF file are way too big, need something equivalent to:
-#            \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{...}
-geany-$(VERSION).pdf: geany-$(VERSION).tex
-	$(AM_V_GEN)\
-	(absbuilddir="$$(pwd)/$(builddir)"; \
-	 cd "$(srcdir)" && \
-	 $(PDFLATEX) $(PDFLATEX_FLAGS) -interaction=nonstopmode -halt-on-error -file-line-error \
-	 	-output-directory="$$absbuilddir" "$$absbuilddir/geany-$(VERSION).tex" | \
-	 { r=$?; grep -iA1 "^!\|.*:[0-9]*:.*\|warning" >&2; exit $r; })
-
-geany-$(VERSION).tex: $(srcdir)/geany.txt
-	$(AM_V_GEN)$(RST2LATEX) -stg --documentoptions="10pt,a4paper" --output-encoding=utf8 $(srcdir)/geany.txt $@
+geany-$(VERSION).pdf: geany.txt
+	$(AM_V_GEN)$(RST2PDF) $(srcdir)/geany.txt -o $@
 
 all-pdf-local: geany-$(VERSION).pdf
 
 clean-pdf-local:
-	-rm -f geany-$(VERSION).tex geany-$(VERSION).aux geany-$(VERSION).log \
-		geany-$(VERSION).out geany-$(VERSION).toc geany-$(VERSION).pdf
+	-rm -f geany-$(VERSION).pdf
 
 else
 all-pdf-local:;

--- a/m4/geany-docutils.m4
+++ b/m4/geany-docutils.m4
@@ -40,23 +40,20 @@ AC_DEFUN([GEANY_CHECK_DOCUTILS_PDF],
 [
 	AC_ARG_ENABLE([pdf-docs],
 		[AS_HELP_STRING([--enable-pdf-docs],
-			[generate PDF documentation using rst2latex and pdflatex [default=no]])],
+			[generate PDF documentation using rst2pdf [default=no]])],
 		[geany_enable_pdf_docs="$enableval"],
 		[geany_enable_pdf_docs="no"])
-	AC_ARG_VAR([RST2LATEX], [Path to Docutils rst2latex executable])
-	AC_ARG_VAR([PDFLATEX], [Path to pdflatex executable])
+	AC_ARG_VAR([RST2PDF], [Path to Docutils rst2pdf executable])
 	AS_IF([test "x$geany_enable_pdf_docs" != "xno"],
 	[
-		AS_IF([test -z "$RST2LATEX"], [RST2LATEX="rst2latex"])
-		AC_PATH_PROG([RST2LATEX], [$RST2LATEX], [no])
-		AS_IF([test -z "$PDFLATEX"], [PDFLATEX="pdflatex"])
-		AC_PATH_PROG([PDFLATEX], [$PDFLATEX], [no])
-		AS_IF([test "x$RST2LATEX" != "xno" -a "x$PDFLATEX" != "xo"],
+		AS_IF([test -z "$RST2PDF"], [RST2PDF="rst2pdf"])
+		AC_PATH_PROG([RST2PDF], [$RST2PDF], [no])
+		AS_IF([test "x$RST2PDF" != "xno"],
 			[geany_enable_pdf_docs="yes"],
 			[test "x$geany_enable_pdf_docs" = "xyes"],
-			[AC_MSG_ERROR([PDF documentation enabled but rst2latex or pdflatex not found])],
+			[AC_MSG_ERROR([PDF documentation enabled but rst2pdf not found])],
 			[geany_enable_pdf_docs="no"])
 	])
-	AM_CONDITIONAL([WITH_LATEXPDF], [test "x$geany_enable_pdf_docs" != "xno"])
+	AM_CONDITIONAL([WITH_RST2PDF], [test "x$geany_enable_pdf_docs" != "xno"])
 	GEANY_STATUS_ADD([Build PDF documentation], [$geany_enable_pdf_docs])
 ])


### PR DESCRIPTION
This makes the generation code a lot simpler, and the generated PDF is arguably better (TOC on top, non-overflowing images, among other things).
