### PR TITLE
main: Refactor quit functions

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -157,61 +157,11 @@ G_MODULE_EXPORT void on_clone1_activate(GtkMenuItem *menuitem, gpointer user_dat
 /*static gboolean switch_tv_notebook_page = FALSE; */
 
 
-static gboolean check_no_unsaved(void)
-{
-	guint i;
-
-	for (i = 0; i < documents_array->len; i++)
-	{
-		if (documents[i]->is_valid && documents[i]->changed)
-		{
-			return FALSE;
-		}
-	}
-	return TRUE;	/* no unsaved edits */
-}
-
-
-/* should only be called from on_window_delete_event */
-static void quit_app(void)
-{
-	configuration_save();
-
-	if (app->project != NULL)
-		project_close(FALSE);	/* save project session files */
-
-	document_close_all();
-
-	main_status.quitting = TRUE;
-
-	main_quit();
-}
-
 
 /* wrapper function to abort exit process if cancel button is pressed */
 G_MODULE_EXPORT gboolean on_window_delete_event(GtkWidget *widget, GdkEvent *event, gpointer gdata)
 {
-	main_status.quitting = TRUE;
-
-	if (! check_no_unsaved())
-	{
-		if (document_account_for_unsaved())
-		{
-			quit_app();
-			return FALSE;
-		}
-	}
-	else
-	if (! prefs.confirm_exit ||
-		dialogs_show_question_full(NULL, GTK_STOCK_QUIT, GTK_STOCK_CANCEL, NULL,
-			_("Do you really want to quit?")))
-	{
-		quit_app();
-		return FALSE;
-	}
-
-	main_status.quitting = FALSE;
-	return TRUE;
+	return !main_quit();
 }
 
 
@@ -296,7 +246,7 @@ G_MODULE_EXPORT void on_close1_activate(GtkMenuItem *menuitem, gpointer user_dat
 
 G_MODULE_EXPORT void on_quit1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	on_window_delete_event(NULL, NULL, NULL);
+	main_quit();
 }
 
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -39,6 +39,7 @@
 #include "documentprivate.h"
 #include "filetypes.h"
 #include "keybindingsprivate.h"
+#include "main.h"
 #include "msgwindow.h"
 #include "navqueue.h"
 #include "notebook.h"
@@ -1364,7 +1365,7 @@ static gboolean cb_func_file_action(guint key_id)
 			on_print1_activate(NULL, NULL);
 			break;
 		case GEANY_KEYS_FILE_QUIT:
-			on_quit1_activate(NULL, NULL);
+			main_quit();
 			break;
 	}
 	return TRUE;

--- a/src/main.c
+++ b/src/main.c
@@ -788,13 +788,13 @@ static gint setup_config_dir(void)
 	return mkdir_result;
 }
 
-/* Signal handling removed since on_quit1_activate() uses functions that are
+/* Signal handling removed since main_quit() uses functions that are
  * illegal in signal handlers
 static void signal_cb(gint sig)
 {
 	if (sig == SIGTERM)
 	{
-		on_quit1_activate(NULL, NULL);
+		main_quit();
 	}
 }
  */
@@ -1247,9 +1247,18 @@ static void queue_free(GQueue *queue)
 }
 
 
-void main_quit(void)
+static void do_main_quit(void)
 {
 	geany_debug("Quitting...");
+
+	configuration_save();
+
+	if (app->project != NULL)
+		project_close(FALSE);   /* save project session files */
+
+	document_close_all();
+
+	main_status.quitting = TRUE;
 
 #ifdef HAVE_SOCKET
 	socket_finalize();
@@ -1342,6 +1351,47 @@ void main_quit(void)
 	gtk_main_quit();
 }
 
+
+static gboolean check_no_unsaved(void)
+{
+	guint i;
+
+	for (i = 0; i < documents_array->len; i++)
+	{
+		if (documents[i]->is_valid && documents[i]->changed)
+		{
+			return FALSE;
+		}
+	}
+	return TRUE;    /* no unsaved edits */
+}
+
+
+/* Returns false when quitting is aborted due to user cancellation */
+gboolean main_quit(void)
+{
+	main_status.quitting = TRUE;
+
+	if (! check_no_unsaved())
+	{
+		if (document_account_for_unsaved())
+		{
+			do_main_quit();
+			return TRUE;
+		}
+	}
+	else
+	if (! prefs.confirm_exit ||
+		dialogs_show_question_full(NULL, GTK_STOCK_QUIT, GTK_STOCK_CANCEL, NULL,
+			_("Do you really want to quit?")))
+	{
+		do_main_quit();
+		return TRUE;
+	}
+
+	main_status.quitting = FALSE;
+	return FALSE;
+}
 
 /**
  *  Reloads most of Geany's configuration files without restarting. Currently the following

--- a/src/main.h
+++ b/src/main.h
@@ -60,7 +60,7 @@ const gchar *main_get_version_string(void);
 
 gchar *main_get_argv_filename(const gchar *filename);
 
-void main_quit(void);
+gboolean main_quit(void);
 
 gboolean main_handle_filename(const gchar *locale_filename);
 


### PR DESCRIPTION
Move quit-related functions to main.c and make them static. main_quit() now
does all the heavy work and can be called from signal handlers.
