### PR TITLE
Grab focus of the "arm" button in the gtk-bandit

### DIFF
--- a/src/gb.c
+++ b/src/gb.c
@@ -145,7 +145,7 @@ static void create_window(GtkWindow *parent)
 	g_signal_connect(button4, "clicked", G_CALLBACK(help_clicked_cb), parent);
 	g_signal_connect(button5, "clicked", G_CALLBACK(close_clicked_cb), NULL);
 
-	gtk_widget_grab_focus(button4);
+	gtk_widget_grab_focus(button1);
 }
 
 


### PR DESCRIPTION
It's not immediately obvious this is a button so emphasize it a bit.
This also makes it easier to start playing using just the keyboard (which
all the professional gtk-bandit gamers do). Nobody will use Geany for
text editing any more after this change!