### PR TITLE
Revert "Microoptimization in merge"

### DIFF
--- a/tagmanager/src/tm_tag.c
+++ b/tagmanager/src/tm_tag.c
@@ -895,9 +895,7 @@ static GPtrArray *merge(GPtrArray *big_array, GPtrArray *small_array,
 				while (i1 <= j1) 
 				{
 					val1 = big_array->pdata[i1];
-					/* we allocated enough space so we are sure we don't need to reallocate
-					 * the array - copy and increment the size directly so it can be inlined */
-					res_array->pdata[res_array->len++] = val1;
+					g_ptr_array_add(res_array, val1);
 					i1++;
 				}
 			}


### PR DESCRIPTION
Slightly forgot about this one. I wanted to remove it from the TM patches - there's nothing wrong about the code but there's actually no speed improvement (I misread the profile) so better to remove and get rid of the potentially misleading comment.
