### PR TITLE
Vs find dialog style

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1252,8 +1252,7 @@ gboolean on_search_key_press_event(GtkWidget *widget, GdkEventKey *ev, gpointer 
                         group == keybindings_get_core_group(GEANY_KEY_GROUP_CLIPBOARD)  ||
                         group == keybindings_get_core_group(GEANY_KEY_GROUP_SELECT)             ||
                         group == keybindings_get_core_group(GEANY_KEY_GROUP_INSERT)             ||
-                        group == keybindings_get_core_group(GEANY_KEY_GROUP_GOTO)               ||
-                        group == keybindings_get_core_group(GEANY_KEYS_HELP_HELP)
+                        group == keybindings_get_core_group(GEANY_KEY_GROUP_GOTO)
                         )
                         continue;
                         

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -432,9 +432,7 @@ static void on_open_in_new_window_activate(GtkMenuItem *menuitem, gpointer user_
 static void on_copy_full_path_activate_cb (GtkButton *button, gpointer user_data)
 {
         GeanyDocument *doc = NULL;
-        gint cur_page = gtk_notebook_page_num(GTK_NOTEBOOK(main_widgets.notebook), GTK_WIDGET(user_data));
-        doc = document_get_from_page(cur_page);
-
+	doc = (GeanyDocument*) user_data;
         if(doc && doc->real_path)
                 gtk_clipboard_set_text(
                                 gtk_clipboard_get(gdk_atom_intern("CLIPBOARD", FALSE)),
@@ -495,14 +493,19 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
         gtk_widget_show(menu_item);
         gtk_container_add(GTK_CONTAINER(menu), menu_item);
 
+        menu_item = gtk_separator_menu_item_new();
+        gtk_widget_show(menu_item);
+        gtk_container_add(GTK_CONTAINER(menu), menu_item);
+
         menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("Copy Full Path"));
         gtk_widget_show(menu_item);
         gtk_container_add(GTK_CONTAINER(menu), menu_item);
-        g_signal_connect(menu_item, "activate", G_CALLBACK(on_copy_full_path_activate_cb), page);
-        gtk_widget_set_sensitive(GTK_WIDGET(menu_item), (page != NULL));
+        g_signal_connect(menu_item, "activate", G_CALLBACK(on_copy_full_path_activate_cb),  doc );
+        gtk_widget_set_sensitive(GTK_WIDGET(menu_item), (doc != NULL));
         /* disable if not on disk */
         if (doc == NULL || !doc->real_path)
                 gtk_widget_set_sensitive(menu_item, FALSE);
+
 
 
 	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event->button, event->time);

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -429,6 +429,19 @@ static void on_open_in_new_window_activate(GtkMenuItem *menuitem, gpointer user_
 	g_free(doc_path);
 }
 
+static void on_copy_full_path_activate_cb (GtkButton *button, gpointer user_data)
+{
+        GeanyDocument *doc = NULL;
+        gint cur_page = gtk_notebook_page_num(GTK_NOTEBOOK(main_widgets.notebook), GTK_WIDGET(user_data));
+        doc = document_get_from_page(cur_page);
+
+        if(doc && doc->real_path)
+                gtk_clipboard_set_text(
+                                gtk_clipboard_get(gdk_atom_intern("CLIPBOARD", FALSE)),
+                                doc->real_path,
+                                strlen(doc->real_path));
+}
+
 
 static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 {
@@ -477,6 +490,20 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_all1_activate), NULL);
+
+        menu_item = gtk_separator_menu_item_new();
+        gtk_widget_show(menu_item);
+        gtk_container_add(GTK_CONTAINER(menu), menu_item);
+
+        menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("Copy Full Path"));
+        gtk_widget_show(menu_item);
+        gtk_container_add(GTK_CONTAINER(menu), menu_item);
+        g_signal_connect(menu_item, "activate", G_CALLBACK(on_copy_full_path_activate_cb), page);
+        gtk_widget_set_sensitive(GTK_WIDGET(menu_item), (page != NULL));
+        /* disable if not on disk */
+        if (doc == NULL || !doc->real_path)
+                gtk_widget_set_sensitive(menu_item, FALSE);
+
 
 	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event->button, event->time);
 }

--- a/src/search.c
+++ b/src/search.c
@@ -746,10 +746,11 @@ void search_show_replace_dialog(void)
 
 	sel = editor_get_default_selection(doc->editor, search_prefs.use_current_word, NULL);
 
-if(replace_dlg.dialog)
-        {gtk_widget_destroy(replace_dlg.dialog);replace_dlg.dialog=NULL;}
+if(find_dlg.dialog)
+        {gtk_widget_destroy(find_dlg.dialog);find_dlg.dialog=NULL;}
 if(fif_dlg.dialog)
         {gtk_widget_destroy(fif_dlg.dialog);fif_dlg.dialog=NULL;}
+
 
 
 	if (replace_dlg.dialog == NULL)
@@ -761,7 +762,7 @@ if(fif_dlg.dialog)
 
 		set_dialog_position(replace_dlg.dialog, replace_dlg.position);
 		gtk_widget_show_all(replace_dlg.dialog);
-                g_signal_connect (GTK_DIALOG (find_dlg.dialog),"key-press-event", G_CALLBACK(on_search_key_press_event), NULL);
+                g_signal_connect (GTK_DIALOG (replace_dlg.dialog),"key-press-event", G_CALLBACK(on_search_key_press_event), NULL);
 	}
 	else
 	{

--- a/src/search.c
+++ b/src/search.c
@@ -144,6 +144,7 @@ static struct
 }
 fif_dlg = {NULL, NULL, NULL, NULL, NULL, NULL, {0, 0}};
 
+extern gboolean on_search_key_press_event(GtkWidget *widget, GdkEventKey *event, gpointer user_data);
 
 static void search_read_io(GString *string, GIOCondition condition, gpointer data);
 static void search_read_io_stderr(GString *string, GIOCondition condition, gpointer data);
@@ -737,6 +738,12 @@ void search_show_replace_dialog(void)
 
 	sel = editor_get_default_selection(doc->editor, search_prefs.use_current_word, NULL);
 
+if(replace_dlg.dialog)
+        {gtk_widget_destroy(replace_dlg.dialog);replace_dlg.dialog=NULL;}
+if(fif_dlg.dialog)
+        {gtk_widget_destroy(fif_dlg.dialog);fif_dlg.dialog=NULL;}
+
+
 	if (replace_dlg.dialog == NULL)
 	{
 		create_replace_dialog();
@@ -746,11 +753,12 @@ void search_show_replace_dialog(void)
 
 		set_dialog_position(replace_dlg.dialog, replace_dlg.position);
 		gtk_widget_show_all(replace_dlg.dialog);
+                g_signal_connect (GTK_DIALOG (find_dlg.dialog),"key-press-event", G_CALLBACK(on_search_key_press_event), NULL);
 	}
 	else
 	{
 		/* only set selection if the dialog is not already visible */
-		if (! gtk_widget_get_visible(replace_dlg.dialog) && sel)
+	//	if (! gtk_widget_get_visible(replace_dlg.dialog) && sel)
 			gtk_entry_set_text(GTK_ENTRY(replace_dlg.find_entry), sel);
 		if (sel != NULL) /* when we have a selection, reset the entry widget's background colour */
 			ui_set_search_entry_background(replace_dlg.find_entry, TRUE);
@@ -1045,10 +1053,18 @@ void search_show_find_in_files_dialog_full(const gchar *text, const gchar *dir)
 	gchar *cur_dir = NULL;
 	GeanyEncodingIndex enc_idx = GEANY_ENCODING_UTF_8;
 
+if(find_dlg.dialog)
+        {gtk_widget_destroy(find_dlg.dialog);find_dlg.dialog=NULL;}
+if(replace_dlg.dialog)
+        {gtk_widget_destroy(replace_dlg.dialog);replace_dlg.dialog=NULL;}
+
+
+
 	if (fif_dlg.dialog == NULL)
 	{
 		create_fif_dialog();
 		gtk_widget_show_all(fif_dlg.dialog);
+                g_signal_connect (GTK_DIALOG (fif_dlg.dialog),"key-press-event", G_CALLBACK(on_search_key_press_event), NULL);
 		if (doc && !text)
 			sel = editor_get_default_selection(doc->editor, search_prefs.use_current_word, NULL);
 	}
@@ -1057,7 +1073,7 @@ void search_show_find_in_files_dialog_full(const gchar *text, const gchar *dir)
 	if (!text)
 	{
 		/* only set selection if the dialog is not already visible, or has just been created */
-		if (doc && ! sel && ! gtk_widget_get_visible(fif_dlg.dialog))
+		//if (doc && ! sel && ! gtk_widget_get_visible(fif_dlg.dialog))
 			sel = editor_get_default_selection(doc->editor, search_prefs.use_current_word, NULL);
 
 		text = sel;

--- a/src/search.c
+++ b/src/search.c
@@ -562,6 +562,12 @@ void search_show_find_dialog(void)
 
 	sel = editor_get_default_selection(doc->editor, search_prefs.use_current_word, NULL);
 
+if(replace_dlg.dialog)
+        {gtk_widget_destroy(replace_dlg.dialog);replace_dlg.dialog=NULL;}
+if(fif_dlg.dialog)
+        {gtk_widget_destroy(fif_dlg.dialog);fif_dlg.dialog=NULL;}
+
+
 	if (find_dlg.dialog == NULL)
 	{
 		create_find_dialog();
@@ -571,11 +577,13 @@ void search_show_find_dialog(void)
 
 		set_dialog_position(find_dlg.dialog, find_dlg.position);
 		gtk_widget_show_all(find_dlg.dialog);
+		g_signal_connect (GTK_DIALOG (find_dlg.dialog),"key-press-event", G_CALLBACK(on_search_key_press_event), NULL);
+
 	}
 	else
 	{
 		/* only set selection if the dialog is not already visible */
-		if (! gtk_widget_get_visible(find_dlg.dialog) && sel)
+//		if (! gtk_widget_get_visible(find_dlg.dialog) && sel)
 			gtk_entry_set_text(GTK_ENTRY(find_dlg.entry), sel);
 		gtk_widget_grab_focus(find_dlg.entry);
 		set_dialog_position(find_dlg.dialog, find_dlg.position);


### PR DESCRIPTION
1) Changes the "Find" dialog box behavior like VS
[CTRL]-F, 
[CTRL]-H, 
[CTRL]-[SHIFT]-F 
behavior is changed mimicking VS IDE style.
a) Only one dialog can be displayed at the time.
b) Marked text is automatically loaded as text to find

2) Attaches to the tab menu an option giving the full path of the open file.
Very handy when writing/commenting about code.