### PR TITLE
Improve "Open in New Window" feature

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -2156,18 +2156,17 @@ const gchar *utils_resource_dir(GeanyResourceDirType type)
 // Attempts to get the path to the executable for this Geany instance
 static gchar *utils_find_self_executable(void)
 {
+	gchar *exe_file;
+
 #if defined(MAC_INTEGRATION)
 	// GtkOSX integration library provides a wrapper to get path from bundle
-	if (is_osx_bundle())
-	{
-		gchar *exec_file = gtkosx_application_get_executable_path();
-		if (exec_file != NULL)
-			return exe_file;
-	}
+	exe_file = gtkosx_application_get_executable_path();
+	if (exe_file != NULL)
+		return exe_file;
 #endif
 
 	// Try using the installation directory
-	gchar *exe_file = g_build_filename(GEANY_PREFIX, "bin", "geany", NULL);
+	exe_file = g_build_filename(GEANY_PREFIX, "bin", "geany", NULL);
 	if (g_file_test(exe_file, G_FILE_TEST_IS_EXECUTABLE))
 		return exe_file;
 	g_free(exe_file);


### PR DESCRIPTION
Make an attempt to use the same executable file for the new window as the current instance of Geany. Also flush configuration to disk and provide path to it for the new instance using the `-c` option.

Not mentioned in the commit message, I also changed the error cases to use `ui_set_statusbar()` instead of `g_printerr()` to give a little better feedback to the user if it fails.

<del>The extra steps to find the correct Geany executable should fall back to the existing behaviour if they fail. <del>There's some [additional platform-specific ways to find the executable path](http://stackoverflow.com/a/1024937) if someone feels like implementing them.</del>(done)</del>(people didn't like I guess).

<del>The Win32 code path is not tested but "should work" (famous last words) barring any typos.</del>(uses same code as other platforms now).

<del>The OSX bundle case is not handled yet, see the `TODO:` comments left in the source.</del>


<del>I updated my branch. As before it still tries the platform-specific ways to get the executable path first, and then falls back to other ways if they fail.</del>


<del>Currently supports:</del>
- <del>Linux</del>
- <del>Windows</del>
- <del>OSX with or without bundle (untested)</del>
- <del>FreeBSD, NetBSD, DragonFly BSD (untested)</del>
- <del>Every other platform Geany supports</del>
  - <del>If Geany is installed, it should be correct executable</del>
  - <del>If not, it will be correct executable if same `geany` is in the `PATH` (as before)</del>

An additional change added, as with PR #446 it tries the actual installation path if the platform-specific way failed, before finally falling back to the existing `g_find_program_in_path()`. Unlike PR #446, it tries to use the same configuration directory by passing `-c` argument.

Unlike PR #606, it doesn't try to use the program name from `argv[0]` because it's not really a great candidate as it might not even contain a path, let alone the path to the actual executable, and also I didn't really understand the logic in that PR with respect to trying to extract a meaningful path from it. This could be added as a final fallback before trying `g_find_program_in_path()` if people really want it.

<del>It's kind of ugly using platform-specific code like this, but this really is a platform-specific thing trying to be determined and all of that code is nicely isolated inside a single trivial function (instead of spread around more as with PR #606). If people really don't like the platform-specific code, we could remove the roughly 60-70 lines of commented `#ifdef` stuff in `utils_find_self_executable()` and it would be pretty much like an improved version of PR #446.</del>(done)

I should also note that it's still using `utils_spawn_async()` instead of the new spawn functions, just because it's kind of unrelated to the PR. If anyone wants to use other functions, we could add that as a separate commit.
