### PR TITLE
Addition of Templates

### DIFF
--- a/data/templates/README
+++ b/data/templates/README
@@ -1,0 +1,2 @@
+Not all of these license-header templates are used by Geany. Geany has a hard-coded list of the headers.
+The ones not in the list are still included in this directory to be added later by another developer.

--- a/data/templates/agpl
+++ b/data/templates/agpl
@@ -1,0 +1,14 @@
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.

--- a/data/templates/agpl3
+++ b/data/templates/agpl3
@@ -1,0 +1,12 @@
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/data/templates/asf-2
+++ b/data/templates/asf-2
@@ -1,0 +1,16 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.

--- a/data/templates/cc0
+++ b/data/templates/cc0
@@ -1,0 +1,2 @@
+Any copyright is dedicated to the Public Domain.
+http://creativecommons.org/publicdomain/zero/1.0/

--- a/data/templates/files/main-py3.py
+++ b/data/templates/files/main-py3.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fileencoding=utf-8
+
+def main():
+    """DOCSTRING"""
+    return 0
+
+if __name__ == "__main__":
+    main()

--- a/data/templates/files/main2.pyx
+++ b/data/templates/files/main2.pyx
@@ -1,0 +1,18 @@
+#!python2
+#cython: language_level=2, boundscheck=False
+#cython: c_string_encoding=utf-8, c_string_type=unicode
+# -*- coding: utf-8 -*-
+# vim:fileencoding=utf-8
+import pyximport
+pyximport.install()
+
+def int main():
+    """DOCSTRING"""
+    return 0
+
+cdef int FUNCTION():
+    """DOCSTRING"""
+    return 0
+
+if __name__ == "__main__":
+    main()

--- a/data/templates/files/main3.pyx
+++ b/data/templates/files/main3.pyx
@@ -1,0 +1,18 @@
+#!python3
+#cython: language_level=3, boundscheck=False
+#cython: c_string_encoding=utf-8, c_string_type=unicode
+# -*- coding: utf-8 -*-
+# vim:fileencoding=utf-8
+import pyximport
+pyximport.install()
+
+def int main():
+    """DOCSTRING"""
+    return 0
+
+cdef int FUNCTION():
+    """DOCSTRING"""
+    return 0
+
+if __name__ == "__main__":
+    main()

--- a/data/templates/files/script.js
+++ b/data/templates/files/script.js
@@ -1,0 +1,9 @@
+/*
+ * Author: NAME
+ * Version: 0.01
+ * Description:
+*/
+
+function NAME() {
+alert("Hello World")
+}

--- a/data/templates/files/script.sh
+++ b/data/templates/files/script.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# -*- coding: utf-8 -*-
+# vim:fileencoding=utf-8

--- a/data/templates/gpl3
+++ b/data/templates/gpl3
@@ -1,0 +1,12 @@
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/data/templates/lgpl
+++ b/data/templates/lgpl
@@ -1,0 +1,14 @@
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.

--- a/data/templates/lgpl3
+++ b/data/templates/lgpl3
@@ -1,0 +1,12 @@
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/data/templates/mpl2
+++ b/data/templates/mpl2
@@ -1,0 +1,3 @@
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
This pull request includes more file templates and license-headers.

I understand Geany uses a hard-coded list of the license-headers, so simply adding headers with the rest of the licenses will not instantly work. However, I hope that if I add some license-headers that another developer will add them. We should be aware that not all developers use GPLv2 or BSD. In my personal opinion, the Geany project should include other license headers and should continue to increase its list.

Devyn Collier Johnson
DevynCJohnson@Gmail.com