### PR TITLE
Support relative project paths (by providing absolute path property)

### DIFF
--- a/plugins/filebrowser.c
+++ b/plugins/filebrowser.c
@@ -365,7 +365,7 @@ static gchar *get_default_dir(void)
 	GeanyProject *project = geany->app->project;
 
 	if (project)
-		dir = project->base_path;
+		dir = project->abs_path;
 	else
 		dir = geany->prefs->default_open_path;
 
@@ -1047,21 +1047,10 @@ static void project_change_cb(G_GNUC_UNUSED GObject *obj, G_GNUC_UNUSED GKeyFile
 	gchar *new_dir;
 	GeanyProject *project = geany->app->project;
 
-	if (! fb_set_project_base_path || project == NULL || EMPTY(project->base_path))
+	if (! fb_set_project_base_path || project == NULL || EMPTY(project->abs_path))
 		return;
 
-	/* TODO this is a copy of project_get_base_path(), add it to the plugin API */
-	if (g_path_is_absolute(project->base_path))
-		new_dir = g_strdup(project->base_path);
-	else
-	{	/* build base_path out of project file name's dir and base_path */
-		gchar *dir = g_path_get_dirname(project->file_name);
-
-		new_dir = g_strconcat(dir, G_DIR_SEPARATOR_S, project->base_path, NULL);
-		g_free(dir);
-	}
-	/* get it into locale encoding */
-	SETPTR(new_dir, utils_get_locale_from_utf8(new_dir));
+	new_dir = project->abs_path;
 
 	if (! utils_str_equal(current_dir, new_dir))
 	{

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1399,10 +1399,10 @@ void on_menu_open_selected_file1_activate(GtkMenuItem *menuitem, gpointer user_d
 			filename = g_build_path(G_DIR_SEPARATOR_S, path, sel, NULL);
 
 			if (! g_file_test(filename, G_FILE_TEST_EXISTS) &&
-				app->project != NULL && !EMPTY(app->project->base_path))
+				app->project != NULL && !EMPTY(app->project->abs_path))
 			{
 				/* try the project's base path */
-				SETPTR(path, project_get_base_path());
+				SETPTR(path, app->project->abs_path);
 				SETPTR(path, utils_get_locale_from_utf8(path));
 				SETPTR(filename, g_build_path(G_DIR_SEPARATOR_S, path, sel, NULL));
 			}

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -168,9 +168,9 @@ static gboolean open_file_dialog_handle_response(GtkWidget *dialog, gint respons
 		}
 		g_slist_free(filelist);
 	}
-	if (app->project && !EMPTY(app->project->base_path))
+	if (app->project && !EMPTY(app->project->abs_path))
 		gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(dialog),
-			app->project->base_path, NULL);
+			app->project->abs_path, NULL);
 	return ret;
 }
 
@@ -474,9 +474,9 @@ void dialogs_show_open_file(void)
 		if (initdir != NULL && g_path_is_absolute(initdir))
 				gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), initdir);
 
-		if (app->project && !EMPTY(app->project->base_path))
+		if (app->project && !EMPTY(app->project->abs_path))
 			gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(dialog),
-					app->project->base_path, NULL);
+					app->project->abs_path, NULL);
 
 		while (!open_file_dialog_handle_response(dialog,
 			gtk_dialog_run(GTK_DIALOG(dialog))));
@@ -637,9 +637,9 @@ static gboolean show_save_as_gtk(GeanyDocument *doc)
 		g_free(fname);
 	}
 
-	if (app->project && !EMPTY(app->project->base_path))
+	if (app->project && !EMPTY(app->project->abs_path))
 		gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(dialog),
-			app->project->base_path, NULL);
+			app->project->abs_path, NULL);
 
 	/* Run the dialog synchronously, pausing this function call */
 	do
@@ -648,9 +648,9 @@ static gboolean show_save_as_gtk(GeanyDocument *doc)
 	}
 	while (! save_as_dialog_handle_response(dialog, resp));
 
-	if (app->project && !EMPTY(app->project->base_path))
+	if (app->project && !EMPTY(app->project->abs_path))
 		gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(dialog),
-			app->project->base_path, NULL);
+			app->project->abs_path, NULL);
 
 	gtk_widget_destroy(dialog);
 

--- a/src/project.c
+++ b/src/project.c
@@ -440,6 +440,7 @@ static void destroy_project(gboolean open_default)
 	g_free(app->project->description);
 	g_free(app->project->file_name);
 	g_free(app->project->base_path);
+	g_free(app->project->abs_path);
 	g_strfreev(app->project->file_patterns);
 
 	g_free(app->project);
@@ -796,6 +797,7 @@ static gboolean update_config(const PropertyDialogElements *e, gboolean new_proj
 	SETPTR(p->file_name, g_strdup(file_name));
 	/* use "." if base_path is empty */
 	SETPTR(p->base_path, g_strdup(!EMPTY(base_path) ? base_path : "./"));
+	SETPTR(p->abs_path, project_get_base_path());
 
 	if (! new_project)	/* save properties specific fields */
 	{
@@ -1054,6 +1056,7 @@ static gboolean load_config(const gchar *filename)
 	p->description = utils_get_setting_string(config, "project", "description", "");
 	p->file_name = utils_get_utf8_from_locale(filename);
 	p->base_path = utils_get_setting_string(config, "project", "base_path", "");
+	p->abs_path = project_get_base_path();
 	p->file_patterns = g_key_file_get_string_list(config, "project", "file_patterns", NULL, NULL);
 
 	p->priv->long_line_behaviour = utils_get_setting_integer(config, "long line marker",
@@ -1148,7 +1151,7 @@ static gboolean write_config(gboolean emit_signal)
 }
 
 
-/** Forces the project file rewrite and emission of the project-save signal. Plugins 
+/** Forces the project file rewrite and emission of the project-save signal. Plugins
  * can use this function to save additional project data outside the project dialog.
  *
  *  @since 1.25

--- a/src/project.h
+++ b/src/project.h
@@ -37,6 +37,7 @@ typedef struct GeanyProject
 	gchar *description; 	/**< Short description of the project. */
 	gchar *file_name; 		/**< Where the project file is stored (in UTF-8). */
 	gchar *base_path;		/**< Base path of the project directory (in UTF-8, maybe relative). */
+	gchar *abs_path;	/**< Base path of the project directory (in UTF-8, guaranteed absolute). */
 	/** Identifier whether it is a pure Geany project or modified/extended
 	 * by a plugin. */
 	gint type;

--- a/src/search.c
+++ b/src/search.c
@@ -1069,10 +1069,10 @@ void search_show_find_in_files_dialog_full(const gchar *text, const gchar *dir)
 
 	/* add project's base path directory to the dir list, we do this here once
 	 * (in create_fif_dialog() it would fail if a project is opened after dialog creation) */
-	if (app->project != NULL && !EMPTY(app->project->base_path))
+	if (app->project != NULL && !EMPTY(app->project->abs_path))
 	{
 		ui_combo_box_prepend_text_once(GTK_COMBO_BOX_TEXT(fif_dlg.dir_combo),
-			app->project->base_path);
+			app->project->abs_path);
 	}
 
 	entry = gtk_bin_get_child(GTK_BIN(fif_dlg.dir_combo));
@@ -1704,7 +1704,7 @@ search_find_in_files(const gchar *utf8_search_text, const gchar *utf8_dir, const
 		NULL, &error))
  	{
 		gchar *utf8_str;
- 
+
  		ui_progress_bar_start(_("Searching..."));
  		msgwin_set_messages_dir(dir);
 		utf8_str = g_strdup_printf(_("%s %s -- %s (in directory: %s)"),

--- a/src/utils.c
+++ b/src/utils.c
@@ -1631,9 +1631,9 @@ guint utils_string_regex_replace_all(GString *haystack, GRegex *regex,
 /* Get project or default startup directory (if set), or NULL. */
 const gchar *utils_get_default_dir_utf8(void)
 {
-	if (app->project && !EMPTY(app->project->base_path))
+	if (app->project && !EMPTY(app->project->abs_path))
 	{
-		return app->project->base_path;
+		return app->project->abs_path;
 	}
 
 	if (!EMPTY(prefs.default_open_path))


### PR DESCRIPTION
This is a different approach to #586 as suggested in https://github.com/geany/geany/pull/32#issuecomment-4561744.

> According to the documentation, the relative path `./` can be used to refer to the directory of the project file.
> 
> However, this is not the observed behavior in the app. If such a relative path is set in the project properties, the Open File, Save File, Find in Files, and other dialogs default to `~` instead of the actual project directory. In addition, the project directory is not added automatically to the Open File and Save File dialog sidebars, as they are added when using an absolute path for the project directory.
> 
> This pull request fixes this bug in the three dialogs mentioned and possibly in other places.
