### PR TITLE
Support pseudo-unique IDs for documents

### DIFF
--- a/plugins/geanyfunctions.h
+++ b/plugins/geanyfunctions.h
@@ -80,6 +80,8 @@
 	geany_functions->p_document->document_compare_by_tab_order
 #define document_compare_by_tab_order_reverse \
 	geany_functions->p_document->document_compare_by_tab_order_reverse
+#define document_find_by_id \
+	geany_functions->p_document->document_find_by_id
 #define editor_get_indent_prefs \
 	geany_functions->p_editor->editor_get_indent_prefs
 #define editor_create_widget \

--- a/src/document.h
+++ b/src/document.h
@@ -118,6 +118,10 @@ typedef struct GeanyDocument
 	 * not be set elsewhere.
 	 * @see file_name. */
 	gchar 			*real_path;
+	/** A pseudo-unique ID for this document.
+	 * @c 0 is reserved as an unused value.
+	 * @see document_find_by_id(). */
+	guint			 id;
 
 	struct GeanyDocumentPrivate *priv;	/* should be last, append fields before this item */
 }
@@ -207,6 +211,8 @@ void document_rename_file(GeanyDocument *doc, const gchar *new_filename);
 GeanyDocument *document_index(gint idx);
 
 GeanyDocument *document_find_by_sci(ScintillaObject *sci);
+
+GeanyDocument *document_find_by_id(guint id);
 
 gint document_get_notebook_page(GeanyDocument *doc);
 

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -69,7 +69,7 @@ MessageWindow msgwindow;
 enum
 {
 	MSG_COL_LINE = 0,
-	MSG_COL_DOC,
+	MSG_COL_DOC_ID,
 	MSG_COL_COLOR,
 	MSG_COL_STRING,
 	MSG_COL_COUNT
@@ -186,8 +186,8 @@ static void prepare_msg_tree_view(void)
 	GtkTreeViewColumn *column;
 	GtkTreeSelection *selection;
 
-	/* line, doc, fg, str */
-	msgwindow.store_msg = gtk_list_store_new(MSG_COL_COUNT, G_TYPE_INT, G_TYPE_POINTER,
+	/* line, doc id, fg, str */
+	msgwindow.store_msg = gtk_list_store_new(MSG_COL_COUNT, G_TYPE_INT, G_TYPE_UINT,
 		GDK_TYPE_COLOR, G_TYPE_STRING);
 	gtk_tree_view_set_model(GTK_TREE_VIEW(msgwindow.tree_msg), GTK_TREE_MODEL(msgwindow.store_msg));
 	g_object_unref(msgwindow.store_msg);
@@ -392,7 +392,8 @@ void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const 
 
 	gtk_list_store_append(msgwindow.store_msg, &iter);
 	gtk_list_store_set(msgwindow.store_msg, &iter,
-		MSG_COL_LINE, line, MSG_COL_DOC, doc, MSG_COL_COLOR, color, MSG_COL_STRING, utf8_msg, -1);
+		MSG_COL_LINE, line, MSG_COL_DOC_ID, doc ? doc->id : 0, MSG_COL_COLOR,
+		color, MSG_COL_STRING, utf8_msg, -1);
 
 	g_free(tmp);
 	if (utf8_msg != tmp)
@@ -1079,18 +1080,28 @@ gboolean msgwin_goto_messages_file_line(gboolean focus_editor)
 	if (gtk_tree_selection_get_selected(selection, &model, &iter))
 	{
 		gint line;
+		guint id;
 		gchar *string;
 		GeanyDocument *doc;
 		GeanyDocument *old_doc = document_get_current();
 
 		gtk_tree_model_get(model, &iter,
-			MSG_COL_LINE, &line, MSG_COL_DOC, &doc, MSG_COL_STRING, &string, -1);
-		/* doc may have been closed, so check doc is valid: */
-		if (line >= 0 && DOC_VALID(doc))
+			MSG_COL_LINE, &line, MSG_COL_DOC_ID, &id, MSG_COL_STRING, &string, -1);
+		if (line >= 0 && id > 0)
 		{
-			ret = navqueue_goto_line(old_doc, doc, line);
-			if (ret && focus_editor)
-				gtk_widget_grab_focus(GTK_WIDGET(doc->editor->sci));
+			/* check doc is still open */
+			doc = document_find_by_id(id);
+			if (!doc)
+			{
+				ui_set_statusbar(FALSE, _("The document has been closed."));
+				utils_beep();
+			}
+			else
+			{
+				ret = navqueue_goto_line(old_doc, doc, line);
+				if (ret && focus_editor)
+					gtk_widget_grab_focus(GTK_WIDGET(doc->editor->sci));
+			}
 		}
 		else if (line < 0 && string != NULL)
 		{

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 218
+#define GEANY_API_VERSION 219
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */
@@ -324,6 +324,7 @@ typedef struct DocumentFuncs
 	gint		(*document_compare_by_display_name) (gconstpointer a, gconstpointer b);
 	gint		(*document_compare_by_tab_order) (gconstpointer a, gconstpointer b);
 	gint		(*document_compare_by_tab_order_reverse) (gconstpointer a, gconstpointer b);
+	GeanyDocument*	(*document_find_by_id)(guint id);
 }
 DocumentFuncs;
 

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -111,7 +111,8 @@ static DocumentFuncs doc_funcs = {
 	&document_get_notebook_page,
 	&document_compare_by_display_name,
 	&document_compare_by_tab_order,
-	&document_compare_by_tab_order_reverse
+	&document_compare_by_tab_order_reverse,
+	&document_find_by_id
 };
 
 static EditorFuncs editor_funcs = {


### PR DESCRIPTION
Add `GeanyDocument::id`, `document_find_by_id()` to plugin API.

This also fixes clicking on a _Messages_ item whose document has been
closed and reused. Now the click will be ignored instead of jumping to
an unexpected line in the new document.
- Some discussion on this here: https://github.com/geany/geany/pull/247#issuecomment-42037982
