### PR TITLE
Fix Doxygen warnings

### DIFF
--- a/doc/plugins.dox
+++ b/doc/plugins.dox
@@ -69,7 +69,7 @@ other useful notes.
 
 @page guidelines Plugin Writing Guidelines
 
-@section intro Introduction
+@section intro_guidelines Introduction
 
 The following hints and guidelines are only recommendations. Nobody is forced to follow
 them at all.
@@ -140,7 +140,7 @@ geany-devel at uvena.de or the plugin author directly.
 
 @page howto Plugin HowTo
 
-@section intro Introduction
+@section intro_howto Introduction
 
 Since Geany 0.12 there is a plugin interface to extend Geany's functionality and
 add new features. This document gives a brief overview about how to add new

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -198,15 +198,17 @@ static gchar *spawn_get_program_name(const gchar *command_line, GError **error)
  *  All OS:
  *     - any leading spaces, tabs and new lines are skipped
  *     - an empty command is invalid
+ *
  *  Unix:
  *     - the standard shell quoting and escaping rules are used, see @c g_shell_parse_argv()
  *     - as a consequence, an unqouted # at the start of an argument comments to the end of line
+ *
  *  Windows:
  *     - leading carriage returns are skipped too
  *     - a quoted program name must be entirely inside the quotes. No "C:\Foo\Bar".pdf or
- *       "C:\Foo\Bar".bat, which would be executed by Windows as C:\Foo\Bar.exe
- *     - an unquoted program name may not contain spaces. Foo Bar Qux will not be considered
- *       "Foo Bar.exe" Qux or "Foo Bar Qux.exe", depending on what executables exist, as
+ *       "C:\Foo\Bar".bat, which would be executed by Windows as `C:\Foo\Bar.exe`
+ *     - an unquoted program name may not contain spaces. `Foo Bar Qux` will not be considered
+ *       `"Foo Bar.exe" Qux` or `"Foo Bar Qux.exe"`, depending on what executables exist, as
  *       Windows normally does.
  *     - the program name must be separated from the arguments by at least one space or tab
  *     - the standard Windows quoting and escaping rules are used: double quote is escaped with
@@ -851,7 +853,7 @@ static void spawn_watch_cb(GPid pid, gint status, gpointer data)
  *
  *  The synchronous execution may not be combined with recursive callbacks.
  *
- *  In line buffered mode, the child input is broken on '\n', "\r\n", '\r', '\0' and max length.
+ *  In line buffered mode, the child input is broken on `\n`, `\r\n`, `\r`, `\0` and max length.
  *
  *  All I/O callbacks are guaranteed to be invoked at least once with @c G_IO_ERR, @c G_IO_HUP
  *  or @c G_IO_NVAL set (except for a @a stdin_cb which returns @c FALSE before that). For the
@@ -1020,6 +1022,10 @@ gboolean spawn_with_callbacks(const gchar *working_directory, const gchar *comma
  *  callback data, make sure that @c stdin_data exists while the child is being executed.
  *  (For example, on asynchronous execution, you can allocate the data in the heap, and free
  *  it in your @c spawn_with_callbacks() @c exit_cb callback.)
+ *
+ * @param channel the channel to write data to.
+ * @param condition condition to check for @c G_IO_OUT.
+ * @param data @c SpawnWriteData to write to @a channel.
  *
  *  @return @c TRUE if the remaining size is > 0 and @a condition does not indicate any error,
  *  @c FALSE otherwise.


### PR DESCRIPTION
This resolves warnings from Doxygen about non-existing commands
caused by unescaped backslashes as well as multiply
defined section names.

The warnings in detail:
```
/tmp/geany/doc/plugins.dox:143: warning: multiple use of section label 'intro' while adding section, (first occurrence: /tmp/geany/doc/plugins.dox, line 72)
/tmp/geany/src/spawn.c:206: warning: Found unknown command `\Foo'
/tmp/geany/src/spawn.c:206: warning: Found unknown command `\Bar'
/tmp/geany/src/spawn.c:853: warning: Found unknown command `\r'
/tmp/geany/src/spawn.c:1013: warning: parameters of member spawn_write_data are not (all) documented
```
The section name change should be pretty obvious. AFAIK in our case the section names have no relevance as they are not referenced or something.

The warnings in `spawn.c` lines 206 and 853 are caused by using backslashes but Doxygen interprets them as commands. I don't like the solution of escaping them because it makes the source comment harder to read but didn't find a better solution.

@zhekov if you have better docs for `spawn_write_data()` params, let me know.