### PR TITLE
Keybindings rework3

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -202,6 +202,45 @@ GeanyKeyBinding *keybindings_set_item(GeanyKeyGroup *group, gsize key_id,
 }
 
 
+/** Creates a new keybinding using a GeanyKeyBindingFunc and attaches is to a keybinding group
+ *
+ * If given the callback should return @c TRUE if the keybinding was handled, otherwise @c FALSE
+ * to allow other callbacks to be run. This allows for multiplexing keybindings on the same keys,
+ * depending on the focused widget (or context). If the callback is NULL the group's callback will
+ * be invoked, but the same rule applies.
+ *
+ * @param group Group.
+ * @param key_id Keybinding index for the group.
+ * @param cb New-style callback to be called when activated, or @c NULL to use the group callback.
+ * @param pdata Plugin-specific data passed back to the callback.
+ * @param key (Lower case) default key, e.g. @c GDK_j, but usually 0 for unset.
+ * @param mod Default modifier, e.g. @c GDK_CONTROL_MASK, but usually 0 for unset.
+ * @param kf_name Key name for the configuration file, such as @c "menu_new".
+ * @param label Label used in the preferences dialog keybindings tab. May contain
+ * underscores - these won't be displayed.
+ * @param menu_item Optional widget to set an accelerator for, or @c NULL.
+ * @return The keybinding - normally this is ignored.
+ *
+ * @since 1.26 (API 226)
+ * @see See plugin_set_key_group_full
+ **/
+GEANY_API_SYMBOL
+GeanyKeyBinding *keybindings_set_item_full(GeanyKeyGroup *group, gsize key_id,
+		GeanyKeyBindingFunc cb, gpointer pdata, guint key, GdkModifierType mod,
+		const gchar *kf_name, const gchar *label, GtkWidget *menu_item)
+{
+	GeanyKeyBinding *kb;
+
+	/* For now, this is intended for plugins only */
+	g_assert(group->plugin);
+
+	kb = keybindings_set_item(group, key_id, NULL, key, mod, kf_name, label, menu_item);
+	kb->cb_func = cb;
+	kb->cb_data = pdata;
+	return kb;
+}
+
+
 static void add_kb_group(GeanyKeyGroup *group,
 		const gchar *name, const gchar *label, GeanyKeyGroupCallback callback, gboolean plugin)
 {

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -37,12 +37,42 @@ G_BEGIN_DECLS
 #define GEANY_PRIMARY_MOD_MASK GDK_CONTROL_MASK
 #endif
 
+/** A collection of keybindings grouped together. */
+typedef struct GeanyKeyGroup GeanyKeyGroup;
+typedef struct GeanyKeyBinding GeanyKeyBinding;
+
+/** Function pointer type used for keybinding group callbacks.
+ *
+ * You should return @c TRUE to indicate handling the callback. (Occasionally, if the keybinding
+ * cannot apply in the current situation, it is useful to return @c FALSE to allow a later keybinding
+ * with the same key combination to handle it). */
+typedef gboolean (*GeanyKeyGroupCallback) (guint key_id);
+
+/** Function pointer type used for keybinding group callbacks, with userdata for passing context.
+ *
+ * You should return @c TRUE to indicate handling the callback. (Occasionally, if the keybinding
+ * cannot apply in the current situation, it is useful to return @c FALSE to allow a later keybinding
+ * with the same key combination to handle it).
+ *
+ * @since 1.26 (API 226) */
+typedef gboolean (*GeanyKeyGroupFunc)(GeanyKeyGroup *group, guint key_id, gpointer pdata);
+
 /** Function pointer type used for keybinding callbacks. */
 typedef void (*GeanyKeyCallback) (guint key_id);
 
+/** Function pointer type used for keybinding callbacks, with userdata for passing context
+ *
+ * You should return @c TRUE to indicate handling the callback. (Occasionally, if the keybinding
+ * cannot apply in the current situation, it is useful to return @c FALSE to allow a later keybinding
+ * with the same key combination to handle it).
+ *
+ * @since 1.26 (API 226) */
+typedef gboolean (*GeanyKeyBindingFunc)(GeanyKeyBinding *key, guint key_id, gpointer pdata);
+
 /** Represents a single keybinding action.
+ *
  * Use keybindings_set_item() to set. */
-typedef struct GeanyKeyBinding
+struct GeanyKeyBinding
 {
 	guint key;				/**< Key value in lower-case, such as @c GDK_a or 0 */
 	GdkModifierType mods;	/**< Modifier keys, such as @c GDK_CONTROL_MASK or 0 */
@@ -57,19 +87,9 @@ typedef struct GeanyKeyBinding
 	guint id;
 	guint default_key;
 	GdkModifierType default_mods;
-}
-GeanyKeyBinding;
-
-
-/** Function pointer type used for keybinding group callbacks.
- * You should return @c TRUE to indicate handling the callback. (Occasionally, if the keybinding
- * cannot apply in the current situation, it is useful to return @c FALSE to allow a later keybinding
- * with the same key combination to handle it). */
-typedef gboolean (*GeanyKeyGroupCallback) (guint key_id);
-
-/** A collection of keybindings grouped together. */
-typedef struct GeanyKeyGroup GeanyKeyGroup;
-
+	GeanyKeyBindingFunc cb_func;
+	gpointer cb_data;
+};
 
 /* Note: we don't need to break the plugin ABI when appending keybinding or keygroup IDs,
  * just make sure to insert immediately before the _COUNT item, so

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -275,6 +275,10 @@ GeanyKeyBinding *keybindings_set_item(GeanyKeyGroup *group, gsize key_id,
 		GeanyKeyCallback callback, guint key, GdkModifierType mod,
 		const gchar *name, const gchar *label, GtkWidget *menu_item);
 
+GeanyKeyBinding *keybindings_set_item_full(GeanyKeyGroup *group, gsize key_id,
+		GeanyKeyBindingFunc cb, gpointer pdata, guint key, GdkModifierType mod,
+		const gchar *kf_name, const gchar *label, GtkWidget *menu_item);
+
 GeanyKeyBinding *keybindings_get_item(GeanyKeyGroup *group, gsize key_id);
 
 GdkModifierType keybindings_get_modifiers(GdkModifierType mods);

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -89,6 +89,7 @@ struct GeanyKeyBinding
 	GdkModifierType default_mods;
 	GeanyKeyBindingFunc cb_func;
 	gpointer cb_data;
+	GDestroyNotify cb_data_destroy;
 };
 
 /* Note: we don't need to break the plugin ABI when appending keybinding or keygroup IDs,
@@ -276,8 +277,9 @@ GeanyKeyBinding *keybindings_set_item(GeanyKeyGroup *group, gsize key_id,
 		const gchar *name, const gchar *label, GtkWidget *menu_item);
 
 GeanyKeyBinding *keybindings_set_item_full(GeanyKeyGroup *group, gsize key_id,
-		GeanyKeyBindingFunc cb, gpointer pdata, guint key, GdkModifierType mod,
-		const gchar *kf_name, const gchar *label, GtkWidget *menu_item);
+		guint key, GdkModifierType mod, const gchar *kf_name, const gchar *label,
+		GtkWidget *menu_item, GeanyKeyBindingFunc func, gpointer pdata,
+		GDestroyNotify destroy_notify);
 
 GeanyKeyBinding *keybindings_get_item(GeanyKeyGroup *group, gsize key_id);
 

--- a/src/keybindingsprivate.h
+++ b/src/keybindingsprivate.h
@@ -40,6 +40,7 @@ struct GeanyKeyGroup
 	GeanyKeyBinding *plugin_keys;	/* array of GeanyKeyBinding structs */
 	GeanyKeyGroupFunc cb_func;	/* use this or individual keybinding callbacks (new style) */
 	gpointer cb_data;
+	GDestroyNotify cb_data_destroy; /* used to destroy handler_data */
 };
 
 G_END_DECLS

--- a/src/keybindingsprivate.h
+++ b/src/keybindingsprivate.h
@@ -38,6 +38,8 @@ struct GeanyKeyGroup
 	GPtrArray *key_items;	/* pointers to GeanyKeyBinding structs */
 	gsize plugin_key_count;			/* number of keybindings the group holds */
 	GeanyKeyBinding *plugin_keys;	/* array of GeanyKeyBinding structs */
+	GeanyKeyGroupFunc cb_func;	/* use this or individual keybinding callbacks (new style) */
+	gpointer cb_data;
 };
 
 G_END_DECLS

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 225
+#define GEANY_API_VERSION 226
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -33,6 +33,8 @@
 
 #include "app.h"
 #include "geanyobject.h"
+#include "keybindings.h"
+#include "keybindingsprivate.h"
 #include "plugindata.h"
 #include "pluginprivate.h"
 #include "plugins.h"
@@ -305,6 +307,34 @@ GeanyKeyGroup *plugin_set_key_group(GeanyPlugin *plugin,
 	priv->key_group = keybindings_set_group(priv->key_group, section_name,
 		priv->info.name, count, callback);
 	return priv->key_group;
+}
+
+/** Sets up or resizes a keybinding group for the plugin
+ *
+ * You should then call keybindings_set_item() or keybindings_set_item_full() for each
+ * keybinding in the group.
+ * @param plugin Must be @ref geany_plugin.
+ * @param section_name Name used in the configuration file, such as @c "html_chars".
+ * @param count Number of keybindings for the group.
+ * @param cb New-style group callback, or @c NULL if you only want individual keybinding callbacks.
+ * @param pdata Plugin specific data, passed to the group callback.
+ * @return The plugin's keybinding group.
+ *
+ * @since 1.26 (API 226)
+ * @see See keybindings_set_item
+ * @see See keybindings_set_item_full
+ **/
+GEANY_API_SYMBOL
+GeanyKeyGroup *plugin_set_key_group_full(GeanyPlugin *plugin,
+		const gchar *section_name, gsize count, GeanyKeyGroupFunc cb, gpointer pdata)
+{
+	GeanyKeyGroup *group;
+
+	group = plugin_set_key_group(plugin, section_name, count, NULL);
+	group->cb_func = cb;
+	group->cb_data = pdata;
+
+	return group;
 }
 
 

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -318,6 +318,7 @@ GeanyKeyGroup *plugin_set_key_group(GeanyPlugin *plugin,
  * @param count Number of keybindings for the group.
  * @param cb New-style group callback, or @c NULL if you only want individual keybinding callbacks.
  * @param pdata Plugin specific data, passed to the group callback.
+ * @param destroy_notify Function that is invoked to free the plugin data when not needed anymore.
  * @return The plugin's keybinding group.
  *
  * @since 1.26 (API 226)
@@ -326,13 +327,15 @@ GeanyKeyGroup *plugin_set_key_group(GeanyPlugin *plugin,
  **/
 GEANY_API_SYMBOL
 GeanyKeyGroup *plugin_set_key_group_full(GeanyPlugin *plugin,
-		const gchar *section_name, gsize count, GeanyKeyGroupFunc cb, gpointer pdata)
+		const gchar *section_name, gsize count,
+		GeanyKeyGroupFunc cb, gpointer pdata, GDestroyNotify destroy_notify)
 {
 	GeanyKeyGroup *group;
 
 	group = plugin_set_key_group(plugin, section_name, count, NULL);
 	group->cb_func = cb;
 	group->cb_data = pdata;
+	group->cb_data_destroy = destroy_notify;
 
 	return group;
 }

--- a/src/pluginutils.h
+++ b/src/pluginutils.h
@@ -54,6 +54,9 @@ guint plugin_idle_add(struct GeanyPlugin *plugin, GSourceFunc function, gpointer
 struct GeanyKeyGroup *plugin_set_key_group(struct GeanyPlugin *plugin,
 		const gchar *section_name, gsize count, GeanyKeyGroupCallback callback);
 
+GeanyKeyGroup *plugin_set_key_group_full(struct GeanyPlugin *plugin,
+		const gchar *section_name, gsize count, GeanyKeyGroupFunc cb, gpointer pdata);
+
 void plugin_show_configure(struct GeanyPlugin *plugin);
 
 void plugin_builder_connect_signals(struct GeanyPlugin *plugin,

--- a/src/pluginutils.h
+++ b/src/pluginutils.h
@@ -55,7 +55,7 @@ struct GeanyKeyGroup *plugin_set_key_group(struct GeanyPlugin *plugin,
 		const gchar *section_name, gsize count, GeanyKeyGroupCallback callback);
 
 GeanyKeyGroup *plugin_set_key_group_full(struct GeanyPlugin *plugin,
-		const gchar *section_name, gsize count, GeanyKeyGroupFunc cb, gpointer pdata);
+		const gchar *section_name, gsize count, GeanyKeyGroupFunc cb, gpointer pdata, GDestroyNotify destroy_notify);
 
 void plugin_show_configure(struct GeanyPlugin *plugin);
 


### PR DESCRIPTION
New API functions for keybindings that have a userdata pointer. This is needed to allow for potential non-C plugins to store context information (e.g. this pointer for object instances).