### PR TITLE
Add "Close Documents To The Right" to document context menu

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -157,6 +157,27 @@ void on_close_all1_activate(GtkMenuItem *menuitem, gpointer user_data)
 }
 
 
+void on_close_allafter1_activate(GtkMenuItem *menuitem, gpointer user_data)
+{
+	guint i;
+	GeanyDocument *cur_doc = user_data;
+
+	if (cur_doc == NULL)
+		cur_doc = document_get_current();
+
+	for (i = cur_doc->index + 1; i < documents_array->len; i++)
+	{
+		GeanyDocument *doc = documents[i];
+
+		if (doc == cur_doc || ! doc->is_valid)
+	  		continue;
+
+		if (! document_close(doc))
+	  		break;
+	}
+}
+
+
 void on_close1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -169,7 +169,7 @@ void on_close_allafter1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	{
 		GeanyDocument *doc = documents[i];
 
-		if (doc == cur_doc || ! doc->is_valid)
+		if (! doc->is_valid)
 	  		continue;
 
 		if (! document_close(doc))

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -47,6 +47,8 @@ void on_close1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_close_all1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
+void on_close_allafter1_activate(GtkMenuItem *menuitem, gpointer user_data);
+
 void on_replace_tabs_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_toolbutton_search_clicked(GtkAction *action, gpointer user_data);

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -473,6 +473,12 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_other_documents1_activate), doc);
 	gtk_widget_set_sensitive(GTK_WIDGET(menu_item), (doc != NULL));
 
+	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("Close Documents To The Right"));
+	gtk_widget_show(menu_item);
+	gtk_container_add(GTK_CONTAINER(menu), menu_item);
+	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_allafter1_activate), doc);
+	gtk_widget_set_sensitive(GTK_WIDGET(menu_item), (doc != NULL));
+
 	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("C_lose All"));
 	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);


### PR DESCRIPTION
Add a "Close Documents To The Right" option to the right click context menu of documents.

This functionality mimics a feature found in the Chrome web-browser for quickly closing all open tabs after the selected one.
