### PR TITLE
Fix "Open in New Window"

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -50,6 +50,7 @@ typedef struct GeanyApp
 	gchar				*docdir;
 	const TMWorkspace	*tm_workspace;	/**< TagManager workspace/session tags. */
 	struct GeanyProject	*project;		/**< Currently active project or @c NULL if none is open. */
+	gchar				*executable;	/**< Full Geany executable name or @c NULL if not determined. */
 }
 GeanyApp;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -308,6 +308,8 @@ gchar *utils_parse_and_format_build_date(const gchar *input);
 
 gchar *utils_get_user_config_dir(void);
 
+gboolean utils_is_osx_bundle(void);
+
 const gchar *utils_resource_dir(GeanyResourceDirType type);
 
 void utils_start_new_geany_instance(const gchar *doc_path);

--- a/src/win32.c
+++ b/src/win32.c
@@ -1024,4 +1024,12 @@ gchar *win32_get_user_config_dir(void)
 	return g_build_filename(g_get_user_config_dir(), "geany", NULL);
 }
 
+
+gchar *win32_get_executable_path(void)
+{
+	gchar buffer[MAX_PATH];
+
+	return GetModuleFileName(NULL, buffer, MAX_PATH) ? g_strdup(buffer) : NULL;
+}
+
 #endif

--- a/src/win32.h
+++ b/src/win32.h
@@ -68,6 +68,8 @@ gchar *win32_expand_environment_variables(const gchar *str);
 
 gchar *win32_get_user_config_dir(void);
 
+gchar *win32_get_executable_path(void);
+
 G_END_DECLS
 
 #endif /* G_OS_WIN32 */


### PR DESCRIPTION
My own attempt to fix #590, inspired by PR #597.

Win~1: the Windows executable name is preffered. Failing that, the *nix procedure is used.

OSX bundle: Bundle executable name is preffered. Failing that, open Geany is used, with --args for OSX >= 10.6.

Unix: if argv[0] is not a basename, realpath(argv[0]) is preffered. Failing that, g_get_prgname (~= basename argv[0]) is attempted, and then "geany".

Whoever has OSX, please test with "app->executable = NULL" instead of "= gtkosx_application_get_executable_path()" in libmain, and fix the MAC code in utils.c if needed.

Due to some last-moment changes, there si a chance that the compilation under Win~1 may fail. I'll re-check it soon.

@elextr 

Fixed realpath(basename).

@codebrainz 

If I say once again that something may be done "easy" and "platform independent", reming me to hit myself with something heavy. Thanks in advance.