### PR TITLE
Re-order win32.[ch] includes a little bit to unbreak build

### DIFF
--- a/src/win32.c
+++ b/src/win32.c
@@ -23,6 +23,7 @@
  * Special functions for the win32 platform, to provide native dialogs.
  */
 
+#include "win32.h"
 
 #ifdef G_OS_WIN32
 
@@ -44,8 +45,6 @@
 
 #include <glib/gstdio.h>
 #include <gdk/gdkwin32.h>
-
-#include "win32.h"
 
 #include "document.h"
 #include "support.h"

--- a/src/win32.h
+++ b/src/win32.h
@@ -22,9 +22,12 @@
 #ifndef GEANY_WIN32_H
 #define GEANY_WIN32_H 1
 
-#ifdef G_OS_WIN32
+#include "document.h"
 
 #include "gtkcompat.h"
+
+
+#ifdef G_OS_WIN32
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
Re-order includes to make `G_OS_WIN32` available and add `document.h` (instead of simply using forward declaration which wouldn't glue these two headers together) to make sure GeanyDocument is available.

@eht16, I haven't a chance to test on Win32 but according to your comments this should fix it. If you or anyone gets motivated, you could fix win32.c includes section to follow the new conventions added to HACKING file, otherwise just leave and next time I re-setup a Win32 VM for building, I'll do it.
