### PR TITLE
'View->Change Font' should respect native dialog setting (Windows)

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -814,7 +814,6 @@ gboolean dialogs_show_unsaved_file(GeanyDocument *doc)
 }
 
 
-#ifndef G_OS_WIN32
 /* Use GtkFontChooserDialog on GTK3.2 for consistency, and because
  * GtkFontSelectionDialog is somewhat broken on 3.4 */
 #if GTK_CHECK_VERSION(3, 2, 0)
@@ -854,15 +853,18 @@ on_font_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 	if (close)
 		gtk_widget_hide(ui_widgets.open_fontsel);
 }
-#endif
 
 
 /* This shows the font selection dialog to choose a font. */
 void dialogs_show_open_font(void)
 {
 #ifdef G_OS_WIN32
-	win32_show_font_dialog();
-#else
+	if (interface_prefs.use_native_windows_dialogs)
+	{
+		win32_show_font_dialog();
+		return;
+	}
+#endif
 
 	if (ui_widgets.open_fontsel == NULL)
 	{
@@ -896,7 +898,6 @@ void dialogs_show_open_font(void)
 		GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel), interface_prefs.editor_font);
 	/* We make sure the dialog is visible. */
 	gtk_window_present(GTK_WINDOW(ui_widgets.open_fontsel));
-#endif
 }
 
 


### PR DESCRIPTION
https://sourceforge.net/p/geany/bugs/1059/

Show GTK dialog when appropriate. Previously it always showed the Windows font dialog.
