### PR TITLE
Disable "maintain history on reload" by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -56,8 +56,8 @@ Geany 1.25 (unreleased)
     * Do not comment out blank lines when toggling comments (PR#79, Igor
       Shaula).
     * Improve handling of Verilog strings and comments.
-    * Keep undo history when reloading files (PR#188, Arthur
-      Rosenstein).
+    * Support for keeping undo history when reloading files (PR#188, Arthur
+      Rosenstein).  This is not enabled by default in this release.
 
     Search
     * Add support for single-line regular expressions (PR#310).

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2652,7 +2652,7 @@ use_gio_unsafe_file_saving        Whether to use GIO as the unsafe file        t
                                   correctly on some complex setups.
 gio_unsafe_save_backup            Make a backup when using GIO unsafe file     false       immediately
                                   saving. Backup is named `filename~`.
-keep_edit_history_on_reload       Whether to maintain the edit history when    true        immediately
+keep_edit_history_on_reload       Whether to maintain the edit history when    false       immediately
                                   reloading a file, and allow the operation
                                   to be reverted.
 **Filetype related**

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2652,7 +2652,7 @@ use_gio_unsafe_file_saving        Whether to use GIO as the unsafe file        t
                                   correctly on some complex setups.
 gio_unsafe_save_backup            Make a backup when using GIO unsafe file     false       immediately
                                   saving. Backup is named `filename~`.
-keep_edit_history_on_reload       Whether to maintain the edit history when    false       immediately
+keep_edit_history_on_reload_125   Whether to maintain the edit history when    false       immediately
                                   reloading a file, and allow the operation
                                   to be reverted.
 **Filetype related**

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -234,7 +234,7 @@ static void init_pref_groups(void)
 	stash_group_add_boolean(group, &file_prefs.use_gio_unsafe_file_saving,
 		"use_gio_unsafe_file_saving", TRUE);
 	stash_group_add_boolean(group, &file_prefs.keep_edit_history_on_reload,
-		"keep_edit_history_on_reload", TRUE);
+		"keep_edit_history_on_reload", FALSE);
 	/* for backwards-compatibility */
 	stash_group_add_integer(group, &editor_prefs.indentation->hard_tab_width,
 		"indent_hard_tab_width", 8);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -234,7 +234,7 @@ static void init_pref_groups(void)
 	stash_group_add_boolean(group, &file_prefs.use_gio_unsafe_file_saving,
 		"use_gio_unsafe_file_saving", TRUE);
 	stash_group_add_boolean(group, &file_prefs.keep_edit_history_on_reload,
-		"keep_edit_history_on_reload", FALSE);
+		"keep_edit_history_on_reload_125", FALSE);
 	/* for backwards-compatibility */
 	stash_group_add_integer(group, &editor_prefs.indentation->hard_tab_width,
 		"indent_hard_tab_width", 8);


### PR DESCRIPTION
While the feature is nice, it might be unexpected and lacks user
feedback.  This might lead to user thinking they lost their work
because they don't know they can undo the reload operation.

So, disable the feature by default until we introduce appropriate user
feedback allowing the user to learn about the feature and new behavior.

See http://lists.geany.org/pipermail/devel/2015-June/thread.html#9537