### PR TITLE
Bump API to reflect the addition of keybindings_get_modifiers() and GEANY_PRIMARY_MOD_MASK

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 221
+#define GEANY_API_VERSION 222
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */


### PR DESCRIPTION
There are a few places in plugins these could be used and to
provide a patch I need to bump the required API for them.