### PR TITLE
Set correct sidebar/message window positions before showing the…

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -105,8 +105,6 @@ static gchar *scribble_text = NULL;
 static gint scribble_pos = -1;
 static GPtrArray *session_files = NULL;
 static gint session_notebook_page;
-static gint hpan_position;
-static gint vpan_position;
 static const gchar atomic_file_saving_key[] = "use_atomic_file_saving";
 
 static GPtrArray *keyfile_groups = NULL;
@@ -1047,8 +1045,8 @@ static void load_ui_prefs(GKeyFile *config)
 		ui_prefs.geometry[3] = MAX(-1, geo[3]);
 		ui_prefs.geometry[4] = geo[4] != 0;
 	}
-	hpan_position = utils_get_setting_integer(config, PACKAGE, "treeview_position", 156);
-	vpan_position = utils_get_setting_integer(config, PACKAGE, "msgwindow_position", (geo) ?
+	ui_prefs.treeview_position = utils_get_setting_integer(config, PACKAGE, "treeview_position", 156);
+	ui_prefs.msgwindow_position = utils_get_setting_integer(config, PACKAGE, "msgwindow_position", (geo) ?
 				(GEANY_MSGWIN_HEIGHT + geo[3] - 440) :
 				(GEANY_MSGWIN_HEIGHT + GEANY_WINDOW_DEFAULT_HEIGHT - 440));
 
@@ -1286,13 +1284,6 @@ void configuration_apply_settings(void)
 		gtk_text_buffer_place_cursor(buffer, &iter);
 	}
 	g_free(scribble_text);
-
-	/* set the position of the hpaned and vpaned */
-	if (prefs.save_winpos)
-	{
-		gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "hpaned1")), hpan_position);
-		gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "vpaned1")), vpan_position);
-	}
 
 	/* set fullscreen after initial draw so that returning to normal view is the right size.
 	 * fullscreen mode is disabled by default, so act only if it is true */

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -161,6 +161,11 @@ static void setup_window_position(void)
 
 	if (ui_prefs.geometry[4] == 1)
 		gtk_window_maximize(GTK_WINDOW(main_widgets.window));
+
+	gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "hpaned1")),
+		ui_prefs.treeview_position);
+	gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "vpaned1")),
+		ui_prefs.msgwindow_position);
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -162,6 +162,8 @@ typedef struct UIPrefs
 	gboolean	allow_always_save; /* if set, files can always be saved, even if unchanged */
 	gchar		*statusbar_template;
 	gboolean	new_document_after_close;
+	gint		treeview_position;
+	gint		msgwindow_position;
 
 	/* Menu-item related data */
 	GQueue		*recent_queue;


### PR DESCRIPTION
… main winodw

At the moment there's a slightly ugly redraw of the sidebar and message window when starting Geany because configuration_apply_settings(), which sets their correct positions, is called after gtk_widget_show() on the main window. When moving it before, this issue disappears.

I'm definitely not a GTK expert and the comment above configuration_apply_settings() says it should be called after the window is realized but is this really the case? It seems to work fine even with this change and even if this isn't the correct approach, I guess there must be some way to set the initial positions before showing the window (other editors start with the correct sizes when launched).

This patch isn't meant to be applied as it is (if the comment above configuration_apply_settings() is wrong, it should be removed at least), it's mainly meant for quick testing and further discussion.
