### PR TITLE
Remove "Show macro list" keybinding and feature

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3399,9 +3399,6 @@ Complete word                   Ctrl-Space                Shows the autocompleti
 Show calltip                    Ctrl-Shift-Space          Shows a calltip for the current function or
                                                           method.
 
-Show macro list                 Ctrl-Return               Shows a list of available macros and variables in
-                                                          the workspace.
-
 Complete snippet                Tab                       If you type a construct like if or for and press
                                                           this key, it will be completed with a matching
                                                           template.

--- a/src/editor.c
+++ b/src/editor.c
@@ -2600,22 +2600,6 @@ gboolean editor_complete_snippet(GeanyEditor *editor, gint pos)
 }
 
 
-void editor_show_macro_list(GeanyEditor *editor)
-{
-	GString *words;
-
-	if (editor == NULL || editor->document->file_type == NULL)
-		return;
-
-	words = symbols_get_macro_list(editor->document->file_type->lang);
-	if (words == NULL)
-		return;
-
-	SSM(editor->sci, SCI_USERLISTSHOW, 1, (sptr_t) words->str);
-	g_string_free(words, TRUE);
-}
-
-
 static void insert_closing_tag(GeanyEditor *editor, gint pos, gchar ch, const gchar *tag_name)
 {
 	ScintillaObject *sci = editor->sci;

--- a/src/editor.h
+++ b/src/editor.h
@@ -234,8 +234,6 @@ void editor_goto_next_snippet_cursor(GeanyEditor *editor);
 
 gboolean editor_complete_snippet(GeanyEditor *editor, gint pos);
 
-void editor_show_macro_list(GeanyEditor *editor);
-
 gboolean editor_show_calltip(GeanyEditor *editor, gint pos);
 
 void editor_do_comment_toggle(GeanyEditor *editor);

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -322,8 +322,6 @@ static void init_default_kb(void)
 		GDK_space, GDK_CONTROL_MASK, "edit_autocomplete", _("Complete word"), NULL);
 	add_kb(group, GEANY_KEYS_EDITOR_CALLTIP, NULL,
 		GDK_space, GDK_CONTROL_MASK | GDK_SHIFT_MASK, "edit_calltip", _("Show calltip"), NULL);
-	add_kb(group, GEANY_KEYS_EDITOR_MACROLIST, NULL,
-		GDK_Return, GDK_CONTROL_MASK, "edit_macrolist", _("Show macro list"), NULL);
 	add_kb(group, GEANY_KEYS_EDITOR_WORDPARTCOMPLETION, NULL,
 		GDK_Tab, 0, "edit_wordpartcompletion", _("Word part completion"), NULL);
 	add_kb(group, GEANY_KEYS_EDITOR_MOVELINEUP, NULL,
@@ -2046,9 +2044,6 @@ static gboolean cb_func_editor_action(guint key_id)
 			break;
 		case GEANY_KEYS_EDITOR_CALLTIP:
 			editor_show_calltip(doc->editor, -1);
-			break;
-		case GEANY_KEYS_EDITOR_MACROLIST:
-			editor_show_macro_list(doc->editor);
 			break;
 		case GEANY_KEYS_EDITOR_CONTEXTACTION:
 			if (check_current_word(doc, FALSE))

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -137,7 +137,8 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_FORMAT_SENDTOVTE,				/**< Keybinding. */
 	GEANY_KEYS_PROJECT_PROPERTIES,				/**< Keybinding. */
 	GEANY_KEYS_DOCUMENT_LINEWRAP,				/**< Keybinding. */
-	GEANY_KEYS_EDITOR_MACROLIST,				/**< Keybinding. */
+	GEANY_KEYS_EDITOR_MACROLIST,				/**< Keybinding.
+												 * @deprecated 1.25, it doesn't do anything anymore */
 	GEANY_KEYS_EDITOR_SUPPRESSSNIPPETCOMPLETION, /**< Keybinding. */
 	GEANY_KEYS_FOCUS_SIDEBAR_SYMBOL_LIST,		/**< Keybinding. */
 	GEANY_KEYS_GOTO_LINESTART,					/**< Keybinding. */

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -319,60 +319,6 @@ const gchar *symbols_get_context_separator(gint ft_id)
 }
 
 
-GString *symbols_get_macro_list(gint lang)
-{
-	guint j, i;
-	GPtrArray *ftags;
-	GString *words;
-	gint tag_lang;
-	TMTag *tag;
-
-	if (app->tm_workspace->source_files == NULL)
-		return NULL;
-
-	ftags = g_ptr_array_sized_new(50);
-	words = g_string_sized_new(200);
-
-	for (j = 0; j < app->tm_workspace->source_files->len; j++)
-	{
-		GPtrArray *tags;
-
-		tags = tm_tags_extract(TM_SOURCE_FILE(app->tm_workspace->source_files->pdata[j])->tags_array,
-			tm_tag_enum_t | tm_tag_variable_t | tm_tag_macro_t | tm_tag_macro_with_arg_t);
-		if (NULL != tags)
-		{
-			for (i = 0; ((i < tags->len) && (i < editor_prefs.autocompletion_max_entries)); ++i)
-			{
-				tag = TM_TAG(tags->pdata[i]);
-				tag_lang = (tag->file) ?
-					tag->file->lang : tag->lang;
-
-				if (tag_lang == lang)
-					g_ptr_array_add(ftags, (gpointer) tags->pdata[i]);
-			}
-			g_ptr_array_free(tags, TRUE);
-		}
-	}
-
-	if (ftags->len == 0)
-	{
-		g_ptr_array_free(ftags, TRUE);
-		g_string_free(words, TRUE);
-		return NULL;
-	}
-
-	tm_tags_sort(ftags, NULL, FALSE, FALSE);
-	for (j = 0; j < ftags->len; j++)
-	{
-		if (j > 0)
-			g_string_append_c(words, '\n');
-		g_string_append(words, TM_TAG(ftags->pdata[j])->name);
-	}
-	g_ptr_array_free(ftags, TRUE);
-	return words;
-}
-
-
 /* Note: if tags is sorted, we can use bsearch or tm_tags_find() to speed this up. */
 static TMTag *
 symbols_find_tm_tag(const GPtrArray *tags, const gchar *tag_name)

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -54,8 +54,6 @@ GString *symbols_find_typenames_as_string(gint lang, gboolean global);
 
 const GList *symbols_get_tag_list(GeanyDocument *doc, guint tag_types);
 
-GString *symbols_get_macro_list(gint lang);
-
 const gchar **symbols_get_html_entities(void);
 
 gboolean symbols_recreate_tag_list(GeanyDocument *doc, gint sort_mode);


### PR DESCRIPTION
This feature looks like a poorly implemented subset of "Complete word",
but lacks some important features like prefix filtering.  It is also
misnamed as it shows not only macros, but also variables and enums.

It also only shows `editor_prefs.autocompletion_max_entries`, but does
so from *each* file, not as a whole.

So drop it altogether, as this feature doesn't really look useful and
the current implementation seem to suffer of too many shortcomings for
it to realistically be actually used.

See [discussion in #356](/geany/geany/pull/356#issuecomment-61737645)
@eht16 @ntrel @codebrainz any opinion on why it exists and removing it?