### PR TITLE
SaveActions: Set file permissions of backup copies to 0600

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -5176,8 +5176,23 @@ you can configure the automatically added extension in the configure dialog
 in Geany's plugin manager.
 
 After the plugin was loaded in Geany's plugin manager, every file is
-copied into the configured backup directory when the file is saved in Geany.
+copied into the configured backup directory *after* the file has been saved
+in Geany.
 
+The created backup copy file permissions are set to read-write only for
+the user. This should help to not create world-readable files on possibly
+unsecure destination directories like /tmp (especially useful
+on multi-user systems).
+This applies only to non-Windows systems. On Windows, no explicit file
+permissions are set.
+
+
+Additionally, you can define how many levels of the original file's
+directory structure should be replicated in the backup copy path.
+For example, setting the option
+*Directory levels to include in the backup destination* to *2*
+cause the plugin to create the last two components of the original
+file's path in the backup copy path and place the new file there.
 
 
 Contributing to this document

--- a/plugins/saveactions.c
+++ b/plugins/saveactions.c
@@ -27,6 +27,8 @@
 #include "geanyplugin.h"
 #include "gtkcompat.h"
 
+#include <stdio.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
 #include <glib/gstdio.h>
@@ -195,6 +197,7 @@ static void backupcopy_document_save_cb(GObject *obj, GeanyDocument *doc, gpoint
 	gchar *dir_parts_src;
 	gchar *stamp;
 	gchar buf[512];
+	gint fd_dst = -1;
 
 	if (! enable_backupcopy)
 		return;
@@ -220,7 +223,14 @@ static void backupcopy_document_save_cb(GObject *obj, GeanyDocument *doc, gpoint
 	g_free(basename_src);
 	g_free(dir_parts_src);
 
+#ifdef G_OS_WIN32
 	if ((dst = g_fopen(locale_filename_dst, "wb")) == NULL)
+#else
+	/* Use g_open() on non-Windows to set file permissions to 600 atomically.
+	 * On Windows, seting file permissions would require specific Windows API. */
+	fd_dst = g_open(locale_filename_dst, O_CREAT | O_WRONLY, S_IWUSR | S_IRUSR);
+	if (fd_dst == -1 || (dst = fdopen(fd_dst, "w")) == NULL)
+#endif
 	{
 		ui_set_statusbar(FALSE, _("Backup Copy: File could not be saved (%s)."),
 			g_strerror(errno));
@@ -228,6 +238,8 @@ static void backupcopy_document_save_cb(GObject *obj, GeanyDocument *doc, gpoint
 		g_free(locale_filename_dst);
 		g_free(stamp);
 		fclose(src);
+		if (fd_dst != -1)
+			close(fd_dst);
 		return;
 	}
 
@@ -238,6 +250,8 @@ static void backupcopy_document_save_cb(GObject *obj, GeanyDocument *doc, gpoint
 
 	fclose(src);
 	fclose(dst);
+	if (fd_dst != -1)
+		close(fd_dst);
 	g_free(locale_filename_src);
 	g_free(locale_filename_dst);
 	g_free(stamp);


### PR DESCRIPTION
As discussed in SF bug 125 (https://sourceforge.net/p/geany-plugins/bugs/125/), it might be dangerous to store backup
copies in a publicly accessable directory like /tmp with default
permissions, especially on multi-user systems.
So set the file permissions on non-Windows systems to 0600 by default.
Also improve the documentation of the save Actions plugin to reflect this
change.

On Windows systems, settings proper file permissions would require specific
Windows API and might not be trivial to do right, so it is skipped at this point.