### PR TITLE
Create geany_run_script.sh in the temporary directory instead of the wor...

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3018,8 +3018,9 @@ The Terminal field of the tools preferences tab requires a command to
 execute the terminal program and to pass it the name of the Geany run
 script that it should execute in a Bourne compatible shell (eg /bin/sh).
 The marker "%c" is substituted with the name of the Geany run script,
-which is created in the working directory set in the Build commands
-dialog, see `Build menu commands dialog`_ for details.
+which is created in the temporary directory and which changes the working
+directory to the directory set in the Build commands dialog, see 
+`Build menu commands dialog`_ for details.
 
 As an example the default (Linux) command is::
 


### PR DESCRIPTION
...king directory

Under some conditions, geany_run_script.sh is not deleted and we
have no means to detect this in Geany (e.g. when the terminal emulator
is started correctly but it fails to execute the script for some reason).
In this case it is better to keep the garbage in /tmp than the working
directory. Apart from that, it eliminates potential transfer of the run script
over a NFS and eliminates the visibility of the script in working directory
on Windows.

Apart from that this patch fixes some locale/utf8 conversion problems
and other subtle problems with the previous implementation.

(I ran into this by having "jhbuild shell" inside my .bashrc in which case
the terminal didn't start the run script.)

I'll mark some places in the code which are worth attention - even though
the patch is simple in principle, there are many subtle things which
could go wrong. I hope I fixed some which were there but it is also
possible I introduced some.