### PR TITLE
callbacks: Refactor on_reload_as_activate() as document_reload_prompt()

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -395,45 +395,11 @@ G_MODULE_EXPORT void on_toolbutton_quit_clicked(GtkAction *action, gpointer user
 /* reload file */
 G_MODULE_EXPORT void on_toolbutton_reload_clicked(GtkAction *action, gpointer user_data)
 {
-	on_reload_as_activate(NULL, GINT_TO_POINTER(-1));
-}
-
-
-/* also used for reloading when user_data is -1 */
-G_MODULE_EXPORT void on_reload_as_activate(GtkMenuItem *menuitem, gpointer user_data)
-{
 	GeanyDocument *doc = document_get_current();
-	gchar *base_name;
-	gint i = GPOINTER_TO_INT(user_data);
-	const gchar *charset = NULL;
 
 	g_return_if_fail(doc != NULL);
 
-	/* No need to reload "untitled" (non-file-backed) documents */
-	if (doc->file_name == NULL)
-		return;
-
-	if (i >= 0)
-	{
-		if (i >= GEANY_ENCODINGS_MAX || encodings[i].charset == NULL)
-			return;
-		charset = encodings[i].charset;
-	}
-	else
-		charset = doc->encoding;
-
-	base_name = g_path_get_basename(doc->file_name);
-	/* don't prompt if file hasn't been edited at all */
-	if ((!doc->changed && !document_can_undo(doc) && !document_can_redo(doc)) ||
-		dialogs_show_question_full(NULL, _("_Reload"), GTK_STOCK_CANCEL,
-		_("Any unsaved changes will be lost."),
-		_("Are you sure you want to reload '%s'?"), base_name))
-	{
-		document_reload_file(doc, charset);
-		if (charset != NULL)
-			ui_update_statusbar(doc, -1);
-	}
-	g_free(base_name);
+	document_reload_prompt(doc, NULL);
 }
 
 

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -385,10 +385,6 @@ on_menu_remove_indicators1_activate	(GtkMenuItem	 *menuitem,
 										gpointer		 user_data);
 
 G_MODULE_EXPORT void
-on_reload_as_activate				  (GtkMenuItem	 *menuitem,
-										gpointer		 user_data);
-
-G_MODULE_EXPORT void
 on_print1_activate					 (GtkMenuItem	 *menuitem,
 										gpointer		 user_data);
 

--- a/src/document.h
+++ b/src/document.h
@@ -194,6 +194,8 @@ GeanyDocument* document_open_file(const gchar *locale_filename, gboolean readonl
 
 gboolean document_reload_file(GeanyDocument *doc, const gchar *forced_enc);
 
+gboolean document_reload_prompt(GeanyDocument *doc, const gchar *forced_enc);
+
 void document_set_text_changed(GeanyDocument *doc, gboolean changed);
 
 void document_set_filetype(GeanyDocument *doc, GeanyFiletype *type);

--- a/src/encodings.c
+++ b/src/encodings.c
@@ -360,11 +360,11 @@ static gchar *regex_match(GRegex *preg, const gchar *buffer, gsize size)
 static void encodings_radio_item_change_cb(GtkCheckMenuItem *menuitem, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();
-	guint i = GPOINTER_TO_INT(user_data);
+	const gchar *charset = user_data;
 
-	if (ignore_callback || doc == NULL || encodings[i].charset == NULL ||
+	if (ignore_callback || doc == NULL || charset == NULL ||
 		! gtk_check_menu_item_get_active(menuitem) ||
-		utils_str_equal(encodings[i].charset, doc->encoding))
+		utils_str_equal(charset, doc->encoding))
 		return;
 
 	if (doc->readonly)
@@ -374,7 +374,16 @@ static void encodings_radio_item_change_cb(GtkCheckMenuItem *menuitem, gpointer 
 	}
 	document_undo_add(doc, UNDO_ENCODING, g_strdup(doc->encoding));
 
-	document_set_encoding(doc, encodings[i].charset);
+	document_set_encoding(doc, charset);
+}
+
+static void encodings_reload_radio_item_change_cb(GtkMenuItem *menuitem, gpointer user_data)
+{
+	GeanyDocument *doc = document_get_current();
+
+	g_return_if_fail(doc != NULL);
+
+	document_reload_prompt(doc, user_data);
 }
 
 
@@ -416,7 +425,7 @@ void encodings_init(void)
 	menu[0] = ui_lookup_widget(main_widgets.window, "set_encoding1_menu");
 	menu[1] = ui_lookup_widget(main_widgets.window, "menu_reload_as1_menu");
 	cb_func[0] = G_CALLBACK(encodings_radio_item_change_cb);
-	cb_func[1] = G_CALLBACK(on_reload_as_activate);
+	cb_func[1] = G_CALLBACK(encodings_reload_radio_item_change_cb);
 
 	for (k = 0; k < 2; k++)
 	{
@@ -488,8 +497,8 @@ void encodings_init(void)
 							item = gtk_menu_item_new_with_label(label);
 						gtk_widget_show(item);
 						gtk_container_add(GTK_CONTAINER(submenu), item);
-						g_signal_connect(item, "activate",
-										cb_func[k], GINT_TO_POINTER(encodings[j].idx));
+						g_signal_connect(item, "activate", cb_func[k],
+								(gpointer) encodings[j].charset);
 						g_free(label);
 						break;
 					}

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -819,7 +819,7 @@ static void document_action(GeanyDocument *doc, gint action)
 		}
 		case OPENFILES_ACTION_RELOAD:
 		{
-			on_toolbutton_reload_clicked(NULL, NULL);
+			document_reload_prompt(doc, NULL);
 			break;
 		}
 	}


### PR DESCRIPTION
The callback wasn't used from glade but is useful for some other places so
it's worth moving into document.c. This also fixes a bug where reload via sidebar
always reloads the current document instead of the actually clicked one.
