### PR TITLE
Add -O2 flag also for C++ files when building with waf

### DIFF
--- a/wscript
+++ b/wscript
@@ -336,6 +336,10 @@ but you then may not have a local copy of the HTML manual.'''
     conf.env.append_value('CFLAGS', ['-DGTK'])
     conf.env.append_value('CXXFLAGS',
         ['-DNDEBUG', '-DGTK', '-DSCI_LEXER', '-DG_THREADS_IMPL_NONE'])
+    if conf.env['CXX_NAME'] == 'gcc' and '-O' not in ''.join(conf.env['CXXFLAGS']):
+        conf.env.append_value('CXXFLAGS', ['-O2'])
+    if revision is not None:
+        conf.env.append_value('CXXFLAGS', ['-g'])
 
     # summary
     Logs.pprint('BLUE', 'Summary:')


### PR DESCRIPTION
Just noticed this now. A bit stupid because I use mostly waf for building and the performance profiling I did was slightly off because of this ("fortunately" the slow things in scintilla are still slow even with -O2 so I didn't do the optimizing work unnecessarily).