### PR TITLE
Parse C files using CPP ctags parser

### DIFF
--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -133,7 +133,7 @@ static void init_builtin_filetypes(void)
 	 * --------------------------------------------------------------------------------------------------------------------------
 	 *       [0]         [1]           [2]                 [3]                        [4]          [5]      */
 	FT_INIT( NONE,       NONE,         "None",             _("None"),                 NONE,        NONE     );
-	FT_INIT( C,          C,            "C",                NULL,                      SOURCE_FILE, COMPILED );
+	FT_INIT( C,          CPP,          "C",                NULL,                      SOURCE_FILE, COMPILED );
 	FT_INIT( CPP,        CPP,          "C++",              NULL,                      SOURCE_FILE, COMPILED );
 	FT_INIT( OBJECTIVEC, OBJC,         "Objective-C",      NULL,                      SOURCE_FILE, COMPILED );
 	FT_INIT( CS,         CSHARP,       "C#",               NULL,                      SOURCE_FILE, COMPILED );


### PR DESCRIPTION
This can be useful for *.h files which can be C/CPP and I can't think of
C code that would produce CPP tags so there should never be any extra
CPP tags for valid C code.

After this the special handling of C/CPP compatibility can be removed
from TM.