### PR TITLE
Use consistent shadows across Geany

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8135,7 +8135,6 @@
                         <property name="can_focus">True</property>
                         <property name="hscrollbar_policy">automatic</property>
                         <property name="vscrollbar_policy">automatic</property>
-                        <property name="shadow_type">in</property>
                         <child>
                           <object class="GtkTreeView" id="treeview2">
                             <property name="visible">True</property>
@@ -8159,7 +8158,6 @@
                       <object class="GtkScrolledWindow" id="scrolledwindow7">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="shadow_type">in</property>
                         <child>
                           <object class="GtkTreeView" id="treeview6">
                             <property name="visible">True</property>
@@ -8529,10 +8527,12 @@
                     <property name="can_focus">True</property>
                     <property name="hscrollbar_policy">automatic</property>
                     <property name="vscrollbar_policy">automatic</property>
+                    <property name="shadow_type">in</property>
                     <child>
                       <object class="GtkViewport" id="viewport_project_dialog_description">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkTextView" id="textview_project_dialog_description">
                             <property name="visible">True</property>

--- a/plugins/htmlchars.c
+++ b/plugins/htmlchars.c
@@ -525,8 +525,8 @@ static void tools_show_dialog_insert_special_chars(void)
 		swin = gtk_scrolled_window_new(NULL, NULL);
 		gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(swin), GTK_POLICY_AUTOMATIC,
 			GTK_POLICY_AUTOMATIC);
-		gtk_scrolled_window_add_with_viewport(
-					GTK_SCROLLED_WINDOW(swin), GTK_WIDGET(sc_tree));
+		gtk_container_add(GTK_CONTAINER(swin), GTK_WIDGET(sc_tree));
+		gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin), GTK_SHADOW_IN);
 
 		gtk_box_pack_start(GTK_BOX(vbox), swin, TRUE, TRUE, 0);
 

--- a/plugins/splitwindow.c
+++ b/plugins/splitwindow.c
@@ -299,7 +299,7 @@ static void split_view(gboolean horizontal)
 {
 	GtkWidget *notebook = geany_data->main_widgets->notebook;
 	GtkWidget *parent = gtk_widget_get_parent(notebook);
-	GtkWidget *pane, *toolbar, *box;
+	GtkWidget *pane, *toolbar, *box, *splitwin_notebook;
 	GeanyDocument *doc = document_get_current();
 	gint width = gtk_widget_get_allocated_width(notebook) / 2;
 	gint height = gtk_widget_get_allocated_height(notebook) / 2;
@@ -321,8 +321,13 @@ static void split_view(gboolean horizontal)
 	box = gtk_vbox_new(FALSE, 0);
 	toolbar = create_toolbar();
 	gtk_box_pack_start(GTK_BOX(box), toolbar, FALSE, FALSE, 0);
-	gtk_container_add(GTK_CONTAINER(pane), box);
 	edit_window.vbox = box;
+
+	/* used just to make the split window look the same as the main editor */
+	splitwin_notebook = gtk_notebook_new();
+	gtk_notebook_set_show_tabs(GTK_NOTEBOOK(splitwin_notebook), FALSE);
+	gtk_notebook_append_page(GTK_NOTEBOOK(splitwin_notebook), box, NULL);
+	gtk_container_add(GTK_CONTAINER(pane), splitwin_notebook);
 
 	set_editor(&edit_window, doc->editor);
 

--- a/src/gb.c
+++ b/src/gb.c
@@ -169,15 +169,13 @@ static GtkWidget *create_help_dialog(GtkWindow *parent)
 	scrolledwindow1 = gtk_scrolled_window_new(NULL, NULL);
 	gtk_widget_show(scrolledwindow1);
 	gtk_box_pack_start(GTK_BOX (dialog_vbox1), scrolledwindow1, TRUE, TRUE, 3);
-	gtk_container_set_border_width(GTK_CONTAINER(scrolledwindow1), 2);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolledwindow1), GTK_POLICY_NEVER, GTK_POLICY_NEVER);
-	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scrolledwindow1), GTK_SHADOW_OUT);
+	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scrolledwindow1), GTK_SHADOW_IN);
 
 	textview1 = gtk_text_view_new();
 	gtk_widget_show(textview1);
 	gtk_container_add(GTK_CONTAINER(scrolledwindow1), textview1);
 	gtk_widget_set_size_request(textview1, 450, -1);
-	gtk_container_set_border_width(GTK_CONTAINER(textview1), 1);
 	gtk_text_view_set_editable(GTK_TEXT_VIEW(textview1), FALSE);
 	gtk_text_view_set_accepts_tab(GTK_TEXT_VIEW(textview1), FALSE);
 	gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(textview1), GTK_WRAP_WORD);

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -1362,7 +1362,7 @@ void highlighting_show_color_scheme_dialog(void)
 		GEANY_DEFAULT_DIALOG_HEIGHT * 7/4, GEANY_DEFAULT_DIALOG_HEIGHT);
 
 	swin = gtk_scrolled_window_new(NULL, NULL);
-	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin), GTK_SHADOW_ETCHED_IN);
+	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin), GTK_SHADOW_IN);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(swin),
 		GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 	gtk_container_add(GTK_CONTAINER(swin), tree);

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -893,7 +893,7 @@ static GtkWidget *create_dialog(void)
 	swin = gtk_scrolled_window_new(NULL, NULL);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(swin), GTK_POLICY_NEVER,
 		GTK_POLICY_AUTOMATIC);
-	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin), GTK_SHADOW_ETCHED_IN);
+	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin), GTK_SHADOW_IN);
 	gtk_container_add(GTK_CONTAINER(swin), tree);
 
 	gtk_box_pack_start(GTK_BOX(vbox), label, FALSE, FALSE, 6);

--- a/src/log.c
+++ b/src/log.c
@@ -202,6 +202,7 @@ void log_show_debug_messages_dialog(void)
 	gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(textview), GTK_WRAP_WORD_CHAR);
 
 	swin = gtk_scrolled_window_new(NULL, NULL);
+	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin), GTK_SHADOW_IN);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(swin),
 		GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 	gtk_container_add(GTK_CONTAINER(swin), textview);

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -173,6 +173,7 @@ static void create_default_tag_tree(void)
 	tv.default_tag_tree = gtk_viewport_new(
 		gtk_scrolled_window_get_hadjustment(scrolled_window),
 		gtk_scrolled_window_get_vadjustment(scrolled_window));
+	gtk_viewport_set_shadow_type(GTK_VIEWPORT(tv.default_tag_tree), GTK_SHADOW_NONE);
 	label = gtk_label_new(_("No tags found"));
 	gtk_misc_set_alignment(GTK_MISC(label), 0.1f, 0.01f);
 	gtk_container_add(GTK_CONTAINER(tv.default_tag_tree), label);

--- a/src/toolbar.c
+++ b/src/toolbar.c
@@ -978,7 +978,7 @@ static TBEditorWidget *tb_editor_create_dialog(GtkWindow *parent)
 	swin_available = gtk_scrolled_window_new(NULL, NULL);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(swin_available),
 		GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
-	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin_available), GTK_SHADOW_ETCHED_IN);
+	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin_available), GTK_SHADOW_IN);
 	gtk_container_add(GTK_CONTAINER(swin_available), tree_available);
 
 	tree_used = gtk_tree_view_new();
@@ -999,7 +999,7 @@ static TBEditorWidget *tb_editor_create_dialog(GtkWindow *parent)
 	swin_used = gtk_scrolled_window_new(NULL, NULL);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(swin_used),
 		GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
-	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin_used), GTK_SHADOW_ETCHED_IN);
+	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin_used), GTK_SHADOW_IN);
 	gtk_container_add(GTK_CONTAINER(swin_used), tree_used);
 
 	/* drag'n'drop */

--- a/src/vte.c
+++ b/src/vte.c
@@ -258,7 +258,7 @@ static void on_vte_realize(void)
 
 static void create_vte(void)
 {
-	GtkWidget *vte, *scrollbar, *hbox, *frame;
+	GtkWidget *vte, *scrollbar, *hbox;
 
 	vc->vte = vte = vf->vte_terminal_new();
 	scrollbar = gtk_vscrollbar_new(GTK_ADJUSTMENT(VTE_TERMINAL(vte)->adjustment));
@@ -268,10 +268,7 @@ static void create_vte(void)
 	vc->menu = vte_create_popup_menu();
 	g_object_ref_sink(vc->menu);
 
-	frame = gtk_frame_new(NULL);
-
 	hbox = gtk_hbox_new(FALSE, 0);
-	gtk_container_add(GTK_CONTAINER(frame), hbox);
 	gtk_box_pack_start(GTK_BOX(hbox), vte, TRUE, TRUE, 0);
 	gtk_box_pack_start(GTK_BOX(hbox), scrollbar, FALSE, FALSE, 0);
 
@@ -296,8 +293,8 @@ static void create_vte(void)
 
 	vte_start(vte);
 
-	gtk_widget_show_all(frame);
-	gtk_notebook_insert_page(GTK_NOTEBOOK(msgwindow.notebook), frame, gtk_label_new(_("Terminal")), MSG_VTE);
+	gtk_widget_show_all(hbox);
+	gtk_notebook_insert_page(GTK_NOTEBOOK(msgwindow.notebook), hbox, gtk_label_new(_("Terminal")), MSG_VTE);
 
 	g_signal_connect_after(vte, "realize", G_CALLBACK(on_vte_realize), NULL);
 }


### PR DESCRIPTION
In principle, any scrolled window should have GTK_SHADOW_IN so the scrollbars
are not above the surface and there is a frame around the scrolled area.

The only exception are the elements of the main window where adding
GTK_SHADOW_IN causes there are too many shadows (or lines in 2D themes)
around the windows and the result isn't nice. So use GTK_SHADOW_NONE
for all main editor scrolled windows. (One additional exception is the
Help->Credits page which is gray and the extra frame doesn't look good.)

Replace frame around VTE with GtkViewport to avoid the extra line around.

Raise the second editor from the splitwindow plugin so it's at the same
level as the main editor.

Best reviewed with the Redmond theme where the shadows are most obvious.