### PR TITLE
Don't rebuild TagManager workspace tags when quitting

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -714,7 +714,7 @@ static gboolean remove_page(guint page_num)
 	g_free(doc->priv->saved_encoding.encoding);
 	g_free(doc->file_name);
 	g_free(doc->real_path);
-	tm_workspace_remove_object(doc->tm_file, TRUE, TRUE);
+	tm_workspace_remove_object(doc->tm_file, TRUE, !main_status.quitting);
 
 	if (doc->priv->tag_tree)
 		gtk_widget_destroy(doc->priv->tag_tree);


### PR DESCRIPTION
Updating the workspace is useless as the application will be shut down,
and not doing it can save a lot of time (almost 50% speedup quitting an
instance with all Geany source from `src/` open).
