### PR TITLE
Revert some OS X keybinding changes for VTE

### DIFF
--- a/src/vte.c
+++ b/src/vte.c
@@ -329,7 +329,7 @@ void vte_close(void)
 static gboolean vte_keyrelease_cb(GtkWidget *widget, GdkEventKey *event, gpointer data)
 {
 	if (ui_is_keyval_enter_or_return(event->keyval) ||
-		((event->keyval == GDK_c) && (event->state & GEANY_PRIMARY_MOD_MASK)))
+		((event->keyval == GDK_c) && (event->state & GDK_CONTROL_MASK)))
 	{
 		/* assume any text on the prompt has been executed when pressing Enter/Return */
 		clean = TRUE;
@@ -350,7 +350,7 @@ static gboolean vte_keypress_cb(GtkWidget *widget, GdkEventKey *event, gpointer 
 		event->keyval == GDK_d ||
 		event->keyval == GDK_C ||
 		event->keyval == GDK_D) &&
-		event->state & GEANY_PRIMARY_MOD_MASK &&
+		event->state & GDK_CONTROL_MASK &&
 		! (event->state & GDK_SHIFT_MASK) && ! (event->state & GDK_MOD1_MASK))
 	{
 		vte_restart(widget);


### PR DESCRIPTION
I got VTE "fixed" on OS X:

https://github.com/geany/geany-osx/blob/master/01-vte_fix.diff

and noticed I slightly overdid it with the GDK_CONTROL_MASK
replacement.

While all normal keybindings use the Command key instead of
control key on OS X, all the command-line applications and
terminal emulators use the Ctrl key like on Linux. This includes
Ctrl+C (SIGINT) and Ctrl+D (EOF) for which there is some
special handling in the VTE support in Geany and which should
use GDK_CONTROL_MASK instead of GEANY_PRIMARY_MOD_MASK.