### PR TITLE
Confirm infobar reload when document has modifications

### DIFF
--- a/plugins/geanyfunctions.h
+++ b/plugins/geanyfunctions.h
@@ -52,8 +52,8 @@
 	geany_functions->p_document->document_open_files
 #define document_remove_page \
 	geany_functions->p_document->document_remove_page
-#define document_reload_file \
-	geany_functions->p_document->document_reload_file
+#define document_reload_force \
+	geany_functions->p_document->document_reload_force
 #define document_set_encoding \
 	geany_functions->p_document->document_set_encoding
 #define document_set_text_changed \

--- a/src/document.c
+++ b/src/document.c
@@ -1417,7 +1417,7 @@ void document_open_files(const GSList *filenames, gboolean readonly, GeanyFilety
  *
  *  @return @c TRUE if the document was actually reloaded or @c FALSE otherwise.
  **/
-gboolean document_reload_file(GeanyDocument *doc, const gchar *forced_enc)
+gboolean document_reload_force(GeanyDocument *doc, const gchar *forced_enc)
 {
 	gint pos = 0;
 	GeanyDocument *new_doc;
@@ -1458,7 +1458,7 @@ gboolean document_reload_prompt(GeanyDocument *doc, const gchar *forced_enc)
 		_("Any unsaved changes will be lost."),
 		_("Are you sure you want to reload '%s'?"), base_name))
 	{
-		result = document_reload_file(doc, forced_enc);
+		result = document_reload_force(doc, forced_enc);
 		if (forced_enc != NULL)
 			ui_update_statusbar(doc, -1);
 	}

--- a/src/document.h
+++ b/src/document.h
@@ -196,7 +196,7 @@ gboolean document_save_file_as(GeanyDocument *doc, const gchar *utf8_fname);
 GeanyDocument* document_open_file(const gchar *locale_filename, gboolean readonly,
 		GeanyFiletype *ft, const gchar *forced_enc);
 
-gboolean document_reload_file(GeanyDocument *doc, const gchar *forced_enc);
+gboolean document_reload_force(GeanyDocument *doc, const gchar *forced_enc);
 
 gboolean document_reload_prompt(GeanyDocument *doc, const gchar *forced_enc);
 

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 219
+#define GEANY_API_VERSION 220
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */
@@ -310,7 +310,7 @@ typedef struct DocumentFuncs
 	void		(*document_open_files) (const GSList *filenames, gboolean readonly,
 			struct GeanyFiletype *ft, const gchar *forced_enc);
 	gboolean	(*document_remove_page) (guint page_num);
-	gboolean	(*document_reload_file) (struct GeanyDocument *doc, const gchar *forced_enc);
+	gboolean	(*document_reload_force) (struct GeanyDocument *doc, const gchar *forced_enc);
 	void		(*document_set_encoding) (struct GeanyDocument *doc, const gchar *new_encoding);
 	void		(*document_set_text_changed) (struct GeanyDocument *doc, gboolean changed);
 	void		(*document_set_filetype) (struct GeanyDocument *doc, struct GeanyFiletype *type);
@@ -740,6 +740,8 @@ BuildFuncs;
 
 /* Deprecated aliases */
 #ifndef GEANY_DISABLE_DEPRECATED
+
+#define document_reload_file document_reload_force
 
 /** @deprecated - copy into your plugin code if needed.
  * @c NULL-safe way to get the index of @a doc_ptr in the documents array. */

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -98,7 +98,7 @@ static DocumentFuncs doc_funcs = {
 	&document_open_file,
 	&document_open_files,
 	&document_remove_page,
-	&document_reload_file,
+	&document_reload_force,
 	&document_set_encoding,
 	&document_set_text_changed,
 	&document_set_filetype,


### PR DESCRIPTION
Also stops infobar from closing when overwriting fails.
