### PR TITLE
Add project_write_config() to force project file rewrite

### DIFF
--- a/plugins/geanyfunctions.h
+++ b/plugins/geanyfunctions.h
@@ -436,5 +436,7 @@
 	geany_functions->p_build->build_set_menu_item
 #define build_get_group_count \
 	geany_functions->p_build->build_get_group_count
+#define project_write_config \
+	geany_functions->p_project->project_write_config
 
 #endif

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -288,6 +288,7 @@ typedef struct GeanyFunctions
 	struct StashFuncs			*p_stash;			/**< See stash.h */
 	struct SymbolsFuncs			*p_symbols;			/**< See symbols.h */
 	struct BuildFuncs			*p_build;			/**< See build.h */
+	struct ProjectFuncs			*p_project;			/**< See project.h */
 }
 GeanyFunctions;
 
@@ -737,6 +738,13 @@ typedef struct BuildFuncs
 	guint (*build_get_group_count)(const GeanyBuildGroup grp);
 }
 BuildFuncs;
+
+/* See project.h */
+typedef struct ProjectFuncs
+{
+	void (*project_write_config)(void);
+}
+ProjectFuncs;
 
 /* Deprecated aliases */
 #ifndef GEANY_DISABLE_DEPRECATED

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -361,6 +361,10 @@ static BuildFuncs build_funcs = {
 	&build_get_group_count
 };
 
+static ProjectFuncs project_funcs = {
+	&project_write_config
+};
+
 static GeanyFunctions geany_functions = {
 	&doc_funcs,
 	&sci_funcs,
@@ -384,7 +388,8 @@ static GeanyFunctions geany_functions = {
 	&msgwin_funcs,
 	&stash_funcs,
 	&symbols_funcs,
-	&build_funcs
+	&build_funcs,
+	&project_funcs
 };
 
 static GeanyData geany_data;

--- a/src/project.c
+++ b/src/project.c
@@ -1153,6 +1153,18 @@ static gboolean write_config(gboolean emit_signal)
 }
 
 
+/** Forces the project file rewrite and emission of the project-save signal. Plugins 
+ * can use this function to save additional project data outside the project dialog.
+ *
+ *  @since 1.25
+ */
+void project_write_config(void)
+{
+	if (!write_config(TRUE))
+		SHOW_ERR(_("Project file could not be written"));
+}
+
+
 /* Constructs the project's base path which is used for "Make all" and "Execute".
  * The result is an absolute string in UTF-8 encoding which is either the same as
  * base path if it is absolute or it is built out of project file name's dir and base_path.

--- a/src/project.h
+++ b/src/project.h
@@ -47,6 +47,9 @@ typedef struct GeanyProject
 GeanyProject;
 
 
+void project_write_config(void);
+
+
 #ifdef GEANY_PRIVATE
 
 typedef struct ProjectPrefs


### PR DESCRIPTION
As I mentioned, I'd like to add a feature to my gproject plugin to add external directories which can be accessed from the project sidebar and which are indexed by the tag manager (done already in my private copy). The problem is that right now, the only way to write the project file is through the project-save signal handler which is only emitted from the project properties dialog. However, I'd like to be able to add the external directory from the sidebar (project dialog isn't really the right place for this) and right now there's no way to force the resubmission of the project-save signal - and this is what this new API call does.
