### PR TITLE
Fix strangely undefined GTK for PlatGtk.cxx by moving build dir (#1001)

### DIFF
--- a/makefile.win32
+++ b/makefile.win32
@@ -33,7 +33,7 @@ all: config.h
 	$(MAKE) -C tagmanager/ctags -f makefile.win32
 	$(MAKE) -C tagmanager/mio -f makefile.win32
 	$(MAKE) -C tagmanager/src -f makefile.win32
-	$(MAKE) -C scintilla -f makefile.win32
+	$(MAKE) -C scintilla/gtk -f makefile.win32
 	$(MAKE) -C plugins -f makefile.win32
 	$(MAKE) -C src -f makefile.win32
 
@@ -48,7 +48,7 @@ clean:
 	$(MAKE) -C tagmanager/ctags -f makefile.win32 clean
 	$(MAKE) -C tagmanager/mio -f makefile.win32 clean
 	$(MAKE) -C tagmanager/src -f makefile.win32 clean
-	$(MAKE) -C scintilla -f makefile.win32 clean
+	$(MAKE) -C scintilla/gtk -f makefile.win32 clean
 	$(MAKE) -C plugins -f makefile.win32 clean
 	$(MAKE) -C src -f makefile.win32 clean
 

--- a/scintilla/gtk/makefile.win32
+++ b/scintilla/gtk/makefile.win32
@@ -1,11 +1,10 @@
 # Make file for Scintilla on Linux or compatible OS
-# Copyright 1998-2001 by Neil Hodgson <neilh@scintilla.org>
+# Copyright 1998-2010 by Neil Hodgson <neilh@scintilla.org>
 # The License.txt file describes the conditions under which this software may be distributed.
-# This makefile assumes GCC 3.1 is used and changes will be needed to use other compilers.
+# This makefile assumes GCC 4.3 is used and changes will be needed to use other compilers.
 # GNU make does not like \r\n line endings so should be saved to CVS in binary form.
-# Builds for GTK+ 2 if available else GTK+ 1.
-# To force GTK+ 2 build, define GTK2 on the make command line.
-# To force GTK+ 1 build, define GTK1 on the make command line.
+# Builds for GTK+ 2 and no longer supports GTK+ 1.
+# Also works with ming32-make on Windows.
 
 .SUFFIXES: .cxx .c .o .h .a
 CXX = g++
@@ -21,19 +20,18 @@ endif
 RANLIB = ranlib
 PREFIX = C:/libs
 RM = del
--include ../localwin32.mk
+-include ../../localwin32.mk
 
 ifdef MSYS
 RM = rm -f
 endif
 
-COMPLIB=scintilla.a
+COMPLIB=../scintilla.a
 
-vpath %.h gtk lexlib src include
-vpath %.cxx gtk lexers lexlib src
-vpath %.c gtk
+vpath %.h ../src ../include ../lexlib
+vpath %.cxx ../src ../lexlib ../lexers
 
-INCLUDEDIRS=-I include -I src -I lexlib -I .
+INCLUDEDIRS=-I ../include -I ../src -I ../lexlib
 CXXBASEFLAGS=-Wall -Wno-missing-braces -Wno-char-subscripts -DGTK -DSCI_LEXER $(INCLUDEDIRS)
 
 ifdef THREADS
@@ -60,7 +58,7 @@ MARSHALLER=scintilla-marshal.o
 .c.o:
 	$(CC) $(CONFIGFLAGS) $(CFLAGS) -w -c $<
 
-LEXOBJS:=$(addsuffix .o,$(basename $(notdir $(wildcard lexers/Lex*.cxx))))
+LEXOBJS:=$(addsuffix .o,$(basename $(notdir $(wildcard ../lexers/Lex*.cxx))))
 
 all: $(COMPLIB)
 
@@ -68,7 +66,7 @@ clean:
 	-$(RM) deps.mak *.o $(COMPLIB) *.plist
 
 deps.mak:
-	$(CXX) -MM  $(CONFIGFLAGS) $(CXXTFLAGS) gtk/*.cxx lexers/*.cxx lexlib/*.cxx src/*.cxx >deps.mak
+	$(CXX) -MM $(CONFIGFLAGS) $(CXXTFLAGS) *.cxx ../src/*.cxx ../lexlib/*.cxx ../lexers/*.cxx >deps.mak
 
 $(COMPLIB): Accessor.o CharacterSet.o LexerBase.o LexerModule.o LexerSimple.o StyleContext.o WordList.o \
 	CharClassify.o Decoration.o Document.o PerLine.o Catalogue.o CallTip.o CaseConvert.o CaseFolder.o \

--- a/scintilla/makefile.win32
+++ b/scintilla/makefile.win32
@@ -11,6 +11,13 @@
 CXX = g++
 CC = gcc
 AR = ar
+
+ifdef GTK3
+GTKVERSION=gtk+-3.0
+else
+GTKVERSION=gtk+-2.0
+endif
+
 RANLIB = ranlib
 PREFIX = C:/libs
 RM = del
@@ -22,25 +29,12 @@ endif
 
 COMPLIB=scintilla.a
 
-GTK_INCLUDES= \
-	-I$(PREFIX)/include/gtk-2.0 \
-	-I$(PREFIX)/lib/gtk-2.0/include \
-	-I$(PREFIX)/include/atk-1.0 \
-	-I$(PREFIX)/include/cairo \
-	-I$(PREFIX)/include/gdk-pixbuf-2.0 \
-	-I$(PREFIX)/include/pango-1.0 \
-	-I$(PREFIX)/include/glib-2.0 \
-	-I$(PREFIX)/lib/glib-2.0/include \
-	-I$(PREFIX)/include \
-	-I$(PREFIX)/include/gettext
-
-
-vpath %.h gtk lexers lexlib src include
+vpath %.h gtk lexlib src include
 vpath %.cxx gtk lexers lexlib src
 vpath %.c gtk
 
-INCLUDEDIRS=-I include -I src -I lexlib -I . $(GTK_INCLUDES)
-CXXBASEFLAGS=-Wall -Wno-missing-braces -Wno-char-subscripts -DGTK -DSCI_LEXER $(INCLUDEDIRS) -mms-bitfields
+INCLUDEDIRS=-I include -I src -I lexlib -I .
+CXXBASEFLAGS=-Wall -Wno-missing-braces -Wno-char-subscripts -DGTK -DSCI_LEXER $(INCLUDEDIRS)
 
 ifdef THREADS
 THREADFLAGS=
@@ -48,113 +42,43 @@ else
 THREADFLAGS=-DG_THREADS_IMPL_NONE
 endif
 
+
 ifdef DEBUG
-CXXFLAGS=-DDEBUG -g -O0 $(CXXBASEFLAGS) $(THREADFLAGS)
+CTFLAGS=-DDEBUG -g -O0 $(CXXBASEFLAGS) $(THREADFLAGS)
 else
-CXXFLAGS=-DNDEBUG -Os $(CXXBASEFLAGS) $(THREADFLAGS)
+CTFLAGS=-DNDEBUG -Os $(CXXBASEFLAGS) $(THREADFLAGS)
 endif
 
-CONFIGFLAGS=$(GTK_INCLUDES)
+CFLAGS:=$(CTFLAGS)
+CXXTFLAGS:=--std=c++0x $(CTFLAGS) $(REFLAGS)
+
+CONFIGFLAGS:=$(shell pkg-config --cflags $(GTKVERSION))
 MARSHALLER=scintilla-marshal.o
 
 .cxx.o:
-	$(CXX) $(CXXFLAGS) -c $<
+	$(CXX) $(CONFIGFLAGS) $(CXXTFLAGS) $(CXXFLAGS) -c $<
 .c.o:
-	$(CC) $(CXXFLAGS) -c $<
+	$(CC) $(CONFIGFLAGS) $(CFLAGS) -w -c $<
 
-LEXOBJS=\
-LexAbaqus.o \
-LexAda.o \
-LexAsm.o \
-LexBash.o \
-LexCOBOL.o \
-LexCSS.o \
-LexCPP.o \
-LexCoffeeScript.o \
-LexHTML.o \
-LexOthers.o \
-LexPascal.o \
-LexPerl.o \
-LexPO.o \
-LexPowerShell.o \
-LexPython.o \
-LexSQL.o \
-LexCaml.o \
-LexTCL.o \
-LexTxt2tags.o \
-LexRuby.o \
-LexErlang.o \
-LexForth.o \
-LexFortran.o \
-LexVHDL.o \
-LexVerilog.o \
-LexMarkdown.o \
-LexMatlab.o \
-LexD.o \
-LexLaTeX.o \
-LexLisp.o \
-LexLua.o \
-LexHaskell.o \
-LexBasic.o \
-LexR.o \
-LexRust.o \
-LexYAML.o \
-LexCmake.o \
-LexNsis.o
+LEXOBJS:=$(addsuffix .o,$(basename $(notdir $(wildcard lexers/Lex*.cxx))))
 
 all: $(COMPLIB)
 
 clean:
-	-$(RM) deps.mak *.o $(COMPLIB)
-
-SRCOBJS=\
-	PlatGTK.o \
-	ScintillaGTK.o \
-	Accessor.o \
-	CharacterCategory.o \
-	CaseConvert.o \
-	CaseFolder.o \
-	CharacterSet.o \
-	LexerBase.o \
-	LexerModule.o \
-	LexerNoExceptions.o \
-	LexerSimple.o \
-	PropSetSimple.o \
-	StyleContext.o \
-	WordList.o \
-	AutoComplete.o \
-	CallTip.o \
-	Catalogue.o \
-	CellBuffer.o \
-	CharClassify.o \
-	ContractionState.o \
-	Decoration.o \
-	Document.o \
-	Editor.o \
-	EditModel.o \
-	EditView.o \
-	ExternalLexer.o \
-	Indicator.o \
-	KeyMap.o \
-	LineMarker.o \
-	MarginView.o \
-	PerLine.o \
-	PositionCache.o \
-	RESearch.o \
-	RunStyles.o \
-	ScintillaBase.o \
-	Selection.o \
-	Style.o \
-	UniConversion.o \
-	ViewStyle.o \
-	XPM.o
-
-$(COMPLIB): $(MARSHALLER) $(LEXOBJS) $(SRCOBJS)
-	$(AR) rc $@ $^
-	$(RANLIB) $@
+	-$(RM) deps.mak *.o $(COMPLIB) *.plist
 
 deps.mak:
-	$(CXX) -MM  $(CXXFLAGS) gtk/*.cxx lexers/*.cxx lexlib/*.cxx src/*.cxx >deps.mak
+	$(CXX) -MM  $(CONFIGFLAGS) $(CXXTFLAGS) gtk/*.cxx lexers/*.cxx lexlib/*.cxx src/*.cxx >deps.mak
+
+$(COMPLIB): Accessor.o CharacterSet.o LexerBase.o LexerModule.o LexerSimple.o StyleContext.o WordList.o \
+	CharClassify.o Decoration.o Document.o PerLine.o Catalogue.o CallTip.o CaseConvert.o CaseFolder.o \
+	ScintillaBase.o ContractionState.o EditModel.o Editor.o EditView.o ExternalLexer.o MarginView.o \
+	PropSetSimple.o PlatGTK.o \
+	KeyMap.o LineMarker.o PositionCache.o ScintillaGTK.o CellBuffer.o CharacterCategory.o ViewStyle.o \
+	RESearch.o RunStyles.o Selection.o Style.o Indicator.o AutoComplete.o UniConversion.o XPM.o \
+	$(MARSHALLER) $(LEXOBJS)
+	$(AR) rc $@ $^
+	$(RANLIB) $@
 
 # Generate header dependencies with "make deps.mak"
 include deps.mak

--- a/src/makefile.win32
+++ b/src/makefile.win32
@@ -51,7 +51,7 @@ ALL_GTK_LIBS= \
 	#"$(PREFIX)/lib/asprintf.lib" \
 	#"$(PREFIX)/lib/charset.lib" \
 
-WIN_LIBS=-mwindows -lole32 -luuid -liberty -lwsock32
+WIN_LIBS=-mwindows -lole32 -luuid -lwsock32
 
 CBASEFLAGS=-Wall -pipe -mms-bitfields $(DEFINES) $(INCLUDEDIRS)
 ifdef DEBUG


### PR DESCRIPTION
https://sourceforge.net/p/geany/bugs/1001/

I don't know why using `scintilla/gtk` instead of `scintilla` fixes it, I've been trying to work it out to no avail.
This also merges most scintilla makefile differences to make it easier to compare the files. Using more gnu-make specific things should be fine as we already rely on it.