### PR TITLE
Support relative project paths

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -168,9 +168,9 @@ static gboolean open_file_dialog_handle_response(GtkWidget *dialog, gint respons
 		}
 		g_slist_free(filelist);
 	}
-	if (app->project && !EMPTY(app->project->base_path))
+	if (app->project)
 		gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(dialog),
-			app->project->base_path, NULL);
+			project_get_base_path(), NULL);
 	return ret;
 }
 
@@ -474,9 +474,9 @@ void dialogs_show_open_file(void)
 		if (initdir != NULL && g_path_is_absolute(initdir))
 				gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), initdir);
 
-		if (app->project && !EMPTY(app->project->base_path))
+		if (app->project)
 			gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(dialog),
-					app->project->base_path, NULL);
+				project_get_base_path(), NULL);
 
 		while (!open_file_dialog_handle_response(dialog,
 			gtk_dialog_run(GTK_DIALOG(dialog))));
@@ -637,9 +637,9 @@ static gboolean show_save_as_gtk(GeanyDocument *doc)
 		g_free(fname);
 	}
 
-	if (app->project && !EMPTY(app->project->base_path))
+	if (app->project)
 		gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(dialog),
-			app->project->base_path, NULL);
+			project_get_base_path(), NULL);
 
 	/* Run the dialog synchronously, pausing this function call */
 	do
@@ -648,9 +648,9 @@ static gboolean show_save_as_gtk(GeanyDocument *doc)
 	}
 	while (! save_as_dialog_handle_response(dialog, resp));
 
-	if (app->project && !EMPTY(app->project->base_path))
+	if (app->project)
 		gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(dialog),
-			app->project->base_path, NULL);
+			project_get_base_path(), NULL);
 
 	gtk_widget_destroy(dialog);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1631,9 +1631,9 @@ guint utils_string_regex_replace_all(GString *haystack, GRegex *regex,
 /* Get project or default startup directory (if set), or NULL. */
 const gchar *utils_get_default_dir_utf8(void)
 {
-	if (app->project && !EMPTY(app->project->base_path))
+	if (app->project)
 	{
-		return app->project->base_path;
+		return project_get_base_path();
 	}
 
 	if (!EMPTY(prefs.default_open_path))


### PR DESCRIPTION
According to the documentation, the relative path `./` can be used to refer to the directory of the project file.

However, this is not the observed behavior in the app. If such a relative path is set in the project properties, the Open File, Save File, Find in Files, and other dialogs default to `~` instead of the actual project directory. In addition, the project directory is not added automatically to the Open File and Save File dialog sidebars, as they are added when using an absolute path for the project directory.

This pull request fixes this bug in the three dialogs mentioned and possibly in other places.