### PR TITLE
waf: Don't relink scintilla and geany on every build

### DIFF
--- a/wscript
+++ b/wscript
@@ -416,7 +416,7 @@ def build(bld):
 
     # Scintilla
     files = bld.srcnode.ant_glob('scintilla/**/*.cxx', src=True, dir=False)
-    scintilla_sources.update(files)
+    scintilla_sources.update([file.path_from(bld.srcnode) for file in files])
     bld(
         features        = ['c', 'cxx', 'cxxstlib'],
         name            = 'scintilla',


### PR DESCRIPTION
The ant_glob() function doesn't return a list of strings but rather
a list of waflib.Node.Nod3 objects. These print as paths so build
works but apparently confuse waf which thinks the files have
changed every time the waf command is performed.

Relinking scintilla and geany on every waf invocation is especially
problemmatic during "sudo waf install" where scintilla and geany
binaries get owned by the root user. This isn't a big problem on Linux
but on OS X this prevents subsequent waf calls to update the
binaries and the build fails.

To fix the issue, just convert the waflib.Node.Nod3 objects
to relative (string) paths.

@eht16 You are probably the right person to review this change.