### PR TITLE
Add %l current line number substitution to build commands

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3127,6 +3127,7 @@ before the command is run.
 * %e - substituted by the name of the current file without the extension or path.
 * %f - substituted by the name of the current file without the path.
 * %p - if a project is open, substituted by the base path from the project.
+* %l - substituted by the line number at the current cursor position.
 
 .. note::
    If the basepath set in the project preferences is not an absolute path , then it is


### PR DESCRIPTION
While trying to set up [SyncTex](http://mactex-wiki.tug.org/wiki/index.php/SyncTeX) to work with Geany and [qpdfview](https://launchpad.net/qpdfview), I realized that Geany's build commands only provide file name and path variables, and not a line variable. So, I added a `%l` current line build variable, which can be passed to any build command. Works great with qpdfview using this build command:

`pdflatex -synctex=1 --file-line-error "foo.tex" && qpdfview --unique foo.pdf#src:%f:%l:0`

foo.tex is the main .tex file, but the command can be run from any .tex file (%f) in the document hierarchy.

I did this almost completely by copying existing code and trying to stick to convention. I don't know anything about glib. For instance, I'm not sure if `g_strdup_printf` is the right way to convert the line number integer into a string. Online documentation should be updated as well to reflect the new `%l` build variable.

This branch is against the Geany 1.24.1 git tag.

This enables forward links (foo.tex-->foo.pdf). FYI, for backward links from qpdfview to Geany, I'm using this command in qpdfview in its "source editor line" setting: `geany %1:%2:%3`. That lets me double click a line in qpdfview to make geany open the corresponding spot in the source .tex file. This is documented in more detail [here](https://answers.launchpad.net/qpdfview/+question/250122).