### PR TITLE
Bump GTK+ version to only 2.18 for now

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -155,16 +155,16 @@ Callbacks for the user-interface should go in ``src/callbacks.c``.
 
 GTK versions & API documentation
 --------------------------------
-Geany requires GTK >= 2.16 and GLib >= 2.20. API symbols from newer
+Geany requires GTK >= 2.18 and GLib >= 2.20. API symbols from newer
 GTK/GLib versions should be avoided or made optional to keep the source
 code building on older systems.
 
-The official GTK 2.16 API documentation may not be available online
+The official GTK 2.18 API documentation may not be available online
 anymore, so we put it on http://www.geany.org/manual/gtk/. There
 is also a tarball with all available files for download and use with
 devhelp.
 
-Using the 2.16 API documentation of the GTK libs (including GLib, GDK
+Using the 2.18 API documentation of the GTK libs (including GLib, GDK
 and Pango) has the advantages that you don't get confused by any
 newer API additions and you don't have to take care about whether
 you can use them or not.
@@ -175,8 +175,8 @@ Coding
   them down into smaller static functions where possible. This makes code
   much easier to read and maintain.
 * Use GLib types and functions - gint not int, g_free() not free().
-* Your code should build against GLib 2.20 and GTK 2.16. At least for the
-  moment, we want to keep the minimum requirement for GTK at 2.16 (of
+* Your code should build against GLib 2.20 and GTK 2.18. At least for the
+  moment, we want to keep the minimum requirement for GTK at 2.18 (of
   course, you can use the GTK_CHECK_VERSION macro to protect code using
   later versions).
 * Variables should be declared before statements. You can use

--- a/README
+++ b/README
@@ -28,7 +28,7 @@ The basic features of Geany are:
 
 Requirements
 ------------
-For compiling Geany yourself, you will need the GTK (>= 2.16.0)
+For compiling Geany yourself, you will need the GTK (>= 2.18.0)
 libraries and header files. You will also need its dependency libraries
 and header files, such as Pango, Glib and ATK. All these files are
 available at http://www.gtk.org.

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AS_IF([test "x$enable_gtk3" = xyes],
 	  [gtk_package=gtk+-3.0
 	   gtk_min_version=3.0],
 	  [gtk_package=gtk+-2.0
-	   gtk_min_version=2.16])
+	   gtk_min_version=2.18])
 AM_CONDITIONAL([GTK3], [test "x$gtk_package" = "xgtk+-3.0"])
 
 # GTK/GLib/GIO checks

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="2.16"/>
+  <requires lib="gtk+" version="2.18"/>
   <!-- interface-naming-policy project-wide -->
   <object class="GtkAccelGroup" id="accelgroup1"/>
   <object class="GtkAdjustment" id="adjustment1">

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -103,7 +103,7 @@ Installation
 Requirements
 ------------
 
-You will need the GTK (>= 2.16.0) libraries and their dependencies
+You will need the GTK (>= 2.18.0) libraries and their dependencies
 (Pango, GLib and ATK). Your distro should provide packages for these,
 usually installed by default. For Windows, you can download an installer
 from the website which bundles these libraries.
@@ -120,7 +120,7 @@ Source compilation
 ------------------
 
 Compiling Geany is quite easy.
-To do so, you need the GTK (>= 2.16.0) libraries and header files.
+To do so, you need the GTK (>= 2.18.0) libraries and header files.
 You also need the Pango, GLib and ATK libraries and header files.
 All these files are available at http://www.gtk.org, but very often
 your distro will provide development packages to save the trouble of

--- a/geany.nsi
+++ b/geany.nsi
@@ -204,7 +204,7 @@ SectionEnd
 
 ; Include GTK runtime library but only if desired from command line
 !ifdef INCLUDE_GTK
-Section "GTK 2.16 Runtime Environment" SEC06
+Section "GTK 2.18 Runtime Environment" SEC06
 	SectionIn 1
 	SetOverwrite ifnewer
 	SetOutPath "$INSTDIR\bin"
@@ -323,7 +323,7 @@ SectionEnd
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC04} "Manual in Text and HTML format."
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC05} "Symbol lists necessary for auto completion of symbols."
 !ifdef INCLUDE_GTK
-!insertmacro MUI_DESCRIPTION_TEXT ${SEC06} "You need these files to run Geany. If you have already installed a GTK Runtime Environment (2.16 or higher), you can skip it."
+!insertmacro MUI_DESCRIPTION_TEXT ${SEC06} "You need these files to run Geany. If you have already installed a GTK Runtime Environment (2.18 or higher), you can skip it."
 !endif
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC07} "Add context menu item 'Open With Geany'"
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC08} "Create shortcuts for Geany on the desktop and in the Quicklaunch Bar"

--- a/wscript
+++ b/wscript
@@ -53,7 +53,7 @@ from waflib.Tools.compiler_cxx import cxx_compiler
 APPNAME = 'geany'
 VERSION = '1.25'
 LINGUAS_FILE = os.path.join('po', 'LINGUAS')
-MINIMUM_GTK_VERSION = '2.16.0'
+MINIMUM_GTK_VERSION = '2.18.0'
 MINIMUM_GTK3_VERSION = '3.0.0'
 MINIMUM_GLIB_VERSION = '2.20.0'
 


### PR DESCRIPTION
We might to push it farther in this release cycle, but we only need
2.18 for the GtkInfoBar/document-messages stuff in 8ea54993c5d599f82b6060550f304e06302b46d6.

@eht16 and others, is there other places to update? I suppose the Win32 build needs to be pushed past or to 2.18, etc.

I just did a search replace mostly from 2.16 to 2.18, we should review it closer.
