### PR TITLE
Use a more precise Git revision

### DIFF
--- a/m4/geany-revision.m4
+++ b/m4/geany-revision.m4
@@ -10,7 +10,7 @@ AC_DEFUN([GEANY_CHECK_REVISION],
 	# try Git first
 	GIT=`which git 2>/dev/null`
 	if test -d "$srcdir/.git" -a "x${GIT}" != "x" -a -x "${GIT}"; then
-		REVISION=`cd "$srcdir"; "${GIT}" rev-parse --short --revs-only HEAD 2>/dev/null || echo 0`
+		REVISION=`cd "$srcdir"; "${GIT}" describe --always --long --tags --dirty 2>/dev/null || echo 0`
 	fi
 
 	if test "x${REVISION}" != "x0"; then

--- a/wscript
+++ b/wscript
@@ -857,7 +857,7 @@ def _get_git_rev(conf):
         return
 
     try:
-        cmd = 'git rev-parse --short --revs-only HEAD'
+        cmd = 'git describe --always --long --tags --dirty'
         revision = conf.cmd_and_log(cmd).strip()
     except WafError:
         return None


### PR DESCRIPTION
This gives something like `1.24.1-876-g3a8ef62-dirty`, which contains
more information than the SHA1 alone (including local copy dirtiness),
and is easier to read at first glance.