### PR TITLE
Add SCSS filetype

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -59,6 +59,7 @@ filetypes = \
 	filetypes.ruby \
 	filetypes.rust \
 	filetypes.Scala.conf \
+	filetypes.SCSS.conf \
 	filetypes.sh \
 	filetypes.sql \
 	filetypes.tcl \

--- a/data/filetype_extensions.conf
+++ b/data/filetype_extensions.conf
@@ -56,6 +56,7 @@ R=*.R;*.r;
 Rust=*.rs;
 Ruby=*.rb;*.rhtml;*.ruby;*.gemspec;Gemfile;rakefile;Rakefile;
 Scala=*.scala;*.scl;
+SCSS=*.scss;
 Sh=*.sh;configure;configure.in;configure.in.in;configure.ac;*.ksh;*.mksh;*.zsh;*.ash;*.bash;*.m4;PKGBUILD;*profile;
 SQL=*.sql;
 Tcl=*.tcl;*.tk;*.wish;
@@ -71,6 +72,6 @@ None=*;
 [Groups]
 Programming=Clojure;CUDA;Cython;Genie;Go;Rust;Scala;
 Script=Graphviz;
-Markup=
+Markup=SCSS;
 Misc=
 None=

--- a/data/filetypes.SCSS.conf
+++ b/data/filetypes.SCSS.conf
@@ -8,3 +8,10 @@ lexer.css.scss.language=1
 lexer_filetype=CSS
 tag_parser=CSS
 extension=scss
+
+[build_settings]
+# %f will be replaced by the complete filename
+# %e will be replaced by the filename without extension
+# (use only one of it at one time)
+compiler=sass -c "%f"
+linker=sass --style expanded "%f" "%e.dev.css"

--- a/data/filetypes.SCSS.conf
+++ b/data/filetypes.SCSS.conf
@@ -1,0 +1,10 @@
+[styling=CSS]
+[keywords=CSS]
+
+[lexer_properties=CSS]
+lexer.css.scss.language=1
+
+[settings=CSS]
+lexer_filetype=CSS
+tag_parser=CSS
+extension=scss

--- a/data/filetypes.SCSS.conf
+++ b/data/filetypes.SCSS.conf
@@ -9,6 +9,9 @@ lexer_filetype=CSS
 tag_parser=CSS
 extension=scss
 
+# SCSS has single-line comments in addition to CSS multi-line ones
+comment_single=//
+
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension

--- a/tagmanager/ctags/css.c
+++ b/tagmanager/ctags/css.c
@@ -146,6 +146,11 @@ static CssParserState parseCssLine( const unsigned char *line, CssParserState st
 				}
 				else if( *line == '*' && *(line-1) == '/' ) /* multi-line comment */
 					state = P_STATE_IN_COMMENT;
+				else if( *line == '/' && *(line-1) == '/' ) /* single-line comment (SCSS, Less, etc.) */
+				{
+					while( *line != '\0' )
+						++line;
+				}
 				else if ( stack->length > 0 )
 					state = parseCssDeclaration( &line, K_SELECTOR, vStringValue(stack) );
 


### PR DESCRIPTION
Simpler and cleaner version of #20 using a custom filetype for SCSS, since it actually uses the CSS lexer with a property set.

As in #20, parser isn't great for SCSS, but unlike it single comments work for real.
