### PR TITLE
Fix binary relocation support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,6 +27,10 @@ lib_LTLIBRARIES = libgeany.la
 geany_SOURCES = main.c
 geany_LDADD = libgeany.la $(GTK_LIBS) $(GTHREAD_LIBS) $(INTLLIBS)
 
+if ENABLE_BINRELOC
+geany_LDFLAGS = -Wl,-rpath='$$ORIGIN/../lib'
+endif
+
 geany_includedir = $(includedir)/geany
 geany_include_HEADERS = \
 	app.h \

--- a/src/utils.c
+++ b/src/utils.c
@@ -33,6 +33,7 @@
 #include "dialogs.h"
 #include "document.h"
 #include "prefs.h"
+#include "prefix.h"
 #include "sciwrappers.h"
 #include "spawn.h"
 #include "support.h"


### PR DESCRIPTION
Fix binary relocation support so `--enable-binreloc` actually works again.

* include *prefix.h* in utils, as it now references the various `GEANY_*DIR`s;
* use `$ORIGIN/../lib` rpath when binary relocation is used, so the executable finds the lib.

---
```console
$ ../configure --enable-binreloc
[...]
$ make
[...]
$ make install DESTDIR=/tmp/geany-portable
[...]
$ ldd /tmp/geany-portable/bin/geany | grep libgeany
	libgeany.so.0 => /tmp/geany-portable/bin/../lib/libgeany.so.0 (0x00007f9968aa1000)
```