### PR TITLE
Only show recent file menu entries for files which exist

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -622,7 +622,7 @@ void configuration_save(void)
 }
 
 
-static void load_recent_files(GKeyFile *config, GQueue *queue, const gchar *key)
+static void load_recent_files(GKeyFile *config, GQueue *queue, const gchar *key, gboolean projects)
 {
 	gchar **recent_files;
 	gsize i, len = 0;
@@ -632,8 +632,14 @@ static void load_recent_files(GKeyFile *config, GQueue *queue, const gchar *key)
 	{
 		for (i = 0; (i < len) && (i < file_prefs.mru_length); i++)
 		{
-			gchar *filename = g_strdup(recent_files[i]);
-			g_queue_push_tail(queue, filename);
+			gchar *locale_filename = utils_get_locale_from_utf8(recent_files[i]);
+			
+			if (!projects || g_file_test(locale_filename, G_FILE_TEST_EXISTS))
+			{
+				gchar *filename = g_strdup(recent_files[i]);
+				g_queue_push_tail(queue, filename);
+			}
+			g_free(locale_filename);
 		}
 		g_strfreev(recent_files);
 	}
@@ -656,8 +662,8 @@ void configuration_load_session_files(GKeyFile *config, gboolean read_recent_fil
 
 	if (read_recent_files)
 	{
-		load_recent_files(config, ui_prefs.recent_queue, "recent_files");
-		load_recent_files(config, ui_prefs.recent_projects_queue, "recent_projects");
+		load_recent_files(config, ui_prefs.recent_queue, "recent_files", FALSE);
+		load_recent_files(config, ui_prefs.recent_projects_queue, "recent_projects", TRUE);
 	}
 
 	/* the project may load another list than the main setting */


### PR DESCRIPTION
I have a really strong feeling of dejavu with this patch - either I have already submitted something like this in the past and it was rejected for some reason or just had this patch privately (or was dreaming about making it).

This is mainly meant for the recent projects menu where old and deleted projects still appear (it works for the recent files too, it's just not as big problem as new files are opened much more frequently and the dead ones disappear much sooner).

The dead entries are removed on Geany launch only (doing so dynamically every time the menu appears would be quite a bit more complicated) but still better than leaving the dead items there forever.
