### PR TITLE
Don't colourise scintilla when quitting

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -4636,7 +4636,7 @@ static gboolean editor_check_colourise(GeanyEditor *editor)
 {
 	GeanyDocument *doc = editor->document;
 
-	if (!doc->priv->colourise_needed)
+	if (!doc->priv->colourise_needed || main_status.quitting)
 		return FALSE;
 
 	doc->priv->colourise_needed = FALSE;


### PR DESCRIPTION
There's no need to colourise documents when quitting which happens for
every single closed document right now .

Tested with all *.c *.h documents open from Geany src directory and the
editor closes almost instantly now (there was a visible delay before).
