### PR TITLE
Make it possible to define default symbol_list_sort_mode

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1543,7 +1543,7 @@
                                         <property name="can_focus">False</property>
                                         <property name="left_padding">12</property>
                                         <child>
-                                          <object class="GtkVBox" id="vbox46">
+                                          <object class="GtkVBox" id="box_sidebar_visible_children">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <child>
@@ -1555,11 +1555,75 @@
                                                 <property name="tooltip_text" translatable="yes">Toggle the symbol list on and off</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="draw_indicator">True</property>
+                                                <signal name="toggled" handler="on_show_symbol_list_toggled" swapped="no"/>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
                                                 <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkAlignment" id="alignment15">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="left_padding">12</property>
+                                                <child>
+                                                  <object class="GtkHBox" id="box_show_symbol_list_children">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="tooltip_text" translatable="yes">Default symbol sorting mode</property>
+                                                    <property name="spacing">12</property>
+                                                    <child>
+                                                      <object class="GtkLabel" id="label24">
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="label" translatable="yes">Default sorting mode:</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">0</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkRadioButton" id="radio_symbols_sort_by_name">
+                                                        <property name="label" translatable="yes">Name</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="receives_default">False</property>
+                                                        <property name="active">True</property>
+                                                        <property name="draw_indicator">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">1</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkRadioButton" id="radio_symbols_sort_by_appearance">
+                                                        <property name="label" translatable="yes">Appearance</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="receives_default">False</property>
+                                                        <property name="active">True</property>
+                                                        <property name="draw_indicator">True</property>
+                                                        <property name="group">radio_symbols_sort_by_name</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">2</property>
+                                                      </packing>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
                                               </packing>
                                             </child>
                                             <child>
@@ -1575,7 +1639,7 @@
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
-                                                <property name="position">1</property>
+                                                <property name="position">2</property>
                                               </packing>
                                             </child>
                                           </object>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1902,6 +1902,14 @@ static void on_detect_type_from_file_activate(GtkMenuItem *menuitem, gpointer us
 }
 
 
+static void on_show_symbol_list_toggled(GtkToggleButton *button, gpointer user_data)
+{
+	GtkWidget *widget = ui_lookup_widget(ui_widgets.prefs_dialog, "box_show_symbol_list_children");
+
+	gtk_widget_set_sensitive(widget, gtk_toggle_button_get_active(button));
+}
+
+
 static void on_detect_width_from_file_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();

--- a/src/document.c
+++ b/src/document.c
@@ -2734,7 +2734,10 @@ static void document_load_config(GeanyDocument *doc, GeanyFiletype *type,
 		editor_set_indentation_guides(doc->editor);
 		build_menu_update(doc);
 		queue_colourise(doc);
-		doc->priv->symbol_list_sort_mode = type->priv->symbol_list_sort_mode;
+		if (type->priv->symbol_list_sort_mode == SYMBOLS_SORT_USE_PREVIOUS)
+			doc->priv->symbol_list_sort_mode = interface_prefs.symbols_sort_mode;
+		else
+			doc->priv->symbol_list_sort_mode = type->priv->symbol_list_sort_mode;
 	}
 
 	document_update_tags(doc);

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -965,7 +965,7 @@ static void load_settings(guint ft_id, GKeyFile *config, GKeyFile *configh)
 	}
 
 	ft->priv->symbol_list_sort_mode = utils_get_setting(integer, configh, config, "settings",
-		"symbol_list_sort_mode", SYMBOLS_SORT_BY_NAME);
+		"symbol_list_sort_mode", SYMBOLS_SORT_USE_PREVIOUS);
 	ft->priv->xml_indent_tags = utils_get_setting(boolean, configh, config, "settings",
 		"xml_indent_tags", FALSE);
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -48,6 +48,7 @@
 #include "sciwrappers.h"
 #include "stash.h"
 #include "support.h"
+#include "symbols.h"
 #include "templates.h"
 #include "toolbar.h"
 #include "ui_utils.h"
@@ -160,6 +161,11 @@ static void init_pref_groups(void)
 		"sidebar_pos", GTK_POS_LEFT,
 		"radio_sidebar_left", GTK_POS_LEFT,
 		"radio_sidebar_right", GTK_POS_RIGHT,
+		NULL);
+	stash_group_add_radio_buttons(group, &interface_prefs.symbols_sort_mode,
+		"symbols_sort_mode", SYMBOLS_SORT_BY_NAME,
+		"radio_symbols_sort_by_name", SYMBOLS_SORT_BY_NAME,
+		"radio_symbols_sort_by_appearance", SYMBOLS_SORT_BY_APPEARANCE,
 		NULL);
 	stash_group_add_radio_buttons(group, &interface_prefs.msgwin_orientation,
 		"msgwin_orientation", GTK_ORIENTATION_VERTICAL,

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1558,8 +1558,7 @@ static void on_sidebar_visible_toggled(GtkToggleButton *togglebutton, gpointer u
 {
 	gboolean sens = gtk_toggle_button_get_active(togglebutton);
 
-	gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "check_list_openfiles"), sens);
-	gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "check_list_symbol"), sens);
+	gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "box_sidebar_visible_children"), sens);
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -68,6 +68,7 @@ typedef struct GeanyInterfacePrefs
 	/** whether compiler messages window is automatically scrolled to show new messages */
 	gboolean		compiler_tab_autoscroll;
 	gint			msgwin_orientation;			/**< orientation of the message window */
+	gint 			symbols_sort_mode;			/**< symbol list sorting mode */
 }
 GeanyInterfacePrefs;
 


### PR DESCRIPTION
Both sorting by name and appearance makes sense for most languages. Some
users may prefer sorting by appearance so make it configurable in
preferences (the possibility to override the settings for specific
filetypes is preserved).

Fixes #313.