### PR TITLE
Fix empty symbol tree under some conditions

### DIFF
--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -78,6 +78,8 @@ typedef struct GeanyDocumentPrivate
 	GtkWidget		*tag_tree;
 	/* GtkTreeStore object for this document within the Symbols treeview of the sidebar. */
 	GtkTreeStore	*tag_store;
+	/* Indicates whether tag tree has to be updated */
+	gboolean		tag_tree_dirty;
 	/* Iter for this document within the Open Files treeview of the sidebar. */
 	GtkTreeIter		 iter;
 	/* Used by the Undo/Redo management code. */

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -192,6 +192,9 @@ void sidebar_update_tag_list(GeanyDocument *doc, gboolean update)
 
 	g_return_if_fail(doc == NULL || doc->is_valid);
 
+	if (update)
+		doc->priv->tag_tree_dirty = TRUE;
+
 	if (gtk_notebook_get_current_page(GTK_NOTEBOOK(main_widgets.sidebar_notebook)) != TREEVIEW_SYMBOL)
 		return; /* don't bother updating symbol tree if we don't see it */
 
@@ -219,7 +222,7 @@ void sidebar_update_tag_list(GeanyDocument *doc, gboolean update)
 		return;
 	}
 
-	if (update)
+	if (doc->priv->tag_tree_dirty)
 	{	/* updating the tag list in the left tag window */
 		if (doc->priv->tag_tree == NULL)
 		{
@@ -232,6 +235,7 @@ void sidebar_update_tag_list(GeanyDocument *doc, gboolean update)
 		}
 
 		doc->has_tags = symbols_recreate_tag_list(doc, SYMBOLS_SORT_USE_PREVIOUS);
+		doc->priv->tag_tree_dirty = FALSE;
 	}
 
 	if (doc->has_tags)
@@ -1088,7 +1092,7 @@ static void on_sidebar_switch_page(GtkNotebook *notebook,
 	gpointer page, guint page_num, gpointer user_data)
 {
 	if (page_num == TREEVIEW_SYMBOL)
-		sidebar_update_tag_list(document_get_current(), TRUE);
+		sidebar_update_tag_list(document_get_current(), FALSE);
 }
 
 


### PR DESCRIPTION
Since symbol tree update is skipped now when the Symbols tab isn't shown,
it can happen that sidebar_update_tag_list() is called with update==FALSE
but the tag tree hasn't been created yet in which case empty tree is
shown.

Update the tag tree even for update==FALSE when it hasn't been created yet.

Steps to reproduce the problem:
1. Have some documents open
2. Switch to tab other than the Symbols tab
3. Restart Geany (at this point none of the open documents will have tags
tree created)
4. Switch to the Symbols tab (symbols are shown correctly for the current
document)
5. Close the document (Geany switches to other document tab but in this
case sidebar_update_tag_list(doc, FALSE) is called and the tag tree
is empty)