### PR TITLE
Cleanup Plugin Manager dialog

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1374,6 +1374,7 @@ static void pm_prepare_treeview(GtkWidget *tree, GtkListStore *store)
 
 	g_signal_connect(tree, "query-tooltip", G_CALLBACK(pm_treeview_query_tooltip), NULL);
 	gtk_widget_set_has_tooltip(tree, TRUE);
+	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(tree), FALSE);
 
 	checkbox_renderer = gtk_cell_renderer_toggle_new();
 	column = gtk_tree_view_column_new_with_attributes(


### PR DESCRIPTION
Merge "Name" and "Description" columns, and move plugin details to tooltips.

---

List:
![pm-dialog-1](https://cloud.githubusercontent.com/assets/793526/2841750/2666f90c-d06c-11e3-8bca-f5c98508a97f.png)
Tooltip:
![pm-dialog-2](https://cloud.githubusercontent.com/assets/793526/2841749/2662673e-d06c-11e3-954c-f926557c1393.png)
