### PR TITLE
Consider filepaths that contain the + character, with <Primary><Shift>o.

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1373,7 +1373,7 @@ void on_menu_open_selected_file1_activate(GtkMenuItem *menuitem, gpointer user_d
 #ifdef G_OS_WIN32
 	wc = GEANY_WORDCHARS "./-" "\\";
 #else
-	wc = GEANY_WORDCHARS "./-";
+	wc = GEANY_WORDCHARS "./-+";
 #endif
 
 	g_return_if_fail(doc != NULL);


### PR DESCRIPTION
Please consider this small change that should allow to use the Ctrl+Shift+o keyboard shortcut for opening files with '+' in the file-path.

One example of files with + in their file-paths is source files of the GTK+ graphical user interface library.

I like this change (I am using it, locally).     If you think is good, please merge it.
