### PR TITLE
Set "rules hint" where it makes sense

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8164,7 +8164,6 @@
                           <object class="GtkTreeView" id="treeview6">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="rules_hint">True</property>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
The "rules hint" property is used to tell the theme for which TreeView
even/odd rows should have a different color. This is typically used for
long rows or rows which need to be visually separated for some reason.

Currently the Documents sidebar view uses it which doesn't make much
sense because the row is short and neither of the other tabs in the sidebar
use it.

On the other hand, the Compiler tab in the message window doesn't use it
even though the lines are long and the separation might be useful. In addition,
both Status and Messages tabs use it so setting it makes the UI more
consistent.

The rest of the rules hint usages seem to be fine in Geany.