### PR TITLE
fix basic callbacks to work with splitwindow

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -228,16 +228,13 @@ void on_redo1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 void on_cut1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	GeanyDocument *doc = document_get_current();
 	GtkWidget *focusw = gtk_window_get_focus(GTK_WINDOW(main_widgets.window));
 
 	if (GTK_IS_EDITABLE(focusw))
 		gtk_editable_cut_clipboard(GTK_EDITABLE(focusw));
-	else
-	if (IS_SCINTILLA(focusw) && doc != NULL)
-		sci_cut(doc->editor->sci);
-	else
-	if (GTK_IS_TEXT_VIEW(focusw))
+	else if (IS_SCINTILLA(focusw))
+		sci_cut(SCINTILLA(focusw));
+	else if (GTK_IS_TEXT_VIEW(focusw))
 	{
 		GtkTextBuffer *buffer = gtk_text_view_get_buffer(
 			GTK_TEXT_VIEW(focusw));
@@ -248,16 +245,13 @@ void on_cut1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 void on_copy1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	GeanyDocument *doc = document_get_current();
 	GtkWidget *focusw = gtk_window_get_focus(GTK_WINDOW(main_widgets.window));
 
 	if (GTK_IS_EDITABLE(focusw))
 		gtk_editable_copy_clipboard(GTK_EDITABLE(focusw));
-	else
-	if (IS_SCINTILLA(focusw) && doc != NULL)
-		sci_copy(doc->editor->sci);
-	else
-	if (GTK_IS_TEXT_VIEW(focusw))
+	else if (IS_SCINTILLA(focusw))
+		sci_copy(SCINTILLA(focusw));
+	else if (GTK_IS_TEXT_VIEW(focusw))
 	{
 		GtkTextBuffer *buffer = gtk_text_view_get_buffer(
 			GTK_TEXT_VIEW(focusw));
@@ -268,18 +262,13 @@ void on_copy1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 void on_paste1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	GeanyDocument *doc = document_get_current();
 	GtkWidget *focusw = gtk_window_get_focus(GTK_WINDOW(main_widgets.window));
 
 	if (GTK_IS_EDITABLE(focusw))
 		gtk_editable_paste_clipboard(GTK_EDITABLE(focusw));
-	else
-	if (IS_SCINTILLA(focusw) && doc != NULL)
-	{
-		sci_paste(doc->editor->sci);
-	}
-	else
-	if (GTK_IS_TEXT_VIEW(focusw))
+	else if (IS_SCINTILLA(focusw))
+		sci_paste(SCINTILLA(focusw));
+	else if (GTK_IS_TEXT_VIEW(focusw))
 	{
 		GtkTextBuffer *buffer = gtk_text_view_get_buffer(
 			GTK_TEXT_VIEW(focusw));
@@ -291,16 +280,13 @@ void on_paste1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 void on_delete1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	GeanyDocument *doc = document_get_current();
 	GtkWidget *focusw = gtk_window_get_focus(GTK_WINDOW(main_widgets.window));
 
 	if (GTK_IS_EDITABLE(focusw))
 		gtk_editable_delete_selection(GTK_EDITABLE(focusw));
-	else
-	if (IS_SCINTILLA(focusw) && doc != NULL && sci_has_selection(doc->editor->sci))
-		sci_clear(doc->editor->sci);
-	else
-	if (GTK_IS_TEXT_VIEW(focusw))
+	else if (IS_SCINTILLA(focusw) && sci_has_selection(SCINTILLA(focusw)))
+		sci_clear(SCINTILLA(focusw));
+	else if (GTK_IS_TEXT_VIEW(focusw))
 	{
 		GtkTextBuffer *buffer = gtk_text_view_get_buffer(
 			GTK_TEXT_VIEW(focusw));
@@ -1200,10 +1186,10 @@ void on_print1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 void on_menu_select_all1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	GeanyDocument *doc = document_get_current();
-	g_return_if_fail(doc != NULL);
+	GtkWidget *focusw = gtk_window_get_focus(GTK_WINDOW(main_widgets.window));
+	g_return_if_fail(IS_SCINTILLA(focusw));
 
-	sci_select_all(doc->editor->sci);
+	sci_select_all(SCINTILLA(focusw));
 }
 
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1187,9 +1187,27 @@ void on_print1_activate(GtkMenuItem *menuitem, gpointer user_data)
 void on_menu_select_all1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	GtkWidget *focusw = gtk_window_get_focus(GTK_WINDOW(main_widgets.window));
-	g_return_if_fail(IS_SCINTILLA(focusw));
 
-	sci_select_all(SCINTILLA(focusw));
+	/* special case for Select All in the scribble widget */
+	if (focusw == msgwindow.scribble)
+	{
+		g_signal_emit_by_name(msgwindow.scribble, "select-all", TRUE);
+	}
+	/* special case for Select All in the VTE widget */
+#ifdef HAVE_VTE
+	else if (vte_info.have_vte && focusw == vc->vte)
+	{
+		vte_select_all();
+	}
+#endif
+	else if (GTK_IS_EDITABLE(focusw))
+	{
+		gtk_editable_select_region(GTK_EDITABLE(focusw), 0, -1);
+	}
+	else if (IS_SCINTILLA(focusw))
+	{
+		sci_select_all(SCINTILLA(focusw));
+	}
 }
 
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1831,10 +1831,7 @@ static void goto_matching_brace(GeanyDocument *doc)
 
 static gboolean cb_func_clipboard_action(guint key_id)
 {
-	GeanyDocument *doc = document_get_current();
-
-	if (doc == NULL)
-		return TRUE;
+	GtkWidget *focusw = gtk_window_get_focus(GTK_WINDOW(main_widgets.window));
 
 	switch (key_id)
 	{
@@ -1848,10 +1845,12 @@ static gboolean cb_func_clipboard_action(guint key_id)
 			on_paste1_activate(NULL, NULL);
 			break;
 		case GEANY_KEYS_CLIPBOARD_COPYLINE:
-			sci_send_command(doc->editor->sci, SCI_LINECOPY);
+			if (IS_SCINTILLA(focusw))
+				sci_send_command(SCINTILLA(focusw), SCI_LINECOPY);
 			break;
 		case GEANY_KEYS_CLIPBOARD_CUTLINE:
-			sci_send_command(doc->editor->sci, SCI_LINECUT);
+			if (IS_SCINTILLA(focusw))
+				sci_send_command(SCINTILLA(focusw), SCI_LINECUT);
 			break;
 	}
 	return TRUE;

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -2358,46 +2358,11 @@ static gboolean cb_func_format_action(guint key_id)
 }
 
 
-/* common function for select keybindings, only valid when scintilla has focus. */
+/* common function for select keybindings, valid for scintilla and/or gtk_editable objects. */
 static gboolean cb_func_select_action(guint key_id)
 {
-	GeanyDocument *doc;
-	ScintillaObject *sci;
+	GeanyDocument *doc = document_get_current();
 	GtkWidget *focusw = gtk_window_get_focus(GTK_WINDOW(main_widgets.window));
-	GtkWidget *toolbar_search_entry = toolbar_get_widget_child_by_name("SearchEntry");
-	GtkWidget *toolbar_goto_entry = toolbar_get_widget_child_by_name("GotoEntry");
-
-	/* special case for Select All in the scribble widget */
-	if (key_id == GEANY_KEYS_SELECT_ALL && focusw == msgwindow.scribble)
-	{
-		g_signal_emit_by_name(msgwindow.scribble, "select-all", TRUE);
-		return TRUE;
-	}
-	/* special case for Select All in the VTE widget */
-#ifdef HAVE_VTE
-	else if (key_id == GEANY_KEYS_SELECT_ALL && vte_info.have_vte && focusw == vc->vte)
-	{
-		vte_select_all();
-		return TRUE;
-	}
-#endif
-	/* special case for Select All in the toolbar search widget */
-	else if (key_id == GEANY_KEYS_SELECT_ALL && focusw == toolbar_search_entry)
-	{
-		gtk_editable_select_region(GTK_EDITABLE(toolbar_search_entry), 0, -1);
-		return TRUE;
-	}
-	else if (key_id == GEANY_KEYS_SELECT_ALL && focusw == toolbar_goto_entry)
-	{
-		gtk_editable_select_region(GTK_EDITABLE(toolbar_goto_entry), 0, -1);
-		return TRUE;
-	}
-
-	doc = document_get_current();
-	/* keybindings only valid when scintilla widget has focus */
-	if (doc == NULL || focusw != GTK_WIDGET(doc->editor->sci))
-		return TRUE;
-	sci = doc->editor->sci;
 
 	switch (key_id)
 	{
@@ -2405,19 +2370,24 @@ static gboolean cb_func_select_action(guint key_id)
 			on_menu_select_all1_activate(NULL, NULL);
 			break;
 		case GEANY_KEYS_SELECT_WORD:
-			editor_select_word(doc->editor);
+			if (doc != NULL)
+				editor_select_word(doc->editor);
 			break;
 		case GEANY_KEYS_SELECT_LINE:
-			editor_select_lines(doc->editor, FALSE);
+			if (doc != NULL)
+				editor_select_lines(doc->editor, FALSE);
 			break;
 		case GEANY_KEYS_SELECT_PARAGRAPH:
-			editor_select_paragraph(doc->editor);
+			if (doc != NULL)
+				editor_select_paragraph(doc->editor);
 			break;
 		case GEANY_KEYS_SELECT_WORDPARTLEFT:
-			sci_send_command(sci, SCI_WORDPARTLEFTEXTEND);
+			if (IS_SCINTILLA(focusw))
+				sci_send_command(SCINTILLA(focusw), SCI_WORDPARTLEFTEXTEND);
 			break;
 		case GEANY_KEYS_SELECT_WORDPARTRIGHT:
-			sci_send_command(sci, SCI_WORDPARTRIGHTEXTEND);
+			if (IS_SCINTILLA(focusw))
+				sci_send_command(SCINTILLA(focusw), SCI_WORDPARTRIGHTEXTEND);
 			break;
 	}
 	return TRUE;


### PR DESCRIPTION
This fixes callbacks for: cut, paste, copy, delete, select-all to function correctly with the built-in splitwindow plugin. https://github.com/geany/geany/issues/460
