### PR TITLE
Don't explicitly re-highlight the document when typenames change

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -509,8 +509,12 @@ static gint document_get_new_idx(void)
 }
 
 
-static void queue_colourise(GeanyDocument *doc)
+static void queue_colourise(GeanyDocument *doc, gboolean full_colourise)
 {
+	/* make sure we don't override previously set full_colourise=TRUE by FALSE */
+	if (!doc->priv->colourise_needed || !doc->priv->full_colourise)
+		doc->priv->full_colourise = full_colourise;
+
 	/* Colourise the editor before it is next drawn */
 	doc->priv->colourise_needed = TRUE;
 
@@ -1393,7 +1397,7 @@ GeanyDocument *document_open_file_full(GeanyDocument *doc, const gchar *filename
 		/* add the text to the ScintillaObject */
 		sci_set_readonly(doc->editor->sci, FALSE);	/* to allow replacing text */
 		sci_set_text(doc->editor->sci, filedata.data);	/* NULL terminated data */
-		queue_colourise(doc);	/* Ensure the document gets colourised. */
+		queue_colourise(doc, TRUE);	/* Ensure the document gets colourised. */
 
 		/* detect & set line endings */
 		editor_mode = utils_get_line_endings(filedata.data, filedata.len);
@@ -2749,7 +2753,7 @@ void document_highlight_tags(GeanyDocument *doc)
 		keywords = g_string_free(keywords_str, FALSE);
 		sci_set_keywords(doc->editor->sci, keyword_idx, keywords);
 		g_free(keywords);
-		queue_colourise(doc); /* force re-highlighting the entire document */
+		queue_colourise(doc, FALSE); /* re-highlight the visible area */
 	}
 }
 
@@ -2810,7 +2814,7 @@ static void document_load_config(GeanyDocument *doc, GeanyFiletype *type,
 		highlighting_set_styles(doc->editor->sci, type);
 		editor_set_indentation_guides(doc->editor);
 		build_menu_update(doc);
-		queue_colourise(doc);
+		queue_colourise(doc, TRUE);
 		doc->priv->symbol_list_sort_mode = type->priv->symbol_list_sort_mode;
 	}
 

--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -90,6 +90,7 @@ typedef struct GeanyDocumentPrivate
 	/* Used so Undo/Redo works for encoding changes. */
 	FileEncoding	 saved_encoding;
 	gboolean		 colourise_needed;	/* use document.c:queue_colourise() instead */
+	gboolean		 full_colourise;
 	gint			 line_count;		/* Number of lines in the document. */
 	gint			 symbol_list_sort_mode;
 	/* indicates whether a file is on a remote filesystem, works only with GIO/GVfs */

--- a/src/editor.c
+++ b/src/editor.c
@@ -4687,12 +4687,28 @@ static gboolean editor_check_colourise(GeanyEditor *editor)
 		return FALSE;
 
 	doc->priv->colourise_needed = FALSE;
-	sci_colourise(editor->sci, 0, -1);
 
-	/* now that the current document is colourised, fold points are now accurate,
-	 * so force an update of the current function/tag. */
-	symbols_get_current_function(NULL, NULL);
-	ui_update_statusbar(NULL, -1);
+	if (doc->priv->full_colourise)
+	{
+		sci_colourise(editor->sci, 0, -1);
+
+		/* now that the current document is colourised, fold points are now accurate,
+		 * so force an update of the current function/tag. */
+		symbols_get_current_function(NULL, NULL);
+		ui_update_statusbar(NULL, -1);
+	}
+	else
+	{
+		gint start_line, end_line, start, end;
+
+		start_line = SSM(doc->editor->sci, SCI_GETFIRSTVISIBLELINE, 0, 0);
+		end_line = start_line + SSM(editor->sci, SCI_LINESONSCREEN, 0, 0);
+		start_line = SSM(editor->sci, SCI_DOCLINEFROMVISIBLE, start_line, 0);
+		end_line = SSM(editor->sci, SCI_DOCLINEFROMVISIBLE, end_line, 0);
+		start = sci_get_position_from_line(editor->sci, start_line);
+		end = sci_get_line_end_position(editor->sci, end_line);
+		sci_colourise(editor->sci, start, end);
+	}
 
 	return TRUE;
 }


### PR DESCRIPTION
The recolorising the whole document is rather expensive and Scintilla
does it for us already for the visible part of the document (and lazily
updates the rest when scrolling). There don't seem to be any unwanted
side-effects of the patch.

After this patch the whole https://github.com/geany/geany/pull/518 patch becomes unnecessary because lexing is performed less and the WordList::InList() function is called less frequently and isn't such a bottleneck any more.