### PR TITLE
project: Remove unecessary calls after loading project files

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -1070,8 +1070,6 @@ static gboolean load_config(const gchar *filename)
 		document_close_all();
 		/* read session files so they can be opened with configuration_open_files() */
 		configuration_load_session_files(config, FALSE);
-		document_new_file_if_non_open();
-		ui_focus_current_document();
 	}
 	g_signal_emit_by_name(geany_object, "project-open", config);
 	g_key_file_free(config);


### PR DESCRIPTION
document_new_file_if_non_open() and ui_focus_current_document() only make sense
when files where actually opened, but the preceeding
configuration_load_session_files() only loads the file names into the global
session_files variable, from which the files are actually opened by a later
call to configuration_open_files(). These two calls should be done after that
one and the callers generally do this already.
