### PR TITLE
Force disk status document check in some specific cases

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -431,13 +431,6 @@ void on_normal_size1_activate(GtkMenuItem *menuitem, gpointer user_data)
 }
 
 
-static gboolean delayed_check_disk_status(gpointer data)
-{
-	document_check_disk_status(data, FALSE);
-	return FALSE;
-}
-
-
 /* Changes window-title after switching tabs and lots of other things.
  * note: using 'after' makes Scintilla redraw before the UI, appearing more responsive */
 static void on_notebook1_switch_page_after(GtkNotebook *notebook, gpointer page,
@@ -462,10 +455,7 @@ static void on_notebook1_switch_page_after(GtkNotebook *notebook, gpointer page,
 		sidebar_update_tag_list(doc, FALSE);
 		document_highlight_tags(doc);
 
-		/* We delay the check to avoid weird fast, unintended switching of notebook pages when
-		 * the 'file has changed' dialog is shown while the switch event is not yet completely
-		 * finished. So, we check after the switch has been performed to be safe. */
-		g_idle_add(delayed_check_disk_status, doc);
+		document_check_disk_status(doc, TRUE);
 
 #ifdef HAVE_VTE
 		vte_cwd((doc->real_path != NULL) ? doc->real_path : doc->file_name, FALSE);

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -222,6 +222,15 @@ static void apply_settings(void)
 }
 
 
+static void on_window_active_changed(GtkWindow *window, GParamSpec *pspec, gpointer data)
+{
+	GeanyDocument *doc = document_get_current();
+
+	if (doc && gtk_window_is_active(window))
+		document_check_disk_status(doc, TRUE);
+}
+
+
 static void main_init(void)
 {
 	/* add our icon path in case we aren't installed in the system prefix */
@@ -248,6 +257,7 @@ static void main_init(void)
 	main_status.opening_session_files	= FALSE;
 
 	main_widgets.window = create_window1();
+	g_signal_connect(main_widgets.window, "notify::is-active", G_CALLBACK(on_window_active_changed), NULL);
 
 	/* add recent projects to the Project menu */
 	ui_widgets.recent_projects_menuitem = ui_lookup_widget(main_widgets.window, "recent_projects1");

--- a/src/osx.c
+++ b/src/osx.c
@@ -86,14 +86,6 @@ static void on_new_window(GtkMenuItem *menuitem, G_GNUC_UNUSED gpointer user_dat
 }
 
 
-static void app_active_cb(GtkosxApplication* app, G_GNUC_UNUSED gpointer user_data)
-{
-	GeanyDocument *doc = document_get_current();
-	if (doc)
-		document_check_disk_status(doc, TRUE);
-}
-
-
 void osx_ui_init(void)
 {
 	GtkWidget *item, *menu;
@@ -118,8 +110,6 @@ void osx_ui_init(void)
 					G_CALLBACK(app_block_termination_cb), NULL);
 	g_signal_connect(osx_app, "NSApplicationOpenFile",
 					G_CALLBACK(app_open_file_cb), NULL);
-	g_signal_connect(osx_app, "NSApplicationDidBecomeActive",
-					G_CALLBACK(app_active_cb), NULL);
 
 	menu = gtk_menu_new();
 	item = gtk_menu_item_new_with_label("New Window");


### PR DESCRIPTION
The disk status change check behaves sometimes a bit magically in Geany and it takes some time for Geany to realize the document has changed. Of course there are performance reasons for it (it's probably not a good idea to do the full check for every character written) but there are several cases where we can do a force check and show the notification immediately:

1. When switching tabs - the current code doesn't do a force-check but IMO it's a good idea to perform it to make sure the document is up-to-date (we do a force-check for the final document when switching documents using Ctrl+Tab and this is a similar case).

   Moreover, the part doing the check on idle is obsoleted by

   https://github.com/geany/geany/commit/5cc8a96d440274c15f50228ee55461fb557cee3e

   and can be removed.

   (now looking at the linked patch maybe it would be possible to remove the switch_in_progress check from document_check_disk_status() and rather put it into on_notebook1_switch_page_after(). Then on_notebook1_switch_page_after() could be moved to notebook.c where it would have direct access to the switch_in_progress variable and we could eliminate the accessor method. Let me know if you prefer this way.)

2. When Geany main window becomes active - the most common case is that the document is modified by the user from the outside by editing it in a different editor or running some script in the terminal. This was already done for OS X and the osx-specific part can be removed now.

3. After building/running because the open document can be some generated output resulting from build/run.

It would be nice to do something similar for VTE too but I don't see a way how to tell if the executed command finished (doing it when user presses enter is too early because the command can still be running).