### PR TITLE
Reload tooltip in the symbol tree also on tag update

### DIFF
--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -192,6 +192,9 @@ void sidebar_update_tag_list(GeanyDocument *doc, gboolean update)
 
 	g_return_if_fail(doc == NULL || doc->is_valid);
 
+	if (gtk_notebook_get_current_page(GTK_NOTEBOOK(main_widgets.sidebar_notebook)) != TREEVIEW_SYMBOL)
+		return; /* don't bother updating symbol tree if we don't see it */
+
 	/* changes the tree view to the given one, trying not to do useless changes */
 	#define CHANGE_TREE(new_child) \
 		G_STMT_START { \
@@ -1081,6 +1084,14 @@ static void on_save_settings(void)
 }
 
 
+static void on_sidebar_switch_page(GtkNotebook *notebook,
+	gpointer page, guint page_num, gpointer user_data)
+{
+	if (page_num == TREEVIEW_SYMBOL)
+		sidebar_update_tag_list(document_get_current(), TRUE);
+}
+
+
 void sidebar_init(void)
 {
 	StashGroup *group;
@@ -1103,6 +1114,8 @@ void sidebar_init(void)
 	/* tabs may have changed when sidebar is reshown */
 	g_signal_connect(main_widgets.sidebar_notebook, "show",
 		G_CALLBACK(sidebar_tabs_show_hide), NULL);
+	g_signal_connect_after(main_widgets.sidebar_notebook, "switch-page",
+		G_CALLBACK(on_sidebar_switch_page), NULL);
 
 	sidebar_tabs_show_hide(GTK_NOTEBOOK(main_widgets.sidebar_notebook), NULL, 0, NULL);
 }

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1521,10 +1521,9 @@ static void update_tree_tags(GeanyDocument *doc, GList **tags)
 			expand = ! gtk_tree_model_iter_has_child(model, parent);
 
 			/* insert the new element */
-			gtk_tree_store_append(store, &iter, parent);
 			name = get_symbol_name(doc, tag, parent_name != NULL);
 			tooltip = get_symbol_tooltip(doc, tag);
-			gtk_tree_store_set(store, &iter,
+			gtk_tree_store_insert_with_values(store, &iter, parent, -1,
 					SYMBOLS_COLUMN_NAME, name,
 					SYMBOLS_COLUMN_TOOLTIP, tooltip,
 					SYMBOLS_COLUMN_ICON, icon,

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1424,6 +1424,7 @@ static void update_tree_tags(GeanyDocument *doc, GList **tags)
 			{
 				const gchar *name;
 				const gchar *parent_name;
+				gchar *tooltip;
 				TMTag *found = found_item->data;
 
 				parent_name = get_parent_name(found, doc->file_type->id);
@@ -1432,12 +1433,15 @@ static void update_tree_tags(GeanyDocument *doc, GList **tags)
 					parent_name = NULL;
 
 				/* only update fields that (can) have changed (name that holds line
-				 * number, and the tag itself) */
+				 * number, tooltip, and the tag itself) */
 				name = get_symbol_name(doc, found, parent_name != NULL);
+				tooltip = get_symbol_tooltip(doc, found);
 				gtk_tree_store_set(store, &iter,
 						SYMBOLS_COLUMN_NAME, name,
+						SYMBOLS_COLUMN_TOOLTIP, tooltip,
 						SYMBOLS_COLUMN_TAG, found,
 						-1);
+				g_free(tooltip);
 
 				update_parents_table(parents_table, found, parent_name, &iter);
 

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1422,9 +1422,7 @@ static void update_tree_tags(GeanyDocument *doc, GList **tags)
 				cont = tree_store_remove_row(store, &iter);
 			else /* tag still exist, update it */
 			{
-				const gchar *name;
 				const gchar *parent_name;
-				gchar *tooltip;
 				TMTag *found = found_item->data;
 
 				parent_name = get_parent_name(found, doc->file_type->id);
@@ -1432,16 +1430,22 @@ static void update_tree_tags(GeanyDocument *doc, GList **tags)
 				if (parent_name && ! g_hash_table_lookup(parents_table, parent_name))
 					parent_name = NULL;
 
-				/* only update fields that (can) have changed (name that holds line
-				 * number, tooltip, and the tag itself) */
-				name = get_symbol_name(doc, found, parent_name != NULL);
-				tooltip = get_symbol_tooltip(doc, found);
-				gtk_tree_store_set(store, &iter,
-						SYMBOLS_COLUMN_NAME, name,
-						SYMBOLS_COLUMN_TOOLTIP, tooltip,
-						SYMBOLS_COLUMN_TAG, found,
-						-1);
-				g_free(tooltip);
+				if (!tm_tags_equal(tag, found))
+				{
+					const gchar *name;
+					gchar *tooltip;
+
+					/* only update fields that (can) have changed (name that holds line
+					 * number, tooltip, and the tag itself) */
+					name = get_symbol_name(doc, found, parent_name != NULL);
+					tooltip = get_symbol_tooltip(doc, found);
+					gtk_tree_store_set(store, &iter,
+							SYMBOLS_COLUMN_NAME, name,
+							SYMBOLS_COLUMN_TOOLTIP, tooltip,
+							SYMBOLS_COLUMN_TAG, found,
+							-1);
+					g_free(tooltip);
+				}
 
 				update_parents_table(parents_table, found, parent_name, &iter);
 

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1523,7 +1523,7 @@ static void update_tree_tags(GeanyDocument *doc, GList **tags)
 			/* insert the new element */
 			name = get_symbol_name(doc, tag, parent_name != NULL);
 			tooltip = get_symbol_tooltip(doc, tag);
-			gtk_tree_store_insert_with_values(store, &iter, parent, -1,
+			gtk_tree_store_insert_with_values(store, &iter, parent, 0,
 					SYMBOLS_COLUMN_NAME, name,
 					SYMBOLS_COLUMN_TOOLTIP, tooltip,
 					SYMBOLS_COLUMN_ICON, icon,

--- a/tagmanager/src/tm_tag.c
+++ b/tagmanager/src/tm_tag.c
@@ -734,6 +734,26 @@ static gint tm_tag_compare(gconstpointer ptr1, gconstpointer ptr2, gpointer user
 	return returnval;
 }
 
+gboolean tm_tags_equal(const TMTag *a, const TMTag *b)
+{
+	if (a == b)
+		return TRUE;
+
+	return (a->line == b->line &&
+			a->file == b->file /* ptr comparison */ &&
+			strcmp(FALLBACK(a->name, ""), FALLBACK(b->name, "")) == 0 &&
+			a->type == b->type &&
+			a->local == b->local &&
+			a->pointerOrder == b->pointerOrder &&
+			a->access == b->access &&
+			a->impl == b->impl &&
+			a->lang == b->lang &&
+			strcmp(FALLBACK(a->scope, ""), FALLBACK(b->scope, "")) == 0 &&
+			strcmp(FALLBACK(a->arglist, ""), FALLBACK(b->arglist, "")) == 0 &&
+			strcmp(FALLBACK(a->inheritance, ""), FALLBACK(b->inheritance, "")) == 0 &&
+			strcmp(FALLBACK(a->var_type, ""), FALLBACK(b->var_type, "")) == 0);
+}
+
 /*
  Removes NULL tag entries from an array of tags. Called after tm_tags_dedup() since 
  this function substitutes duplicate entries with NULL

--- a/tagmanager/src/tm_tag.h
+++ b/tagmanager/src/tm_tag.h
@@ -189,6 +189,7 @@ void tm_tag_unref(TMTag *tag);
 
 TMTag *tm_tag_ref(TMTag *tag);
 
+gboolean tm_tags_equal(const TMTag *a, const TMTag *b);
 
 #ifdef TM_DEBUG /* various debugging functions */
 


### PR DESCRIPTION
Because function return types are not used to determine tag equality,
we need to also update the tooltip of an existing tag otherwise the return
type doesn't get updated when changed.

Fixes https://github.com/geany/geany/issues/474