### PR TITLE
sciwrappers: Remove a few unused functions

### DIFF
--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -269,12 +269,6 @@ void sci_zoom_off(ScintillaObject *sci)
 }
 
 
-gint sci_get_zoom(ScintillaObject *sci)
-{
-	return (gint) SSM(sci, SCI_GETZOOM, 0, 0);
-}
-
-
 /** Sets a line marker.
  * @param sci Scintilla widget.
  * @param line_number Line number.
@@ -812,12 +806,6 @@ void sci_scroll_caret(ScintillaObject *sci)
 }
 
 
-void sci_scroll_lines(ScintillaObject *sci, gint lines)
-{
-	SSM(sci, SCI_LINESCROLL, 0, lines);
-}
-
-
 void sci_scroll_columns(ScintillaObject *sci, gint columns)
 {
 	SSM(sci, SCI_LINESCROLL, (uptr_t) columns, 0);
@@ -975,12 +963,6 @@ void sci_selection_duplicate(ScintillaObject *sci)
 void sci_insert_text(ScintillaObject *sci, gint pos, const gchar *text)
 {
 	SSM(sci, SCI_INSERTTEXT, (uptr_t) pos, (sptr_t) text);
-}
-
-
-void sci_target_from_selection(ScintillaObject *sci)
-{
-	SSM(sci, SCI_TARGETFROMSELECTION, 0, 0);
 }
 
 
@@ -1236,12 +1218,6 @@ void sci_set_scroll_stop_at_last_line(ScintillaObject *sci, gboolean set)
 void sci_cancel(ScintillaObject *sci)
 {
 	SSM(sci, SCI_CANCEL, 0, 0);
-}
-
-
-gint sci_get_target_end(ScintillaObject *sci)
-{
-	return (gint) SSM(sci, SCI_GETTARGETEND, 0, 0);
 }
 
 

--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -157,7 +157,6 @@ void				sci_use_popup				(ScintillaObject *sci, gboolean enable);
 void				sci_goto_pos				(ScintillaObject *sci, gint pos, gboolean unfold);
 void				sci_set_search_anchor		(ScintillaObject *sci);
 void				sci_set_anchor				(ScintillaObject *sci, gint pos);
-void				sci_scroll_lines			(ScintillaObject *sci, gint lines);
 void				sci_scroll_columns			(ScintillaObject *sci, gint columns);
 gint				sci_search_next				(ScintillaObject *sci, gint flags, const gchar *text);
 gint				sci_search_prev				(ScintillaObject *sci, gint flags, const gchar *text);
@@ -169,13 +168,9 @@ void				sci_assign_cmdkey			(ScintillaObject *sci, gint key, gint command);
 void				sci_selection_duplicate		(ScintillaObject *sci);
 void				sci_line_duplicate			(ScintillaObject *sci);
 
-void				sci_target_from_selection	(ScintillaObject *sci);
-gint				sci_get_target_end			(ScintillaObject *sci);
-
 void				sci_set_keywords			(ScintillaObject *sci, guint k, const gchar *text);
 void				sci_set_lexer				(ScintillaObject *sci, guint lexer_id);
 void				sci_set_readonly			(ScintillaObject *sci, gboolean readonly);
-gint				sci_get_zoom				(ScintillaObject *sci);
 
 gint				sci_get_lines_selected		(ScintillaObject *sci);
 gint				sci_get_first_visible_line	(ScintillaObject *sci);


### PR DESCRIPTION
I PR this because I'm not 100% certain we want to remove sciwrappers we don't use, in case we want to get them back later.  These however looked either not useful at all (`sci_get_zoom`), replaced by other API (`sci_scroll_lines` was replaced with `SETFIRSTVISIBLELINE` calls, and `sci_target_from_selection` was replaced by direct target manipulation), or lacking consistency (`sci_get_target_end` doesn't have a `sci_get_target_start` counterpart).

I did *not* remove `sci_get_position_after` (even though it suffers from the same issue as `sci_get_target_end`) because I think that's something we probably should use in more places, but I didn't research deeper.

Opinions?  Either way it's not very important, these basically just wrap the Scintilla call.