### PR TITLE
win32: change default plugin dir to match Linux.

### DIFF
--- a/geany.nsi
+++ b/geany.nsi
@@ -168,7 +168,7 @@ Section "Plugins" SEC02
 	SectionIn 1
 	SetOverwrite ifnewer
 	SetOutPath "$INSTDIR\lib"
-	File "${RESOURCEDIR}\lib\*.dll"
+	File "${RESOURCEDIR}\lib\geany\*.dll"
 SectionEnd
 
 Section "Language Files" SEC03

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -3,11 +3,7 @@
 EXTRA_DIST = \
 	makefile.win32
 
-if MINGW
-plugindir = $(libdir)
-else
 plugindir = $(libdir)/geany
-endif
 
 plugins_includedir = $(includedir)/geany
 plugins_include_HEADERS = \

--- a/src/utils.c
+++ b/src/utils.c
@@ -2121,7 +2121,7 @@ const gchar *utils_resource_dir(GeanyResourceDirType type)
 		resdirs[RESOURCE_DIR_ICON] = g_build_filename(prefix, "share", "icons", NULL);
 		resdirs[RESOURCE_DIR_DOC] = g_build_filename(prefix, "doc", NULL);
 		resdirs[RESOURCE_DIR_LOCALE] = g_build_filename(prefix, "share", "locale", NULL);
-		resdirs[RESOURCE_DIR_PLUGIN] = g_build_filename(prefix, "lib", NULL);
+		resdirs[RESOURCE_DIR_PLUGIN] = g_build_filename(prefix, "lib", "geany", NULL);
 		g_free(prefix);
 #else
 		if (is_osx_bundle())

--- a/wscript
+++ b/wscript
@@ -397,7 +397,7 @@ def build(bld):
 
     def build_plugin(plugin_name, install=True, uselib_add=[]):
         if install:
-            instpath = '${PREFIX}/lib' if is_win32 else '${LIBDIR}/geany'
+            instpath = '${LIBDIR}/geany'
         else:
             instpath = None
 


### PR DESCRIPTION
There is no need to do it differently as Linux here, and it confuses the
autotools based compilation of geany-plugins which installs to libdir/geany
unconditionally.