### PR TITLE
autotools: Detect GTK version to use automatically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,19 +59,28 @@ AC_CHECK_FUNCS([ftruncate fgetpos fnmatch mkstemp strerror strstr])
 GEANY_CHECK_REVISION([dnl force debug mode for a SVN working copy
 					  CFLAGS="-g -DGEANY_DEBUG $CFLAGS"])
 
-
+# GTK version check
 AC_ARG_ENABLE([gtk3],
 		[AS_HELP_STRING([--enable-gtk3],
-						[compile with GTK3 support (experimental) [default=no]])],
+						[compile against GTK3 [default=auto]])],
 		[enable_gtk3=$enableval],
-		[enable_gtk3=no])
+		[enable_gtk3=auto])
 
-AS_IF([test "x$enable_gtk3" = xyes],
-	  [gtk_package=gtk+-3.0
-	   gtk_min_version=3.0],
-	  [gtk_package=gtk+-2.0
-	   gtk_min_version=2.24])
-AM_CONDITIONAL([GTK3], [test "x$gtk_package" = "xgtk+-3.0"])
+gtk2_package=gtk+-2.0
+gtk2_min_version=2.24
+gtk3_package=gtk+-3.0
+gtk3_min_version=3.0
+
+PKG_CHECK_EXISTS([$gtk2_package >= $gtk2_min_version], [have_gtk2=yes], [have_gtk2=no])
+PKG_CHECK_EXISTS([$gtk3_package >= $gtk3_min_version], [have_gtk3=yes], [have_gtk3=no])
+AS_IF([test "x$enable_gtk3" = xyes || (! test "x$enable_gtk3" = xno &&
+									   test "x$have_gtk3" = xyes &&
+									   test "x$have_gtk2" = xno)],
+	  [gtk_package=$gtk3_package
+	   gtk_min_version=$gtk3_min_version],
+	  [gtk_package=$gtk2_package
+	   gtk_min_version=$gtk2_min_version])
+AM_CONDITIONAL([GTK3], [test "x$gtk_package" = "x$gtk3_package"])
 
 # GTK/GLib/GIO checks
 gtk_modules="$gtk_package >= $gtk_min_version glib-2.0 >= 2.28"


### PR DESCRIPTION
This makes GTK3 version first class citizen (well, almost, it still defaults to gtk2 when available).

Related to #452.

Yes, the tests are a bit subtle, but we want to respect the `--enable-gtk3` value, but yet default to gtk2 if nothing is passed and it's found, but also if nothing is passed and no GTK version is found.
- [x] Autotools
- [x] Waf
