### PR TITLE
TM: Consider vartype when sorting and de-duplicating global tags

### DIFF
--- a/tagmanager/src/tm_workspace.c
+++ b/tagmanager/src/tm_workspace.c
@@ -52,7 +52,7 @@ static TMTagAttrType file_tags_sort_attrs[] =
 static TMTagAttrType global_tags_sort_attrs[] =
 {
 	tm_tag_attr_name_t, 
-	tm_tag_attr_type_t, tm_tag_attr_scope_t, tm_tag_attr_arglist_t, 0
+	tm_tag_attr_type_t, tm_tag_attr_scope_t, tm_tag_attr_arglist_t, tm_tag_attr_vartype_t, 0
 };
 
 

--- a/tests/ctags/bug507864.c.tags
+++ b/tests/ctags/bug507864.c.tags
@@ -2,3 +2,4 @@
 ENTSEQNOÌ16Í(seq)Ö0ÏFUNCSTS
 MEMTXTÌ16Í(form_msg)Ö0Ï
 MEMTXTÌ1024Í(form_msg)Ö0Ï
+MEMTXTÌ1024Í(form_msg)Ö0ÏFUNCSTS

--- a/tests/ctags/bug872494.cpp.tags
+++ b/tests/ctags/bug872494.cpp.tags
@@ -1,4 +1,5 @@
 # format=tagmanager
 FooClass2Ì1Ö0
 TemplClassÌ1Ö0
+iÌ64ÎTemplClassÖ0Ïdouble
 iÌ64ÎTemplClassÖ0Ïint

--- a/tests/ctags/keyword_event.cs.tags
+++ b/tests/ctags/keyword_event.cs.tags
@@ -14,6 +14,7 @@ MyDelegateÌ128Í()Ö0Ïpublic delegate void
 MyDelegate1Ì128Í(int i)Ö0Ïpublic delegate void
 MyDelegate1Ì128Í()Ö0Ïpublic delegate void
 MyDelegate2Ì128Í(string s)Ö0Ïpublic delegate int
+MyDelegate2Ì128Í(string s)Ö0Ïpublic delegate void
 MyDelegate3Ì128Í(int i, object o)Ö0Ïpublic delegate void
 MyDelegate4Ì128Í()Ö0Ïpublic delegate void
 MyEvent2StorageÌ8ÎExplicitEventsSampleÖ0ÏMyDelegate2


### PR DESCRIPTION
Don't consider two global tags as identical if their vartype is
different.

This fixes tests/ctags/keyword_event.cs on some systems (seen on a
Debian 6 VM), probably because of a sort instability of some sort.
The problem with this test case is that it has two identical tags but
for their return type, and the picked one was different.

Note that the results for test case tests/ctags/bug507864.c don't seem
really correct, but that's an unrelated issue.