### PR TITLE
Always use absolute path when opening projects from command-line

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -932,11 +932,14 @@ static void load_startup_files(gint argc, gchar **argv)
 
 	if (argc > 1 && g_str_has_suffix(argv[1], ".geany"))
 	{
+		gchar *filename = main_get_argv_filename(argv[1]);
+
 		/* project file specified: load it, but decide the session later */
-		main_load_project_from_command_line(argv[1], FALSE);
+		main_load_project_from_command_line(filename, FALSE);
 		argc--, argv++;
 		/* force session load if using project-based session files */
 		load_session = project_prefs.project_session;
+		g_free(filename);
 	}
 
 	/* Load the default session if:


### PR DESCRIPTION
At the moment when geany project is loaded from commandline using
e.g. "geany myproject.geany", the relative path is used by geany
so e.g. Project->Recent Projects shows the relative path instead of
the absolute one (also if the project is already in the list with an absolute
path, additional entry with relative path is created).

Use main_get_argv_filename(), which is already used for ordinary files,
also for opening .geany files.