### PR TITLE
Spawn fixes/improvements

### DIFF
--- a/src/spawn.c
+++ b/src/spawn.c
@@ -59,6 +59,7 @@
 
 #ifdef SPAWN_TEST
 # define _
+# define GEANY_API_SYMBOL
 #else
 # include "support.h"
 #endif


### PR DESCRIPTION
Fix spawn_async_with_pipes() not to require a glib event loop for child_pid=NULL.

Fix spawn not to require or use GEANY_API_SYMBOL when compiled for testing.
