### PR TITLE
Include win32defines.h before win32.h to fix build errors

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -57,6 +57,8 @@
 
 #ifdef HAVE_SOCKET
 
+#include "win32defines.h" /* should always come before any system headers */
+
 #include "socket.h"
 
 #include "app.h"
@@ -79,7 +81,6 @@
 # include <netinet/in.h>
 # include <glib/gstdio.h>
 #else
-# include "win32defines.h"
 # include <winsock2.h>
 # include <windows.h>
 # include <gdk/gdkwin32.h>

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -43,13 +43,14 @@
 # include "config.h"
 #endif
 
+#include "win32defines.h" /* should always come before any system headers */
+
 #include <errno.h>
 #include <string.h>
 
 #include "spawn.h"
 
 #ifdef G_OS_WIN32
-# include "win32defines.h"
 # include <ctype.h>    /* isspace() */
 # include <fcntl.h>    /* _O_RDONLY, _O_WRONLY */
 # include <io.h>       /* _open_osfhandle, _close */

--- a/src/win32.c
+++ b/src/win32.c
@@ -27,11 +27,11 @@
 # include "config.h"
 #endif
 
+#include "win32defines.h" /* should always come before any system headers */
+
 #include "win32.h"
 
 #ifdef G_OS_WIN32
-
-#include "win32defines.h"
 
 #include "dialogs.h"
 #include "document.h"
@@ -982,14 +982,14 @@ gchar *win32_get_shortcut_target(const gchar *file_name)
 	gchar *path = NULL;
 	wchar_t *wfilename = g_utf8_to_utf16(file_name, -1, NULL, NULL, NULL);
 	HWND hWnd = NULL;
-	
+
 	if (main_widgets.window != NULL)
 	{
 		GdkWindow *window = gtk_widget_get_window(main_widgets.window);
 		if (window != NULL)
 			hWnd = GDK_WINDOW_HWND(window);
 	}
-	
+
 	resolve_link(hWnd, wfilename, &path);
 	g_free(wfilename);
 

--- a/src/win32defines.h
+++ b/src/win32defines.h
@@ -25,6 +25,7 @@
 #define WIN32_LEAN_AND_MEAN
 /* Need Windows XP for SHGetFolderPathAndSubDirW */
 #define WINVER 0x0501
+#define _WIN32_WINNT 0x0501
 /* Needed for SHGFP_TYPE */
 #define _WIN32_IE 0x0500
 


### PR DESCRIPTION
This should fix the problems mentioned in #567.

However, I don't get completely why win32.h includes _mingw.h or any other non-Geany headers.