### PR TITLE
Remove deprecated and unnecessary use of GeanyFunctions declaration

### DIFF
--- a/plugins/classbuilder.c
+++ b/plugins/classbuilder.c
@@ -29,7 +29,6 @@
 #include "geanyplugin.h"
 
 GeanyData		*geany_data;
-GeanyFunctions	*geany_functions;
 
 
 PLUGIN_VERSION_CHECK(GEANY_API_VERSION)

--- a/plugins/demoplugin.c
+++ b/plugins/demoplugin.c
@@ -39,7 +39,6 @@
 /* These items are set by Geany before plugin_init() is called. */
 GeanyPlugin		*geany_plugin;
 GeanyData		*geany_data;
-GeanyFunctions	*geany_functions;
 
 
 /* Check that the running Geany supports the plugin API version used below, and check

--- a/plugins/export.c
+++ b/plugins/export.c
@@ -32,7 +32,6 @@
 
 
 GeanyData		*geany_data;
-GeanyFunctions	*geany_functions;
 
 PLUGIN_VERSION_CHECK(GEANY_API_VERSION)
 PLUGIN_SET_INFO(_("Export"), _("Exports the current file into different formats."), VERSION,

--- a/plugins/filebrowser.c
+++ b/plugins/filebrowser.c
@@ -43,7 +43,6 @@
 
 GeanyPlugin *geany_plugin;
 GeanyData *geany_data;
-GeanyFunctions *geany_functions;
 
 
 PLUGIN_VERSION_CHECK(GEANY_API_VERSION)

--- a/plugins/htmlchars.c
+++ b/plugins/htmlchars.c
@@ -32,7 +32,6 @@
 
 
 GeanyData		*geany_data;
-GeanyFunctions	*geany_functions;
 
 
 PLUGIN_VERSION_CHECK(GEANY_API_VERSION)

--- a/plugins/saveactions.c
+++ b/plugins/saveactions.c
@@ -36,7 +36,6 @@
 
 GeanyPlugin		*geany_plugin;
 GeanyData		*geany_data;
-GeanyFunctions	*geany_functions;
 
 
 PLUGIN_VERSION_CHECK(GEANY_API_VERSION)

--- a/plugins/splitwindow.c
+++ b/plugins/splitwindow.c
@@ -36,7 +36,6 @@ PLUGIN_SET_INFO(_("Split Window"), _("Splits the editor view into two windows.")
 
 
 GeanyData		*geany_data;
-GeanyFunctions	*geany_functions;
 GeanyPlugin		*geany_plugin;
 
 


### PR DESCRIPTION
Currently build breaks when using -DGEANY_DISABLE_DEPRECATED because the internal plugins still use the deprecated GeanyFunctions declaration.

To be honest, I didn't follow all the recent plugin API/infrastructure changes closely. So the suggested solution to fix the build with -DGEANY_DISABLE_DEPRECATED might be wrong or unsufficient.
Hence this PR.