### PR TITLE
Avoid double-shadow around message window

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -70,7 +70,6 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment8">
-    <property name="lower">0</property>
     <property name="upper">50</property>
     <property name="value">4</property>
     <property name="step_increment">1</property>
@@ -8214,11 +8213,11 @@
                 <property name="can_focus">True</property>
                 <property name="hscrollbar_policy">never</property>
                 <property name="vscrollbar_policy">never</property>
-                <property name="shadow_type">in</property>
                 <child>
                   <object class="GtkViewport" id="viewport1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="shadow_type">none</property>
                     <child>
                       <object class="GtkNotebook" id="notebook_info">
                         <property name="visible">True</property>


### PR DESCRIPTION
The shadows of two containers around the message window look a bit strange. With a 3D theme it looks the message window is too deep, with a 2D theme there is a thick line around the message window. I think the message window should be at the same "level" as the rest of the main window components - the sidebar and the editor - which don't use any shadow like that. This patch removes the shadows (edited manually, the diff made by glade was too big).

I've been looking at this for about 4 years now - I have finally managed to overcome my laziness :-)

