### PR TITLE
Add prototypes for all plugin symbols

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -157,15 +157,6 @@ GeanyPlugin;
 	}
 
 
-#ifndef GEANY_PRIVATE
-
-/* Prototypes for building plugins with -Wmissing-prototypes */
-gint plugin_version_check(gint abi_ver);
-void plugin_set_info(PluginInfo *info);
-
-#endif
-
-
 /** @deprecated - use plugin_set_key_group() instead.
  * @see PLUGIN_KEY_GROUP() macro. */
 typedef struct GeanyKeyGroupInfo
@@ -256,6 +247,23 @@ typedef struct GeanyData
 GeanyData;
 
 #define geany			geany_data	/**< Simple macro for @c geany_data that reduces typing. */
+
+
+#ifndef GEANY_PRIVATE
+
+/* Prototypes for building plugins with -Wmissing-prototypes
+ * Also allows the compiler to check if the signature of the plugin's
+ * symbol properly matches what we expect. */
+gint plugin_version_check(gint abi_ver);
+void plugin_set_info(PluginInfo *info);
+
+void plugin_init(GeanyData *data);
+GtkWidget *plugin_configure(GtkDialog *dialog);
+void plugin_configure_single(GtkWidget *parent);
+void plugin_help(void);
+void plugin_cleanup(void);
+
+#endif
 
 
 /** This contains pointers to functions owned by Geany for plugins to use.


### PR DESCRIPTION
This allows the compilers to check that the plugin's symbols have the
proper prototype.  Doing so can avoid subtle and hard-to-find bugs in
case a plugin's symbol has incorrect signature as dlsym() can't check
if the signature is actually the one we expect.

As a bonus, it helps when using -Wmissing-prototypes as it provides the
prototypes.

---

All of GP build just fine with these changes.

The only real downside I could think of is if we wanted `plugin_configure()` and `plugin_configure_single()` not to reference the specialized GTK types as they actually are polymorphic so it would be actually valid to have e.g. a `GtkWidget *plugin_configure(GtkWidget *dialog)` prototype.  However, I don't see why anyone would really want to do that, and we never advertized it (although one can infer it being valid from the GTK documentation).
If we do want this, we can't provide prototypes for `plugin_configure()` and `plugin_configure_single()` as the C implicit conversion between `void*` and specialized pointers doesn't work in protoypes.

Another (harmless) effect of these changes is that `-Wredundant-decls` will report duplicate prototypes for plugins that already define the prototypes (probably only to avoid the `-Wmissing-prototypes` warning).  In GP three plugins do it at least for `plugin_init()`: _GeanyCtags_, _GProject_ and _PrettyPrinter_.  Removing these redundant declarations is of course trivial.
