### PR TITLE
Compile prefix.c and osx.c only when needed to avoid warnings

### DIFF
--- a/m4/geany-binreloc.m4
+++ b/m4/geany-binreloc.m4
@@ -52,9 +52,11 @@ AC_DEFUN([GEANY_CHECK_BINRELOC],
 		AC_MSG_RESULT([no (unknown value "$enable_binreloc")])
 		enable_binreloc=no
 	fi
-	if test "$enable_binreloc" = "yes"; then
+	AM_CONDITIONAL(ENABLE_BINRELOC, [test "$enable_binreloc" = "yes"])
+	AM_COND_IF(ENABLE_BINRELOC,
+	[
 		AC_DEFINE([ENABLE_BINRELOC],,[Use AutoPackage?])
-	fi
+	])
 
 	GEANY_STATUS_ADD([Enable binary relocation], [$enable_binreloc])
 ])

--- a/m4/geany-mac-integration.m4
+++ b/m4/geany-mac-integration.m4
@@ -9,7 +9,8 @@ AC_DEFUN([GEANY_CHECK_MAC_INTEGRATION],
 			[geany_enable_mac_integration="$enableval"],
 			[geany_enable_mac_integration="no"])
 
-	AS_IF([test "x$geany_enable_mac_integration" = "xyes"],
+	AM_CONDITIONAL(ENABLE_MAC_INTEGRATION, [test "x$geany_enable_mac_integration" = "xyes"])
+	AM_COND_IF(ENABLE_MAC_INTEGRATION,
 	[
 		AS_IF([test "x$enable_gtk3" = xyes],
 			[PKG_CHECK_MODULES(MAC_INTEGRATION, gtk-mac-integration-gtk3)], 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,10 +81,8 @@ libgeany_la_SOURCES = \
 	msgwindow.c msgwindow.h \
 	navqueue.c navqueue.h \
 	notebook.c notebook.h \
-	osx.c osx.h \
 	plugins.c plugins.h \
 	pluginutils.c pluginutils.h \
-	prefix.c prefix.h \
 	prefs.c prefs.h \
 	printing.c printing.h \
 	project.c project.h \
@@ -100,6 +98,14 @@ libgeany_la_SOURCES = \
 	sidebar.c sidebar.h \
 	ui_utils.c ui_utils.h \
 	utils.c utils.h
+
+if ENABLE_BINRELOC
+libgeany_la_SOURCES += prefix.c prefix.h
+endif
+
+if ENABLE_MAC_INTEGRATION
+libgeany_la_SOURCES += osx.c osx.h
+endif
 
 libgeany_la_CFLAGS  = $(AM_CPPFLAGS) @LIBGEANY_CFLAGS@
 libgeany_la_LDFLAGS = @LIBGEANY_LDFLAGS@


### PR DESCRIPTION
When mac integration or binary relocation are disabled, the compiled
object file contains no symbols because the guards in the source files
hide all code. On OS X there's a warning during compilation saying:

/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib:
file: .libs/libgeany.a(libgeany_la-prefix.o) has no symbols

If these features are disabled, don't compile the corresponding
sources to avoid the warnings.

Interestingly, waf compilation works without warnings - it appears
linking is done through g++ which doesn't produce these warnings.