### PR TITLE
Don't resize message window when changing Geany's window height

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8327,7 +8327,7 @@
                 </child>
               </object>
               <packing>
-                <property name="resize">True</property>
+                <property name="resize">False</property>
                 <property name="shrink">True</property>
               </packing>
             </child>


### PR DESCRIPTION
At the moment the message window is set to resize when the height of the
main window changes. This is a bit annoying when the message window size
is set to fit all the tabs exactly and when shrinking the window, the
tabs don't fit the shrinked message window.

Set the flag not to resize the notebook_info notebook (similar thing is
already done with the sidebar in the horizontal direction so no change
needed there).

Works fine also when the message window is set to be on the right side.