### PR TITLE
Options for cut/copy to work with no text selection

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2575,6 +2575,11 @@ complete_snippets_whilst_editing  Whether to allow completion of snippets      f
                                   position on the line). Only used when the
                                   keybinding `Complete snippet` is set to
                                   ``Space``.
+no_selection_copies_line          When enabled the copy command will copy the
+                                  contents of the current line if no text is
+                                  selected.                                    false       immediately
+no_selection_cuts_line            When enabled the cut command will cut the
+                                  the current line if no text is selected.     false       immediately
 show_editor_scrollbars            Whether to display scrollbars. If set to     true        immediately
                                   false, the horizontal and vertical
                                   scrollbars are hidden completely.

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -234,7 +234,10 @@ void on_cut1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	if (GTK_IS_EDITABLE(focusw))
 		gtk_editable_cut_clipboard(GTK_EDITABLE(focusw));
 	else if (IS_SCINTILLA(focusw))
-		sci_cut(SCINTILLA(focusw));
+		if (editor_prefs.no_selection_copy && !sci_has_selection(SCINTILLA(focusw)))
+			sci_send_command(SCINTILLA(focusw), SCI_LINECUT);
+		else
+			sci_cut(SCINTILLA(focusw));
 	else if (GTK_IS_TEXT_VIEW(focusw))
 	{
 		GtkTextBuffer *buffer = gtk_text_view_get_buffer(
@@ -251,7 +254,10 @@ void on_copy1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	if (GTK_IS_EDITABLE(focusw))
 		gtk_editable_copy_clipboard(GTK_EDITABLE(focusw));
 	else if (IS_SCINTILLA(focusw))
-		sci_copy(SCINTILLA(focusw));
+		if (editor_prefs.no_selection_copy && !sci_has_selection(SCINTILLA(focusw)))
+			sci_send_command(SCINTILLA(focusw), SCI_LINECOPY);
+		else
+			sci_copy(SCINTILLA(focusw));
 	else if (GTK_IS_TEXT_VIEW(focusw))
 	{
 		GtkTextBuffer *buffer = gtk_text_view_get_buffer(

--- a/src/editor.h
+++ b/src/editor.h
@@ -134,6 +134,8 @@ typedef struct GeanyEditorPrefs
 	gint 		show_virtual_space;
 	gboolean	long_line_enabled;
 	gint		autocompletion_update_freq;
+	gboolean	no_selection_copy;
+	gboolean	no_selection_cut;
 }
 GeanyEditorPrefs;
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -244,6 +244,10 @@ static void init_pref_groups(void)
 		"extract_filetype_regex", GEANY_DEFAULT_FILETYPE_REGEX);
 	stash_group_add_boolean(group, &search_prefs.replace_and_find_by_default,
 		"replace_and_find_by_default", TRUE);
+	stash_group_add_boolean(group, &editor_prefs.no_selection_copy,
+		"no_selection_copies_line", FALSE);
+	stash_group_add_boolean(group, &editor_prefs.no_selection_cut,
+		"no_selection_cuts_line", FALSE);
 
 	/* Note: Interface-related various prefs are in ui_init_prefs() */
 


### PR DESCRIPTION
Added the ability for cut and copy commands to affect the current line when no text is selected.

Being able to quickly copy/cut a line without the need for additional hotkeys can be beneficial when moving a lot of text around.

These features are enabled in the preferences window in the "**various**" section.
* Copy - **no_selection_copies_line**
* Cut - **no_selection_cuts_line**

The features are disabled by default as they change the way two very common commands work.
