### PR TITLE
Wrap search and find again by default

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -145,7 +145,7 @@ G_MODULE_EXPORT gboolean on_exit_clicked(GtkWidget *widget, gpointer gdata)
 	}
 	else
 	if (! prefs.confirm_exit ||
-		dialogs_show_question_full(NULL, GTK_STOCK_QUIT, GTK_STOCK_CANCEL, NULL,
+		dialogs_show_question_full(NULL, GTK_STOCK_QUIT, GTK_STOCK_CANCEL, FALSE, NULL,
 			_("Do you really want to quit?")))
 	{
 		quit_app();
@@ -430,7 +430,7 @@ G_MODULE_EXPORT void on_reload_as_activate(GtkMenuItem *menuitem, gpointer user_
 	base_name = g_path_get_basename(doc->file_name);
 	/* don't prompt if file hasn't been edited at all */
 	if ((!doc->changed && !document_can_undo(doc) && !document_can_redo(doc)) ||
-		dialogs_show_question_full(NULL, _("_Reload"), GTK_STOCK_CANCEL,
+		dialogs_show_question_full(NULL, _("_Reload"), GTK_STOCK_CANCEL, FALSE,
 		_("Any unsaved changes will be lost."),
 		_("Are you sure you want to reload '%s'?"), base_name))
 	{

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -60,7 +60,8 @@ void dialogs_show_file_properties(GeanyDocument *doc);
 gboolean dialogs_show_question(const gchar *text, ...) G_GNUC_PRINTF (1, 2);
 
 gboolean dialogs_show_question_full(GtkWidget *parent, const gchar *yes_btn, const gchar *no_btn,
-	const gchar *extra_text, const gchar *main_text, ...) G_GNUC_PRINTF (5, 6);
+	const gboolean is_yes_btn_default, const gchar *extra_text, const gchar *main_text, ...)
+	G_GNUC_PRINTF (6, 7);
 
 gint dialogs_show_prompt(GtkWidget *parent,
 		const gchar *btn_1, GtkResponseType response_1,

--- a/src/document.c
+++ b/src/document.c
@@ -1969,7 +1969,7 @@ gint document_find_text(GeanyDocument *doc, const gchar *text, const gchar *orig
 
 		/* we searched only part of the document, so ask whether to wraparound. */
 		if (search_prefs.always_wrap ||
-			dialogs_show_question_full(parent, GTK_STOCK_FIND, GTK_STOCK_CANCEL,
+			dialogs_show_question_full(parent, GTK_STOCK_FIND, GTK_STOCK_CANCEL, TRUE,
 				_("Wrap search and find again?"), _("\"%s\" was not found."), original_text))
 		{
 			gint ret;

--- a/src/main.c
+++ b/src/main.c
@@ -673,7 +673,7 @@ static gint create_config_dir(void)
 			if (g_file_test(old_dir, G_FILE_TEST_EXISTS))
 			{
 				if (! dialogs_show_question_full(main_widgets.window,
-					GTK_STOCK_YES, GTK_STOCK_QUIT, _("Move it now?"),
+					GTK_STOCK_YES, GTK_STOCK_QUIT, FALSE, _("Move it now?"),
 					"%s",
 					_("Geany needs to move your old configuration directory before starting.")))
 					exit(0);

--- a/src/project.c
+++ b/src/project.c
@@ -600,7 +600,7 @@ gboolean project_ask_close(void)
 {
 	if (app->project != NULL)
 	{
-		if (dialogs_show_question_full(NULL, GTK_STOCK_CLOSE, GTK_STOCK_CANCEL,
+		if (dialogs_show_question_full(NULL, GTK_STOCK_CLOSE, GTK_STOCK_CANCEL, FALSE,
 			_("Do you want to close it before proceeding?"),
 			_("The '%s' project is open."), app->project->name))
 		{
@@ -691,7 +691,7 @@ static gboolean update_config(const PropertyDialogElements *e, gboolean new_proj
 		{
 			gboolean create_dir;
 
-			create_dir = dialogs_show_question_full(NULL, GTK_STOCK_OK, GTK_STOCK_CANCEL,
+			create_dir = dialogs_show_question_full(NULL, GTK_STOCK_OK, GTK_STOCK_CANCEL, FALSE,
 				_("Create the project's base path directory?"),
 				_("The path \"%s\" does not exist."),
 				base_path);


### PR DESCRIPTION
When search function is launched and user is asked to wraparound,
the default button in question dialog is "cancel".
This change the behavior by selecting the "find" button by default.

Signed-off-by: Yannick GICQUEL ygicquel@gmail.com
