### PR TITLE
Spell "Windows" as "Windows", not "Win"

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -7706,7 +7706,7 @@
                                   <object class="GtkRadioMenuItem" id="crlf">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Convert and Set to _CR/LF (Win)</property>
+                                    <property name="label" translatable="yes">Convert and Set to _CR/LF (Windows)</property>
                                     <property name="use_underline">True</property>
                                     <signal name="activate" handler="on_crlf_activate" swapped="no"/>
                                   </object>

--- a/src/utils.c
+++ b/src/utils.c
@@ -373,7 +373,7 @@ const gchar *utils_get_eol_name(gint eol_mode)
 {
 	switch (eol_mode)
 	{
-		case SC_EOL_CRLF: return _("Win (CRLF)"); break;
+		case SC_EOL_CRLF: return _("Windows (CRLF)"); break;
 		case SC_EOL_CR: return _("Classic Mac (CR)"); break;
 		default: return _("Unix (LF)"); break;
 	}


### PR DESCRIPTION
This makes the labels more clear using the canonical name, and avoids any confusion with the English word "win".

---

No, I'm not Stallman or campaigning for him or something, but 6a132ef3fa4a01f7e05a0b8d673407429e3e6c8a made me realize this was a bit of a poor wording, and we have all the space we need for the extra 4 characters in the UI.