### PR TITLE
waf: explicitly set the location of signallist.i and geany.html in the b...

### DIFF
--- a/wscript
+++ b/wscript
@@ -477,7 +477,7 @@ def build(bld):
     # signallist.i
     bld(
         source  = 'data/geany.glade',
-        target  = 'src/signallist.i',
+        target  = bld.path.get_bld().make_node('src/signallist.i'),
         name    = 'signallist.i',
         rule    = gen_signallist)
 
@@ -536,7 +536,7 @@ def build(bld):
         bld(
             source  = ['doc/geany.txt'],
             deps    = ['doc/geany.css'],
-            target  = 'doc/geany.html',
+            target  = bld.path.get_bld().make_node('doc/geany.html'),
             name    = 'geany.html',
             cwd     = os.path.join(bld.path.abspath(), 'doc'),
             rule    = '%s  -stg --stylesheet=geany.css geany.txt %s' % (rst2html, html_doc_filename))


### PR DESCRIPTION
...uild tree

On OS X signallist.i is always rebuilt because waf looks for it in the build
tree but generates it inside the source tree for some reason so it's
always missing in the build tree. Set the target explicitly to the
build tree to fix the problem.

Similarly, set the target for geany.html to the build tree. Thanks to this
waf also creates the 'doc' directory in the build tree which is otherwise
missing and the cwd command fails for this reason (e.g. when the
_build_ directory is removed).

These two task generators are the only ones that don't use the 'features'
parameter - the features in the other task generators should already
handle the source/build tree problems for us (see the Waf Book section
6.3.3. Nodes, tasks, and task generators).

No idea why it behaves differently on OS X and Linux though...

@eht16 Does it look OK to you?

Fixes #463 