### PR TITLE
Fix Waf build for recent Doxyfile changes

### DIFF
--- a/wscript
+++ b/wscript
@@ -502,7 +502,9 @@ def build(bld):
             source          = 'doc/Doxyfile.in',
             target          = 'doc/Doxyfile',
             install_path    = None,
-            dct             = {'VERSION': VERSION})
+            dct             = {'VERSION': VERSION,
+                               'top_builddir': os.path.join(bld.path.abspath(), out),
+                               'top_srcdir': os.path.join(bld.path.abspath(), top)})
 
     ###
     # Install files


### PR DESCRIPTION
Recent changes to Doxyfile.in added new placeholders the build system has to replace, and Waf even recognized them and failed not knowing what to replace with.
