### PR TITLE
Added Protocol Buffers (protobuf) filetypes

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -53,6 +53,7 @@ filetypes = \
 	filetypes.php \
 	filetypes.po \
 	filetypes.powershell \
+	filetypes.protobuf \
 	filetypes.python \
 	filetypes.r \
 	filetypes.restructuredtext \

--- a/data/filetype_extensions.conf
+++ b/data/filetype_extensions.conf
@@ -49,6 +49,7 @@ Pascal=*.pas;*.pp;*.inc;*.dpr;*.dpk;
 Perl=*.pl;*.perl;*.pm;*.agi;*.pod;
 PHP=*.php;*.php3;*.php4;*.php5;*.phtml;
 Po=*.po;*.pot;
+Protobuf=*.proto;
 Python=*.py;*.pyw;SConstruct;SConscript;wscript;
 PowerShell=*.ps1;*.psm1;
 reStructuredText=*.rest;*.reST;*.rst;

--- a/data/filetypes.protobuf
+++ b/data/filetypes.protobuf
@@ -1,0 +1,50 @@
+# For complete documentation of this file, please see Geany's main documentation
+[styling]
+# Edit these in the colorscheme .conf file intead
+default=default
+commentline=comment
+number=number_1
+word=keyword_1
+word2=keyword_2
+string=string_1
+uuid=other
+operator=operator
+identifier=identifier_1
+stringeol=string_eol
+globalclass=class
+
+[keywords]
+# all items must be in one line
+primary=enum extend extensions false import max message option optional package repeated required returns rpc service true
+secondary=bool bytes double fixed32 fixed64 float int32 int64 sfixed32 sfixed64 sint32 sint64 string uint32 uint64
+
+[settings]
+# default extension used when saving files
+extension=proto
+
+# the following characters are these which a "word" can contains, see documentation
+#wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
+
+# if only single comment char is supported like # in this file, leave comment_close blank
+comment_open=//
+comment_close=
+# this is an alternative way, so multiline comments are used
+#comment_open=/*
+#comment_close=*/
+
+# set to false if a comment character/string should start at column 0 of a line, true uses any
+# indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
+	#command_example();
+# setting to false would generate this
+#	command_example();
+# This setting works only for single line comments
+comment_use_indent=true
+
+# context action command (please see Geany's main documentation for details)
+context_action_cmd=
+
+[build_settings]
+# %f will be replaced by the complete filename
+# %e will be replaced by the filename without extension
+# (use only one of it at one time)
+compiler=protoc --cpp_out=. --java_out=. --python_out=. "%f"

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -190,6 +190,7 @@ static void init_builtin_filetypes(void)
 	FT_INIT( BATCH,      NONE,         "Batch",            NULL,                      SCRIPT,      SCRIPT   );
 	FT_INIT( POWERSHELL, NONE,         "PowerShell",       NULL,                      SOURCE_FILE, SCRIPT   );
 	FT_INIT( RUST,       RUST,         "Rust",             NULL,                      SOURCE_FILE, COMPILED );
+	FT_INIT( PROTOBUF,   NONE,         "Protobuf",         NULL,                      SOURCE_FILE, COMPILED );
 }
 
 

--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -100,6 +100,7 @@ typedef enum
 	GEANY_FILETYPES_BATCH,
 	GEANY_FILETYPES_POWERSHELL,
 	GEANY_FILETYPES_RUST,
+	GEANY_FILETYPES_PROTOBUF,
 	/* ^ append items here */
 	GEANY_MAX_BUILT_IN_FILETYPES	/* Don't use this, use filetypes_array->len instead */
 }

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -1047,6 +1047,7 @@ void highlighting_init_styles(guint filetype_idx, GKeyFile *config, GKeyFile *co
 		init_styleset_case(PHP);
 		init_styleset_case(PO);
 		init_styleset_case(POWERSHELL);
+		init_styleset_case(PROTOBUF);
 		init_styleset_case(PYTHON);
 		init_styleset_case(R);
 		init_styleset_case(RUBY);
@@ -1130,6 +1131,7 @@ void highlighting_set_styles(ScintillaObject *sci, GeanyFiletype *ft)
 		styleset_case(PHP);
 		styleset_case(PO);
 		styleset_case(POWERSHELL);
+		styleset_case(PROTOBUF);
 		styleset_case(PYTHON);
 		styleset_case(R);
 		styleset_case(RUBY);

--- a/src/highlightingmappings.h
+++ b/src/highlightingmappings.h
@@ -1202,6 +1202,17 @@ static const HLKeyword highlighting_keywords_POWERSHELL[] =
 #define highlighting_properties_POWERSHELL	EMPTY_PROPERTIES
 
 
+/* Protobuf */
+#define highlighting_lexer_PROTOBUF			SCLEX_CPP
+#define highlighting_styles_PROTOBUF		highlighting_styles_C
+static const HLKeyword highlighting_keywords_PROTOBUF[] =
+{
+	{ 0, "primary",		FALSE },
+	{ 1, "secondary",	FALSE }
+};
+#define highlighting_properties_PROTOBUF	EMPTY_PROPERTIES
+
+
 /* Python */
 #define highlighting_lexer_PYTHON		SCLEX_PYTHON
 static const HLStyle highlighting_styles_PYTHON[] =


### PR DESCRIPTION
Google's Protocol Buffers, also known as protobuf, is a tool for aiding
in the process of serializing structured data. Protobuf has employed its
own little language which allows it to be compiled down into almost any
language. With the protobuf language getting advanced at times, it makes
having file handling and syntax highlighting in editor very valuable.

This implements the built-in protobuf filetypes and highlight mappings.
