### PR TITLE
waf: Disable build/install phase interleaving

### DIFF
--- a/wscript
+++ b/wscript
@@ -599,6 +599,9 @@ def build(bld):
                                'top_builddir': bld.out_dir,
                                'top_srcdir': bld.top_dir,})
 
+    # disable build/install phase interleaving
+    bld.add_group()
+
     ###
     # Install files
     ###


### PR DESCRIPTION
When doing "./waf install" and some source files are modified
so they need to be rebuilt, the build and install phase can be
interleaved so one thread is still performing build while other
thread is already performing install tasks.

This appears to be a problem (at least on OS X) when some of
the Geany plugins are still being built and libgeany is already
being installed in parallel.

Create a separate group for the install phase to eliminate the
problem.

This is what I get without the patch:

```
...
[325/338] cshlib: _build_/plugins/splitwindow.c.14.o -> _build_/splitwindow.so
[325/338] cshlib: _build_/plugins/filebrowser.c.11.o -> _build_/filebrowser.so
+ install /Users/jhbuild/gtk/inst/lib/libgeany.0.0.0.dylib (from _build_/libgeany.dylib)
[327/338] cshlib: _build_/plugins/saveactions.c.13.o -> _build_/saveactions.so
[328/338] cshlib: _build_/plugins/htmlchars.c.12.o -> _build_/htmlchars.so
[329/338] cxxprogram: _build_/src/main.c.7.o -> _build_/geany
[328/338] cshlib: _build_/plugins/classbuilder.c.8.o -> _build_/classbuilder.so
[329/338] cshlib: _build_/plugins/demoplugin.c.9.o -> _build_/demoplugin.so
ld: mach-o string pool extends beyond end of file in /Users/jhbuild/gtk/inst/lib/libgeany.dylib file '/Users/jhbuild/gtk/inst/lib/libgeany.dylib' for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ld: mach-o string pool extends beyond end of file in /Users/jhbuild/gtk/inst/lib/libgeany.dylib file '/Users/jhbuild/gtk/inst/lib/libgeany.dylib' for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ld: mach-o string pool extends beyond end of file in /Users/jhbuild/gtk/inst/lib/libgeany.dylib file '/Users/jhbuild/gtk/inst/lib/libgeany.dylib' for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ld: mach-o string pool extends beyond end of file in /Users/jhbuild/gtk/inst/lib/libgeany.dylib file '/Users/jhbuild/gtk/inst/lib/libgeany.dylib' for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ld: mach-o string pool extends beyond end of file in /Users/jhbuild/gtk/inst/lib/libgeany.dylib file '/Users/jhbuild/gtk/inst/lib/libgeany.dylib' for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ld: mach-o string pool extends beyond end of file in /Users/jhbuild/gtk/inst/lib/libgeany.dylib file '/Users/jhbuild/gtk/inst/lib/libgeany.dylib' for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ld: mach-o string pool extends beyond end of file in /Users/jhbuild/gtk/inst/lib/libgeany.dylib file '/Users/jhbuild/gtk/inst/lib/libgeany.dylib' for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Waf: Leaving directory `/Users/jhbuild/geany/_build_'
Build failed
-> task in 'splitwindow' failed (exit status 1): 
	{task 4416428368: cshlib splitwindow.c.14.o -> splitwindow.so}
['/Applications/Xcode.app/Contents/Developer/usr/bin/gcc', '-L/Users/jhbuild/gtk/inst/lib', '-L/Users/jhbuild/gtk/inst/lib', '-arch', 'x86_64', '-L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/lib', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk', '-mmacosx-version-min=10.7', '-Wl,-headerpad_max_install_names', '-L/Users/jhbuild/gtk/inst/lib', '-L/Users/jhbuild/gtk/inst/lib', '-arch', 'x86_64', '-L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/usr/lib', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk', '-mmacosx-version-min=10.7', '-Wl,-headerpad_max_install_names', '-dynamiclib', '-Wl,-compatibility_version,1', '-Wl,-current_version,1', 'plugins/splitwindow.c.14.o', '-o', '/Users/jhbuild/geany/_build_/splitwindow.so', '-L.', '-L/Users/jhbuild/gtk/inst/lib', '-L/Users/jhbuild/gtk/inst/lib', '-L/Users/jhbuild/gtk/inst/lib', '-lgeany', '-lgtk-quartz-2.0', '-lgdk-quartz-2.0', '-lpangocairo-1.0', '-lpango-1.0', '-latk-1.0', '-lcairo', '-lgdk_pixbuf-2.0', '-lgio-2.0', '-lgobject-2.0', '-lglib-2.0', '-lintl', '-lglib-2.0', '-lintl', '-lgmodule-2.0', '-lglib-2.0', '-lintl']
 -> task in 'filebrowser' failed (exit status 1): 
... etc. for the rest of the plugins
```