### PR TITLE
Don't force syntax re-highlighting if typenames don't change

### DIFF
--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -108,6 +108,8 @@ typedef struct GeanyDocumentPrivate
 	gint			 protected;
 	/* Save pointer to info bars allowing to cancel them programatically (to avoid multiple ones) */
 	GtkWidget		*info_bars[NUM_MSG_TYPES];
+	/* String containing typenames highlighted by Scintilla */
+	gchar			*typenames;
 }
 GeanyDocumentPrivate;
 

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -809,10 +809,8 @@ static void merge_type_keywords(ScintillaObject *sci, guint ft_id, guint keyword
 	const gchar *user_words = style_sets[ft_id].keywords[keyword_idx];
 	GString *s;
 
-	s = symbols_find_typenames_as_string(filetypes[ft_id]->lang, TRUE);
-	if (G_UNLIKELY(s == NULL))
-		s = g_string_sized_new(200);
-	else
+	s = symbols_find_global_typenames(filetypes[ft_id]->lang);
+	if (s->len > 0)
 		g_string_append_c(s, ' '); /* append a space as delimiter to the existing list of words */
 
 	g_string_append(s, user_words);

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -50,7 +50,9 @@ void symbols_reload_config_files(void);
 
 void symbols_global_tags_loaded(guint file_type_idx);
 
-GString *symbols_find_typenames_as_string(gint lang, gboolean global);
+GString *symbols_find_global_typenames(langType lang);
+
+gchar *symbols_find_workspace_typenames(GeanyDocument *doc);
 
 const GList *symbols_get_tag_list(GeanyDocument *doc, guint tag_types);
 


### PR DESCRIPTION
At the moment every time the document changes, the scintilla editor is
re-highlighted to colorize the typenames (for selected languages). This
is really expensive - it forces re-lexing the document, redrawing folds
and redrawing the document. While with SciTE it is possible to edit
1000000 LOC C file, in Geany, even if ctags parsing is not performed,
the editor becomes very unresponsive at around 100000 LOCs already
because of this.

Another issue is the number of typenames we pass to Scintilla to be
highlighted - for huge projects like the linux kernel it can be
100000 typenames and Scintilla isn't very well optimized for colorizing
too many words (plus it means quite a significant per-editor memory
usage because the 100000 words represent about 1MB per open tab).

This patch tries to solve both of the above issues by
1. Passing to scintilla only the typenames appearing in the editor
2. Remembering these typenames and checking if they differ from the
typenames used to colorize the editor - if they are identical,
recolorization doesn't happen.

(1) above is performed by finding all identifiers in the editor and
intersecting them with the typename words. Even though this means reading
the whole document, it is still much cheaper than calling SCI_COLOURISE.
The resulting typename list is short enough so it doesn't represent a
significant overhead when stored for the document to check if it has
changed (unfortunately there's no getter in the scintilla API to get them
so they have to be stored separately).

Even though we don't have the per-language wordchar information when
reading the document to locate the identifiers (it is available either
inside scintilla lexers or ctags parsers), we can infer them from the
typenames because these are the only words we are interested in in the
document (the patch distinguishes characters appearing at the beginning of
the word and the rest of the word because the set of characters that
can appear at the beginning of an identifier usually differs from the set
of characters appearing in the rest of the identifier for most languages
(e.g. identifiers don't start with numbers).