### PR TITLE
Respect filetype.common's wordchars if a filetype doesn't have its own

### DIFF
--- a/data/filetypes.common
+++ b/data/filetypes.common
@@ -97,6 +97,7 @@ calltips=call_tips
 # which characters should be skipped when moving (or included when deleting) to word boundaries
 # should always include space and tab (\s\t)
 whitespace_chars=\s\t!\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~
+#wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 [named_styles]
 # This is the Default "built-in" color scheme

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -171,10 +171,11 @@ static void get_keyfile_keywords(GKeyFile *config, GKeyFile *configh,
 }
 
 
-static void get_keyfile_wordchars(GKeyFile *config, GKeyFile *configh, gchar **wordchars)
+static void get_keyfile_wordchars(GKeyFile *config, GKeyFile *configh, gchar **wordchars,
+		const gchar *default_wordchars)
 {
 	*wordchars = utils_get_setting(string, configh, config,
-		"settings", "wordchars", GEANY_WORDCHARS);
+		"settings", "wordchars", default_wordchars);
 }
 
 
@@ -578,7 +579,7 @@ static void styleset_common_init(GKeyFile *config, GKeyFile *config_home)
 		0, 0, &common_style_set.styling[GCS_LINE_HEIGHT]);
 
 	g_free(common_style_set.wordchars);
-	get_keyfile_wordchars(config, config_home, &common_style_set.wordchars);
+	get_keyfile_wordchars(config, config_home, &common_style_set.wordchars, GEANY_WORDCHARS);
 	g_free(whitespace_chars);
 	whitespace_chars = get_keyfile_whitespace_chars(config, config_home);
 }
@@ -1054,7 +1055,8 @@ void highlighting_init_styles(guint filetype_idx, GKeyFile *config, GKeyFile *co
 	}
 
 	/* should be done in filetypes.c really: */
-	get_keyfile_wordchars(config, configh, &style_sets[filetype_idx].wordchars);
+	get_keyfile_wordchars(config, configh, &style_sets[filetype_idx].wordchars,
+			common_style_set.wordchars);
 }
 
 


### PR DESCRIPTION
Use filetype.common's wordchars instead of GEANY_WORDCHARS as default
for filetypes not having their own.  This allows to change the
wordchars for all filetypes at once.

Part of issue #492.