### PR TITLE
If project is open, use base_path as a search path in find in files

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1393,6 +1393,21 @@
                                     <property name="position">3</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="check_fif_project_base_dir">
+                                    <property name="label" translatable="yes">Use the project's base directory for Find in Files for projects</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">4</property>
+                                  </packing>
+                                </child>
                               </object>
                             </child>
                           </object>

--- a/src/search.c
+++ b/src/search.c
@@ -196,6 +196,8 @@ static void init_prefs(void)
 		"pref_search_always_wrap", FALSE, "check_hide_find_dialog");
 	stash_group_add_toggle_button(group, &search_prefs.use_current_file_dir,
 		"pref_search_current_file_dir", TRUE, "check_fif_current_dir");
+	stash_group_add_toggle_button(group, &search_prefs.use_project_base_dir,
+		"pref_search_project_base_dir", FALSE, "check_fif_project_base_dir");
 	stash_group_add_boolean(group, &find_dlg.all_expanded, "find_all_expanded", FALSE);
 	stash_group_add_boolean(group, &replace_dlg.all_expanded, "replace_all_expanded", FALSE);
 	/* dialog positions */
@@ -1078,6 +1080,8 @@ void search_show_find_in_files_dialog_full(const gchar *text, const gchar *dir)
 	entry = gtk_bin_get_child(GTK_BIN(fif_dlg.dir_combo));
 	if (!EMPTY(dir))
 		cur_dir = g_strdup(dir);	/* custom directory argument passed */
+	else if (search_prefs.use_project_base_dir && app->project && !EMPTY(app->project->base_path))
+		cur_dir = project_get_base_path();
 	else
 	{
 		if (search_prefs.use_current_file_dir)

--- a/src/search.h
+++ b/src/search.h
@@ -59,6 +59,7 @@ typedef struct GeanySearchPrefs
 	gboolean	hide_find_dialog;		/* hide the find dialog on next or previous */
 	gboolean	replace_and_find_by_default;	/* enter in replace window performs Replace & Find instead of Replace */
 	enum GeanyFindSelOptions find_selection_type;
+	gboolean	use_project_base_dir;	/* use project base directory for find in files */
 }
 GeanySearchPrefs;
 


### PR DESCRIPTION
When project is not open, we have to make some guess where to search
(document's directory or the directory from which Geany was started).

With project open, the answer to the question "in which files to search?"
seems to be obvious - the project ones. Do so.

I do this already in my ProjectOrganizer plugin but this leads to some unnecessary duplication of
functionality (there's an extra menu entry for that and special keybindings). Especially with the keybindings it's a little stupid because there have to be 2 different keybindings - one for normal "find in files" and one for "find in project files" (I have Ctrl+Shift+F for "find in project files" and when project is closed, I'm always surprised it does nothing). I could eliminate the duplication with this patch.
