### PR TITLE
Enable API documentation generation automatically when possible

### DIFF
--- a/m4/geany-doxygen.m4
+++ b/m4/geany-doxygen.m4
@@ -7,7 +7,7 @@ AC_DEFUN([GEANY_CHECK_DOXYGEN],
 			[AS_HELP_STRING([--enable-api-docs],
 					[generate API documentation using Doxygen [default=no]])],
 			[geany_with_doxygen="$enableval"],
-			[geany_with_doxygen="no"])
+			[geany_with_doxygen="auto"])
 
 	AC_ARG_VAR([DOXYGEN], [Path to Doxygen executable])
 


### PR DESCRIPTION
I can't think of any reason why not to enable it automatically when Doxygen is found, but here's a PR in case I missed an obvious reason.

Will merge in a few days if there's no objection.
