### PR TITLE
VTE prompt fixes

### DIFF
--- a/src/vte.c
+++ b/src/vte.c
@@ -163,7 +163,7 @@ static const GtkTargetEntry dnd_targets[] =
 
 static gchar **vte_get_child_environment(void)
 {
-	const gchar *exclude_vars[] = {"COLUMNS", "LINES", "TERM", NULL};
+	const gchar *exclude_vars[] = {"COLUMNS", "LINES", "TERM", "TERM_PROGRAM", NULL};
 
 	return utils_copy_environment(exclude_vars, "TERM", "xterm", NULL);
 }

--- a/src/vte.c
+++ b/src/vte.c
@@ -259,6 +259,13 @@ static void on_vte_realize(void)
 }
 
 
+static gboolean vte_start_idle(G_GNUC_UNUSED gpointer user_data)
+{
+	vte_start(vc->vte);
+	return FALSE;
+}
+
+
 static void create_vte(void)
 {
 	GtkWidget *vte, *scrollbar, *hbox;
@@ -294,7 +301,8 @@ static void create_vte(void)
 	g_signal_connect(vte, "motion-notify-event", G_CALLBACK(on_motion_event), NULL);
 	g_signal_connect(vte, "drag-data-received", G_CALLBACK(vte_drag_data_received), NULL);
 
-	vte_start(vte);
+	/* start shell on idle otherwise the initial prompt can get corrupted */
+	g_idle_add(vte_start_idle, NULL);
 
 	gtk_widget_show_all(hbox);
 	terminal_label = gtk_label_new(_("Terminal"));


### PR DESCRIPTION
There are two problems - one is OS X specific - see the commit message, the corrupted initial prompt appears on Linux. I remember seeing the latter for quite some time but only on some linux distributions - it may be related to different library versions or whatever. Anyway, the patch appears to fix this problem.

![screenshot - 19 5 2015 - 11 53 49](https://cloud.githubusercontent.com/assets/713965/7700379/9ccb25ba-fe1e-11e4-8126-cd1c04da1086.png)
