### PR TITLE
Updated Rust keywords + indentation defaults

### DIFF
--- a/data/filetypes.rust
+++ b/data/filetypes.rust
@@ -25,8 +25,8 @@ lexerror=error
 
 [keywords]
 # all items must be in one line
-primary=alignof as be box break const continue crate do else enum extern false fn for if impl in let loop match mod mut offsetof once priv proc pub pure ref return self sizeof static struct super trait true type typeof unsafe unsized use virtual while yield
-secondary=bool char f32 f64 i16 i32 i64 i8 int str u16 u32 u64 u8 uint
+primary=abstract alignof as become box break const continue crate do else enum extern false final fn for if impl in let loop macro match mod move mut offsetof override priv proc pub pure ref return self sizeof static struct super trait true type typeof unsafe unsized use virtual where while yield
+secondary=bool char f32 f64 i8 i16 i32 i64 int isize str u8 u16 u32 u64 uint usize
 tertiary=Self
 
 [lexer_properties]
@@ -60,7 +60,7 @@ context_action_cmd=
 [indentation]
 #width=4
 # 0 is spaces, 1 is tabs, 2 is tab & spaces
-#type=1
+#type=0
 
 [build-menu]
 FT_00_LB=Compile


### PR DESCRIPTION
Indentation per official style guide: https://aturon.github.io/style/whitespace.html
Keywords updated to match https://github.com/rust-lang/rust/blob/master/src/libsyntax/parse/token.rs