### PR TITLE
c++: Properly parse C++11 overrides, finals and noexcepts

### DIFF
--- a/tagmanager/ctags/c.c
+++ b/tagmanager/ctags/c.c
@@ -76,7 +76,7 @@ typedef enum eKeywordId
 	KEYWORD_LOCAL, KEYWORD_LONG,
 	KEYWORD_M_BAD_STATE, KEYWORD_M_BAD_TRANS, KEYWORD_M_STATE, KEYWORD_M_TRANS,
 	KEYWORD_MODULE, KEYWORD_MUTABLE,
-	KEYWORD_NAMESPACE, KEYWORD_NEW, KEYWORD_NEWCOV, KEYWORD_NATIVE,
+	KEYWORD_NAMESPACE, KEYWORD_NEW, KEYWORD_NEWCOV, KEYWORD_NATIVE, KEYWORD_NOEXCEPT,
 	KEYWORD_OPERATOR, KEYWORD_OUT, KEYWORD_OUTPUT, KEYWORD_OVERLOAD, KEYWORD_OVERRIDE,
 	KEYWORD_PACKED, KEYWORD_PORT, KEYWORD_PACKAGE, KEYWORD_PRIVATE,
 	KEYWORD_PROGRAM, KEYWORD_PROTECTED, KEYWORD_PUBLIC,
@@ -457,6 +457,7 @@ static const keywordDesc KeywordTable [] = {
 	{ "native",         KEYWORD_NATIVE,         { 0, 0, 0, 1, 0, 0, 0 } },
 	{ "new",            KEYWORD_NEW,            { 0, 1, 1, 1, 0, 1, 1 } },
 	{ "newcov",         KEYWORD_NEWCOV,         { 0, 0, 0, 0, 1, 0, 0 } },
+	{ "noexcept",       KEYWORD_NOEXCEPT,       { 0, 1, 0, 0, 0, 0, 0 } },
 	{ "operator",       KEYWORD_OPERATOR,       { 0, 1, 1, 0, 0, 0, 0 } },
 	{ "out",            KEYWORD_OUT,            { 0, 0, 0, 0, 0, 1, 1 } },
 	{ "output",         KEYWORD_OUTPUT,         { 0, 0, 0, 0, 1, 0, 0 } },
@@ -2242,6 +2243,7 @@ static boolean skipPostArgumentStuff (statementInfo *const st,
 					case KEYWORD_ATTRIBUTE:	skipParens ();	break;
 					case KEYWORD_THROW:	skipParens ();		break;
 					case KEYWORD_CONST:						break;
+					case KEYWORD_NOEXCEPT:					break;
 					case KEYWORD_TRY:						break;
 					case KEYWORD_VOLATILE:					break;
 

--- a/tagmanager/ctags/c.c
+++ b/tagmanager/ctags/c.c
@@ -2262,7 +2262,13 @@ static boolean skipPostArgumentStuff (statementInfo *const st,
 						break;
 
 					default:
-						if (isType (token, TOKEN_NONE))
+						/* "override" and "final" are only keywords in the declaration of a virtual
+						 * member function, so need to be handled specially, not as keywords */
+						if (isLanguage(Lang_cpp) && isType (token, TOKEN_NAME) &&
+							(strcmp ("override", vStringValue (token->name)) == 0 ||
+							 strcmp ("final", vStringValue (token->name)) == 0))
+							;
+						else if (isType (token, TOKEN_NONE))
 							;
 						else if (info->isKnrParamList  &&  info->parameterCount > 0)
 							++elementCount;

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -132,6 +132,7 @@ test_sources = \
 	cython_sample.pyx				\
 	cython_sample2.pyx				\
 	cxx11enum.cpp					\
+	cxx11-final.cpp					\
 	db-trig.sql						\
 	debian_432872.f90				\
 	directives.c					\

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -133,6 +133,7 @@ test_sources = \
 	cython_sample2.pyx				\
 	cxx11enum.cpp					\
 	cxx11-final.cpp					\
+	cxx11-override.cpp				\
 	db-trig.sql						\
 	debian_432872.f90				\
 	directives.c					\

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -135,6 +135,7 @@ test_sources = \
 	cxx11-final.cpp					\
 	cxx11-noexcept.cpp				\
 	cxx11-override.cpp				\
+	cxx14-combined.cpp				\
 	db-trig.sql						\
 	debian_432872.f90				\
 	directives.c					\

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -133,6 +133,7 @@ test_sources = \
 	cython_sample2.pyx				\
 	cxx11enum.cpp					\
 	cxx11-final.cpp					\
+	cxx11-noexcept.cpp				\
 	cxx11-override.cpp				\
 	db-trig.sql						\
 	debian_432872.f90				\

--- a/tests/ctags/cxx11-final.cpp
+++ b/tests/ctags/cxx11-final.cpp
@@ -1,0 +1,23 @@
+class Base
+{
+public:
+	virtual void foo() = 0;
+};
+
+class Derived final : public Base
+{
+	virtual void foo();
+	virtual void final();
+};
+
+void Base::foo()
+{
+}
+
+void Derived::foo()
+{
+}
+
+void Derived::final()
+{
+}

--- a/tests/ctags/cxx11-final.cpp
+++ b/tests/ctags/cxx11-final.cpp
@@ -6,7 +6,7 @@ public:
 
 class Derived final : public Base
 {
-	virtual void foo();
+	virtual void foo() final;
 	virtual void final();
 };
 

--- a/tests/ctags/cxx11-final.cpp.tags
+++ b/tests/ctags/cxx11-final.cpp.tags
@@ -1,0 +1,9 @@
+# format=tagmanager
+BaseÌ1Ö0
+DerivedÌ1Ö0
+finalÌ16Í()ÎDerivedÖ0Ïvoid
+finalÌ1024Í()ÎDerivedÖ0Ïvirtual void
+fooÌ16Í()ÎBaseÖ0Ïvoid
+fooÌ16Í()ÎDerivedÖ0Ïvoid
+fooÌ1024Í()ÎBaseÖ0Ïvirtual void
+fooÌ1024Í()ÎDerivedÖ0Ïvirtual void

--- a/tests/ctags/cxx11-noexcept.cpp
+++ b/tests/ctags/cxx11-noexcept.cpp
@@ -1,0 +1,7 @@
+class Base
+{
+public:
+	virtual void foo() noexcept = 0;
+	virtual void bar() const noexcept = 0;
+	int baz() noexcept { return 42; }
+};

--- a/tests/ctags/cxx11-noexcept.cpp.tags
+++ b/tests/ctags/cxx11-noexcept.cpp.tags
@@ -1,0 +1,5 @@
+# format=tagmanager
+BaseÌ1Ö0
+barÌ1024Í()ÎBaseÖ0Ïvirtual void
+bazÌ16Í()ÎBaseÖ0Ïint
+fooÌ1024Í()ÎBaseÖ0Ïvirtual void

--- a/tests/ctags/cxx11-override.cpp
+++ b/tests/ctags/cxx11-override.cpp
@@ -1,0 +1,23 @@
+class Base
+{
+public:
+	virtual void foo() = 0;
+};
+
+class Derived : public Base
+{
+	virtual void foo() override;
+	virtual void override();
+};
+
+void Base::foo()
+{
+}
+
+void Derived::foo()
+{
+}
+
+void Derived::override()
+{
+}

--- a/tests/ctags/cxx11-override.cpp.tags
+++ b/tests/ctags/cxx11-override.cpp.tags
@@ -1,0 +1,9 @@
+# format=tagmanager
+BaseÌ1Ö0
+DerivedÌ1Ö0
+fooÌ16Í()ÎBaseÖ0Ïvoid
+fooÌ16Í()ÎDerivedÖ0Ïvoid
+fooÌ1024Í()ÎBaseÖ0Ïvirtual void
+fooÌ1024Í()ÎDerivedÖ0Ïvirtual void
+overrideÌ16Í()ÎDerivedÖ0Ïvoid
+overrideÌ1024Í()ÎDerivedÖ0Ïvirtual void

--- a/tests/ctags/cxx14-combined.cpp
+++ b/tests/ctags/cxx14-combined.cpp
@@ -1,0 +1,8 @@
+struct Base {
+  virtual void baz() const throw() = 0;
+};
+
+struct Foo final : public Base {
+  static constexpr auto bar() noexcept { return 1; }
+  virtual void baz() const throw() final override;
+};

--- a/tests/ctags/cxx14-combined.cpp.tags
+++ b/tests/ctags/cxx14-combined.cpp.tags
@@ -1,0 +1,6 @@
+# format=tagmanager
+BaseÌ2048Ö0
+FooÌ2048Ö0
+barÌ16Í()ÎFooÖ0Ïconstexpr
+bazÌ1024Í()ÎBaseÖ0Ïvirtual void
+bazÌ1024Í()ÎFooÖ0Ïvirtual void


### PR DESCRIPTION
Based on a Universal CTags patch by Miklos Vajna.

See https://github.com/universal-ctags/ctags/pull/405

---
@elextr please review as the C++ expert ;)