### PR TITLE
"Execute commands" -> "Comandos de ejecución"

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -2496,7 +2496,7 @@ msgstr "Nota: El elemento 2 abre un diálogo y añade la respuesta al comando."
 
 #: ../src/build.c:2174
 msgid "Execute commands"
-msgstr "Ejecutar comandos"
+msgstr "Comandos de ejecución"
 
 #: ../src/build.c:2186
 #, c-format


### PR DESCRIPTION
"Execute commands" (from the Set Build Commands dialog) is translated to Spanish as if it were a sentence (like "Execute these commands"), but it's actually a name ("<language> commands", "Independent commands", and "Execute commands"; so it means "Commands for 'execute'").  Therefore, +"Comandos de ejecución" is a better translation than -"Ejecutar comandos".
