### PR TITLE
Project open changes

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1429,7 +1429,7 @@
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_project_session">
-                                    <property name="label" translatable="yes">Use project-based session files</property>
+                                    <property name="label" translatable="yes">Use per-project session files</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8513,7 +8513,7 @@
                   <object class="GtkEntry" id="entry_project_dialog_file_patterns">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">Space separated list of file patterns used for the find in files dialog (e.g. *.c *.h)</property>
+                    <property name="tooltip_text" translatable="yes">Space separated list of file patterns used by the find in files dialog and plugins (e.g. *.c *.h)</property>
                     <property name="invisible_char">•</property>
                     <property name="primary_icon_activatable">False</property>
                     <property name="secondary_icon_activatable">True</property>

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1443,22 +1443,6 @@
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="check_project_file_in_basedir">
-                                    <property name="label" translatable="yes">Store project file inside the project base directory</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">When enabled, a project file is stored by default inside the project base directory when creating new projects instead of one directory above the base directory. You can still change the path of the project file in the New Project dialog.</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
                               </object>
                             </child>
                           </object>
@@ -7841,19 +7825,8 @@
                       <object class="GtkMenu" id="menu_project1_menu">
                         <property name="can_focus">False</property>
                         <child>
-                          <object class="GtkImageMenuItem" id="project_new1">
-                            <property name="label" translatable="yes">_New...</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="image">image4077</property>
-                            <property name="use_stock">False</property>
-                            <signal name="activate" handler="on_project_new1_activate" swapped="no"/>
-                          </object>
-                        </child>
-                        <child>
                           <object class="GtkImageMenuItem" id="project_open1">
-                            <property name="label" translatable="yes">_Open...</property>
+                            <property name="label" translatable="yes">_Open as Project...</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="use_underline">True</property>
@@ -8427,7 +8400,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">6</property>
-                <property name="n_rows">5</property>
+                <property name="n_rows">4</property>
                 <property name="n_columns">2</property>
                 <property name="column_spacing">6</property>
                 <property name="row_spacing">6</property>
@@ -8436,7 +8409,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Filename:</property>
+                    <property name="label" translatable="yes">Directory:</property>
                   </object>
                   <packing>
                     <property name="x_options">GTK_FILL</property>
@@ -8466,20 +8439,6 @@
                     <property name="label" translatable="yes">Description:</property>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options">GTK_FILL</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label_project_dialog_base_path">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Base path:</property>
-                  </object>
-                  <packing>
                     <property name="top_attach">3</property>
                     <property name="bottom_attach">4</property>
                     <property name="x_options">GTK_FILL</property>
@@ -8494,8 +8453,8 @@
                     <property name="label" translatable="yes">File patterns:</property>
                   </object>
                   <packing>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
                     <property name="x_options">GTK_FILL</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
@@ -8545,8 +8504,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -8564,13 +8523,13 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="label_project_dialog_filename">
+                  <object class="GtkLabel" id="label_project_dialog_directory">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
@@ -8579,56 +8538,6 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="y_options">GTK_FILL</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkHBox" id="hbox_project_dialog_base_path_entry">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkEntry" id="entry_project_dialog_base_path">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Base directory of all files that make up the project. This can be a new path, or an existing directory tree. You can use paths relative to the project filename.</property>
-                        <property name="invisible_char">•</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="secondary_icon_activatable">True</property>
-                        <property name="primary_icon_sensitive">True</property>
-                        <property name="secondary_icon_sensitive">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="button_project_dialog_base_path">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <child>
-                          <object class="GtkImage" id="image_project_dialog_base_path">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="stock">gtk-open</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>

--- a/plugins/filebrowser.c
+++ b/plugins/filebrowser.c
@@ -1015,18 +1015,7 @@ static void project_change_cb(G_GNUC_UNUSED GObject *obj, G_GNUC_UNUSED GKeyFile
 	if (! fb_set_project_base_path || project == NULL || EMPTY(project->base_path))
 		return;
 
-	/* TODO this is a copy of project_get_base_path(), add it to the plugin API */
-	if (g_path_is_absolute(project->base_path))
-		new_dir = g_strdup(project->base_path);
-	else
-	{	/* build base_path out of project file name's dir and base_path */
-		gchar *dir = g_path_get_dirname(project->file_name);
-
-		new_dir = g_strconcat(dir, G_DIR_SEPARATOR_S, project->base_path, NULL);
-		g_free(dir);
-	}
-	/* get it into locale encoding */
-	SETPTR(new_dir, utils_get_locale_from_utf8(new_dir));
+	new_dir = utils_get_locale_from_utf8(project->base_path);
 
 	if (! utils_str_equal(current_dir, new_dir))
 	{

--- a/src/build.c
+++ b/src/build.c
@@ -757,10 +757,8 @@ static gchar *build_replace_placeholder(const GeanyDocument *doc, const gchar *s
 
 	/* replace %p with the current project's (absolute) base directory */
 	replacement = NULL; /* prevent double free if no replacement found */
-	if (app->project)
-	{
-		replacement = project_get_base_path();
-	}
+	if (app->project && !EMPTY(app->project->base_path))
+		replacement = g_strdup(app->project->base_path);
 	else if (strstr(stack->str, "%p"))
 	{   /* fall back to %d */
 		ui_set_statusbar(FALSE, _("failed to substitute %%p, no project active"));
@@ -2578,8 +2576,9 @@ void build_load_menu(GKeyFile *config, GeanyBuildSource src, gpointer p)
 		case GEANY_BCS_PROJ:
 			if (non_ft_pref == NULL)
 				non_ft_pref = g_new0(GeanyBuildCommand, build_groups_count[GEANY_GBG_NON_FT]);
-			basedir = project_get_base_path();
-			if (basedir == NULL)
+			if (app->project && !EMPTY(app->project->base_path))
+				basedir = g_strdup(app->project->base_path);
+			else
 				basedir = g_strdup("%d");
 			bvalue = g_key_file_get_boolean(config, "project", "make_in_base_path", NULL);
 			if (bvalue)

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1396,12 +1396,6 @@ G_MODULE_EXPORT void on_previous_message1_activate(GtkMenuItem *menuitem, gpoint
 }
 
 
-G_MODULE_EXPORT void on_project_new1_activate(GtkMenuItem *menuitem, gpointer user_data)
-{
-	project_new();
-}
-
-
 G_MODULE_EXPORT void on_project_open1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	project_open();
@@ -1476,7 +1470,7 @@ G_MODULE_EXPORT void on_menu_open_selected_file1_activate(GtkMenuItem *menuitem,
 				app->project != NULL && !EMPTY(app->project->base_path))
 			{
 				/* try the project's base path */
-				SETPTR(path, project_get_base_path());
+				SETPTR(path, g_strdup(app->project->base_path));
 				SETPTR(path, utils_get_locale_from_utf8(path));
 				SETPTR(filename, g_build_path(G_DIR_SEPARATOR_S, path, sel, NULL));
 			}

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -130,8 +130,6 @@ G_MODULE_EXPORT void on_menu_toggle_line_commentation1_activate(GtkMenuItem *men
 
 G_MODULE_EXPORT void on_next_message1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
-G_MODULE_EXPORT void on_project_new1_activate(GtkMenuItem *menuitem, gpointer user_data);
-
 G_MODULE_EXPORT void on_project_open1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 G_MODULE_EXPORT void on_project_close1_activate(GtkMenuItem *menuitem, gpointer user_data);

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -81,6 +81,9 @@ gint dialogs_show_prompt(GtkWidget *parent,
 
 void dialogs_show_msgbox_with_secondary(GtkMessageType type, const gchar *text, const gchar *secondary);
 
+gchar *dialogs_show_open_dialog(GtkFileChooserAction action, const gchar *title, const gchar *initial_path,
+								gboolean create_folders);
+
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -295,8 +295,6 @@ static void init_default_kb(void)
 
 	group = keybindings_get_core_group(GEANY_KEY_GROUP_PROJECT);
 
-	add_kb(group, GEANY_KEYS_PROJECT_NEW, NULL,
-		0, 0, "project_new", _("New"), "project_new1");
 	add_kb(group, GEANY_KEYS_PROJECT_OPEN, NULL,
 		0, 0, "project_open", _("Open"), "project_open1");
 	add_kb(group, GEANY_KEYS_PROJECT_PROPERTIES, NULL,
@@ -1367,9 +1365,6 @@ static gboolean cb_func_project_action(guint key_id)
 {
 	switch (key_id)
 	{
-		case GEANY_KEYS_PROJECT_NEW:
-			on_project_new1_activate(NULL, NULL);
-			break;
 		case GEANY_KEYS_PROJECT_OPEN:
 			on_project_open1_activate(NULL, NULL);
 			break;

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -239,7 +239,6 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_INSERT_LINEBEFORE,				/**< Keybinding. */
 	GEANY_KEYS_DOCUMENT_REMOVE_MARKERS_INDICATORS,	/**< Keybinding. */
 	GEANY_KEYS_PROJECT_OPEN,					/**< Keybinding. */
-	GEANY_KEYS_PROJECT_NEW,						/**< Keybinding. */
 	GEANY_KEYS_PROJECT_CLOSE,					/**< Keybinding. */
 	GEANY_KEYS_FORMAT_JOINLINES,				/**< Keybinding. */
 	GEANY_KEYS_GOTO_LINESTARTVISUAL,			/**< Keybinding. */

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -406,7 +406,6 @@ static void save_dialog_prefs(GKeyFile *config)
 	/* general */
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_load_session", prefs.load_session);
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_project_session", project_prefs.project_session);
-	g_key_file_set_boolean(config, PACKAGE, "pref_main_project_file_in_basedir", project_prefs.project_file_in_basedir);
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_save_winpos", prefs.save_winpos);
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_confirm_exit", prefs.confirm_exit);
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_suppress_status_messages", prefs.suppress_status_messages);
@@ -611,7 +610,7 @@ void configuration_save(void)
 	save_ui_prefs(config);
 	project_save_prefs(config);	/* save project filename, etc. */
 	save_recent_files(config, ui_prefs.recent_queue, "recent_files");
-	save_recent_files(config, ui_prefs.recent_projects_queue, "recent_projects");
+	save_recent_files(config, ui_prefs.recent_projects_queue, "recent_project_dirs");
 
 	if (cl_options.load_session)
 		configuration_save_session_files(config);
@@ -668,7 +667,7 @@ void configuration_load_session_files(GKeyFile *config, gboolean read_recent_fil
 	if (read_recent_files)
 	{
 		load_recent_files(config, ui_prefs.recent_queue, "recent_files");
-		load_recent_files(config, ui_prefs.recent_projects_queue, "recent_projects");
+		load_recent_files(config, ui_prefs.recent_projects_queue, "recent_project_dirs");
 	}
 
 	/* the project may load another list than the main setting */
@@ -753,7 +752,6 @@ static void load_dialog_prefs(GKeyFile *config)
 	prefs.suppress_status_messages = utils_get_setting_boolean(config, PACKAGE, "pref_main_suppress_status_messages", FALSE);
 	prefs.load_session = utils_get_setting_boolean(config, PACKAGE, "pref_main_load_session", TRUE);
 	project_prefs.project_session = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_session", TRUE);
-	project_prefs.project_file_in_basedir = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_file_in_basedir", FALSE);
 	prefs.save_winpos = utils_get_setting_boolean(config, PACKAGE, "pref_main_save_winpos", TRUE);
 	prefs.beep_on_errors = utils_get_setting_boolean(config, PACKAGE, "beep_on_errors", TRUE);
 	prefs.switch_to_status = utils_get_setting_boolean(config, PACKAGE, "switch_msgwin_pages", FALSE);

--- a/src/keyfile.h
+++ b/src/keyfile.h
@@ -54,7 +54,7 @@ void configuration_clear_default_session(void);
 
 void configuration_load_session_files(GKeyFile *config, gboolean read_recent_files);
 
-void configuration_save_session_files(GKeyFile *config);
+void configuration_save_session_files(GKeyFile *config, gboolean project);
 
 /* set some settings which are already read from the config file, but need other things, like the
  * realisation of the main window */

--- a/src/main.c
+++ b/src/main.c
@@ -905,7 +905,7 @@ static void load_startup_files(gint argc, gchar **argv)
 		/* project file specified: load it, but decide the session later */
 		main_load_project_from_command_line(filename, FALSE);
 		argc--, argv++;
-		/* force session load if using project-based session files */
+		/* force session load if using per-project session files */
 		load_session = project_prefs.project_session;
 		g_free(filename);
 	}
@@ -914,7 +914,7 @@ static void load_startup_files(gint argc, gchar **argv)
 	 * 1. "Load files from the last session" is active.
 	 * 2. --no-session is not specified.
 	 * 3. We are a primary instance.
-	 * Has no effect if a CL project is loaded and using project-based session files. */
+	 * Has no effect if a CL project is loaded and using per-project session files. */
 	if (prefs.load_session && cl_options.load_session && !cl_options.new_instance)
 	{
 		if (app->project == NULL)

--- a/src/main.c
+++ b/src/main.c
@@ -898,7 +898,7 @@ static void load_startup_files(gint argc, gchar **argv)
 {
 	gboolean load_session = FALSE;
 
-	if (argc > 1 && g_str_has_suffix(argv[1], ".geany"))
+	if (argc > 1 && g_str_has_suffix(argv[1], GEANY_PROJECT_FILENAME))
 	{
 		gchar *filename = main_get_argv_filename(argv[1]);
 

--- a/src/osx.c
+++ b/src/osx.c
@@ -65,7 +65,7 @@ static gboolean app_open_file_cb(GtkosxApplication *osx_app, gchar *path, gpoint
 		g_free(cwd);
 	}
 
-	if (g_str_has_suffix(path, ".geany"))
+	if (g_str_has_suffix(path, GEANY_PROJECT_FILENAME))
 	{
 		g_idle_add((GSourceFunc)open_project_idle, locale_path);
 		opened = TRUE;

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -412,9 +412,6 @@ static void prefs_init_dialog(void)
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_project_session");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), project_prefs.project_session);
 
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_project_file_in_basedir");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), project_prefs.project_file_in_basedir);
-
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_save_win_pos");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), prefs.save_winpos);
 
@@ -894,9 +891,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_project_session");
 		project_prefs.project_session = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_project_file_in_basedir");
-		project_prefs.project_file_in_basedir = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_save_win_pos");
 		prefs.save_winpos = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));

--- a/src/project.c
+++ b/src/project.c
@@ -823,7 +823,9 @@ void project_load_prefs(GKeyFile *config)
 		"project_file_path", NULL);
 	if (local_prefs.project_file_path == NULL)
 	{
-		local_prefs.project_file_path = g_build_filename(g_get_home_dir(), PROJECT_DIR, NULL);
+		gchar *utf8_dir = utils_get_utf8_from_locale(g_get_home_dir());
+		local_prefs.project_file_path = g_build_filename(utf8_dir, PROJECT_DIR, NULL);
+		g_free(utf8_dir);
 	}
 }
 

--- a/src/project.c
+++ b/src/project.c
@@ -765,7 +765,7 @@ static gboolean write_config(gboolean emit_signal)
 
 	/* store the session files into the project too */
 	if (project_prefs.project_session)
-		configuration_save_session_files(config);
+		configuration_save_session_files(config, TRUE);
 	build_save_menu(config, (gpointer)p, GEANY_BCS_PROJ);
 	if (emit_signal)
 	{

--- a/src/project.h
+++ b/src/project.h
@@ -28,7 +28,7 @@
 G_BEGIN_DECLS
 
 #define GEANY_PROJECT_FILENAME				"project.geany"
-
+#define GEANY_PROJECT_SESSION_FILENAME		"geany_session.conf"
 
 /** Structure for representing a project. */
 typedef struct GeanyProject

--- a/src/project.h
+++ b/src/project.h
@@ -27,7 +27,7 @@
 
 G_BEGIN_DECLS
 
-#define GEANY_PROJECT_EXT				"geany"
+#define GEANY_PROJECT_FILENAME				"project.geany"
 
 
 /** Structure for representing a project. */
@@ -36,7 +36,7 @@ typedef struct GeanyProject
 	gchar *name; 			/**< The name of the project. */
 	gchar *description; 	/**< Short description of the project. */
 	gchar *file_name; 		/**< Where the project file is stored (in UTF-8). */
-	gchar *base_path;		/**< Base path of the project directory (in UTF-8, maybe relative). */
+	gchar *base_path;		/**< Base path of the project directory (in UTF-8, absolute). */
 	/** Identifier whether it is a pure Geany project or modified/extended
 	 * by a plugin. */
 	gint type;
@@ -56,7 +56,6 @@ typedef struct ProjectPrefs
 {
 	gchar *session_file;
 	gboolean project_session;
-	gboolean project_file_in_basedir;
 } ProjectPrefs;
 
 extern ProjectPrefs project_prefs;
@@ -66,8 +65,6 @@ void project_init(void);
 
 void project_finalize(void);
 
-
-void project_new(void);
 
 void project_open(void);
 
@@ -83,8 +80,6 @@ gboolean project_ask_close(void);
 gboolean project_load_file(const gchar *locale_file_name);
 
 gboolean project_load_file_with_session(const gchar *locale_file_name);
-
-gchar *project_get_base_path(void);
 
 
 const struct GeanyFilePrefs *project_get_file_prefs(void);

--- a/src/project.h
+++ b/src/project.h
@@ -27,7 +27,7 @@
 
 G_BEGIN_DECLS
 
-#define GEANY_PROJECT_FILENAME				"project.geany"
+#define GEANY_PROJECT_FILENAME				"geany_project.geany"
 #define GEANY_PROJECT_SESSION_FILENAME		"geany_session.conf"
 
 /** Structure for representing a project. */

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -362,16 +362,14 @@ static gboolean utils_filename_has_prefix(const gchar *str, const gchar *prefix)
 static gchar *get_doc_folder(const gchar *path)
 {
 	gchar *tmp_dirname = g_strdup(path);
-	gchar *project_base_path;
 	gchar *dirname = NULL;
 	const gchar *home_dir = g_get_home_dir();
 	const gchar *rest;
 
 	/* replace the project base path with the project name */
-	project_base_path = project_get_base_path();
-
-	if (project_base_path != NULL)
+	if (app->project && !EMPTY(app->project->base_path))
 	{
+		gchar *project_base_path = g_strdup(app->project->base_path);
 		gsize len = strlen(project_base_path);
 
 		/* remove trailing separator so we can match base path exactly */

--- a/src/socket.c
+++ b/src/socket.c
@@ -573,7 +573,7 @@ static void handle_input_filename(const gchar *buf)
 	locale_filename = utils_get_locale_from_utf8(utf8_filename);
 	if (locale_filename)
 	{
-		if (g_str_has_suffix(locale_filename, ".geany"))
+		if (g_str_has_suffix(locale_filename, GEANY_PROJECT_FILENAME))
 		{
 			if (project_ask_close())
 				main_load_project_from_command_line(locale_filename, TRUE);

--- a/src/win32.h
+++ b/src/win32.h
@@ -48,11 +48,8 @@ gboolean win32_message_dialog(GtkWidget *parent, GtkMessageType type, const gcha
 
 void win32_open_browser(const gchar *uri);
 
-gchar *win32_show_project_open_dialog(GtkWidget *parent, const gchar *title,
-								      const gchar *initial_dir, gboolean allow_new_file,
-								      gboolean project_file_filter);
-
-gchar *win32_show_folder_dialog(GtkWidget *parent, const gchar *title, const gchar *initial_dir);
+gchar *win32_show_folder_dialog(GtkWidget *parent, const gchar *title, const gchar *initial_dir,
+								gboolean create_folders);
 
 gint win32_check_write_permission(const gchar *dir);
 


### PR DESCRIPTION
Beware, possibly controversial patch! (feature removal)

I've been long dissatisfied with how painful project creation in Geany is. I often
download some source I want to look at which is in Downloads (and want a project
so I can use my ProjectOrganizer plugin to index it all for better navigation).
The steps I have to do:
1. Project->New
2. Type the name. At this point the project file and base directory paths are
   wrong because they point to the "projects" directory where I have my projects
3. Browse for the folder in "Filename" and enter project name (note: unfortunately
   users can give arbitrary extension to their project files which is then filtered-out when
   opening project)
4. Copy/paste the path portion of "Filename" to "Base Path". (I remember I was
   really confused as a newcomer to Geany about what "base path" is)
5. Click Create.
6. Customize project properties by going to Project->Properties

I think I found a much simpler and less confusing way but it requires one thing:
eliminating the possibility to have base path somewhere else than the project
file. If the base path is equal to the path where the project file is stored
and if the project file has always the same name, e.g. "project.geany", we can
reduce project creation and opening to simple directory opening. If the project
file is found in the path, the existing project is opened; otherwise a new
project is created. Because users usually want to customize the project settings
upon project creation, the project properties dialog can be poped up automatically
(which is also a good feedback for users that a new project was created rather
than existing project opened).

Here's the project creation procedure with this new approach:
1. Project->Open as Project...
2. Select a directory to open as project.
3. Project Properties dialog shows. The project name is prefilled with the last
   directory component (which usually corresponds to the project name). It has focus
   so users can easily change the name immediately.

No copy/paste, no base directory definition, no project file name definition.

Recent projects are displayed as directories (no need to have the "project.geany"
suffix).

Last, having base path identical to project path makes it possible to finally
fix the rather embarrassing bug where projects cannot be moved to other directory
without breaking the paths because all the paths inside are absolute. Now we
don't have to fear that the base path is changed by the user and can use
relative paths for open tabs.

Backward compatibility:
In principle, all has to be done with existing projects is they have to be renamed
to project.geany and placed to the base directory. We can do this patially by
ourselves if when opening a project there's no project.geany and we find
other *.geany in the directory. People who used base path different from project
path have to do this manually though.

Forward compatibility:
The patch still saves base_path to the project file (even though it never reads it)
so old Geany versions have the base_path information. Open tabs, however, will be
lost because old Geany versions won't know how to interpret the relative paths.

TODO:
docs - I think it would be best to just completely eliminate the phrase "base path" 
and use "project path" insted. And of course cover the rest of the changes.

The bad:
- There may be people who liked having the possibility to have the project file
  outside the project tree. In my opinion this isn't a big issue in the times of
  .gitignore files and similar but I would expect some "you screwed up Geany by
  removing this feature" feedback.
- People might not read the release notes that they should rename the project
  file to project.geany and move it to base path so there may be some confusion
  around this.

So @b4n @eht16 @ntrel @frlan @codebrainz @elextr @kugel-  what's your
opinion? I'm aware feature removal is always problematic but in this case I
think it's worth it (I've already talked about this change with Enrico
and Frank and they didn't seem to be completely against this idea).
