### PR TITLE
autotools: Install libgeany in $pkglibdir

### DIFF
--- a/geany.pc.in
+++ b/geany.pc.in
@@ -1,6 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
+pkglibdir=${libdir}/@PACKAGE@
 includedir=@includedir@
 datarootdir=@datarootdir@
 datadir=@datadir@
@@ -10,5 +11,5 @@ Name: Geany
 Description: A fast and lightweight IDE using GTK2
 Requires: @DEPENDENCIES@
 Version: @VERSION@
-Libs: -L${libdir} -lgeany
+Libs: -L${pkglibdir} -lgeany
 Cflags: -DGTK -I${includedir}/geany -I${includedir}/geany/tagmanager -I${includedir}/geany/scintilla

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,7 +22,7 @@ AM_CPPFLAGS = \
 	$(MAC_INTEGRATION_CFLAGS)
 
 bin_PROGRAMS = geany
-lib_LTLIBRARIES = libgeany.la
+pkglib_LTLIBRARIES = libgeany.la
 
 geany_SOURCES = main.c
 geany_LDADD = libgeany.la $(GTK_LIBS) $(GTHREAD_LIBS) $(INTLLIBS)


### PR DESCRIPTION
A short discussion with Debian packagers (@hyperair and partly @evgeni) suggested that we should not install our library in a main system library directory because it's not actually a library that other programs are supposed to use, but only plugins loaded by Geany itself.

So, install libgeany in `$pkglibdir` instead of `$libdir`.

### Todo
- [x] Autotools
- [ ] Waf
- [ ] Windows (installer and stuff)