### PR TITLE
Install src/spawn.h as it is part of the plugin API

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,6 +54,7 @@ geany_include_HEADERS = \
 	project.h \
 	sciwrappers.h \
 	search.h \
+	spawn.h \
 	stash.h \
 	support.h \
 	symbols.h \

--- a/wscript
+++ b/wscript
@@ -640,6 +640,7 @@ def build(bld):
         src/project.h
         src/sciwrappers.h
         src/search.h
+        src/spawn.h
         src/stash.h
         src/support.h
         src/symbols.h


### PR DESCRIPTION
Noticed via http://nightly.geany.org/win32/build_win32_plugins_stderr.log.