### PR TITLE
Rust updates

### DIFF
--- a/data/filetypes.rust
+++ b/data/filetypes.rust
@@ -25,8 +25,8 @@ lexerror=error
 
 [keywords]
 # all items must be in one line
-primary=alignof as be box break const continue crate do else enum extern false fn for if impl in let loop match mod mut offsetof once priv proc pub pure ref return self sizeof static struct super trait true type typeof unsafe unsized use virtual while yield
-secondary=bool char f32 f64 i16 i32 i64 i8 int str u16 u32 u64 u8 uint
+primary=abstract alignof as become box break const continue crate do else enum extern false final fn for if impl in let loop macro match mod move mut offsetof override priv proc pub pure ref return self sizeof static struct super trait true type typeof unsafe unsized use virtual where while yield
+secondary=bool char f32 f64 i16 i32 i64 i8 isize str u16 u32 u64 u8 usize
 tertiary=Self
 
 [lexer_properties]

--- a/tagmanager/ctags/rust.c
+++ b/tagmanager/ctags/rust.c
@@ -650,7 +650,8 @@ static void parseQualifiedType (lexerState *lexer, vString* name)
 	{
 		if (lexer->cur_token == TOKEN_IDENT)
 		{
-			if (strcmp(lexer->token_str->buffer, "for") == 0)
+			if (strcmp(lexer->token_str->buffer, "for") == 0
+				|| strcmp(lexer->token_str->buffer, "where") == 0)
 				break;
 			vStringClear(name);
 			vStringCat(name, lexer->token_str);

--- a/tests/ctags/test_input.rs
+++ b/tests/ctags/test_input.rs
@@ -2,16 +2,14 @@
 #![feature(globs)]
 #![feature(macro_rules)]
 use std::*;
-use std::io::stdio::println;
 use test_input2::*;
 mod test_input2;
 
-fn lifetime_and_char<'lifetime>(_: &'lifetime int)
+fn lifetime_and_char<'lifetime>(_: &'lifetime isize)
 {
 	let s = '"';
 	let s = '}';
 	let s = '\'';
-	let s = '\uffff';
 	fn not_hidden_by_char() {}
 }
 
@@ -19,15 +17,15 @@ fn preserve_string_delims(_bar: extern r#"C"# fn()) {}
 
 pub struct A
 {
-	foo: fn() -> int,
-	bar: int
+	foo: fn() -> isize,
+	bar: isize
 }
 
 pub struct B
 {
 	#[cfg(test)]
-	foo: int,
-	bar: int
+	foo: isize,
+	bar: isize
 }
 
 /*
@@ -41,11 +39,11 @@ pub struct B
  fn ignored_in_nested_comment() {}
  */
 
-static size: uint = 1;
+static size: usize = 1;
 
 #[cfg(test)]
 struct S1 {
-	priv only_field: [int, ..size]
+	only_field: [isize; size]
 }
 
 macro_rules! test_macro
@@ -53,28 +51,28 @@ macro_rules! test_macro
 	() => {1}
 }
 
-macro_rules! ignore (($($x:tt)*) => (()))
+macro_rules! ignore {($($x:tt)*) => (())}
 
-fn yada(a:int,c:Foo,b:test_input2::fruit::SomeStruct) -> String {
+fn yada(a:isize,c:Foo,b:test_input2::fruit::SomeStruct) -> String {
 	a.to_string()
 }
 
 fn main() {	
 	use test_input2::fruit::*;	
-	io::println(foo_bar_test_func(SomeStruct{red_value:1,green_value:2,blue_value:3},(4,5)).to_string().as_slice());
+	println!("{}", foo_bar_test_func(SomeStruct{red_value:1,green_value:2,blue_value:3},(4,5)).to_string());
 	let a=Foo{foo_field_1:2};
 	a.my_method(1);
-	let c=a_cat(3);
+	let c=Animal::a_cat(3);
 	let d=Foo{foo_field_1:a.foo_field_1+2}; a.test();
-	println(a.foo_field_1.to_string().as_slice());
+	println!("{}", a.foo_field_1.to_string());
 	ignore!
 	(
 		fn ignored_inside_macro() {}
-	)
+	);
 	ignore!
 	[
 		fn ignored_inside_macro() {}
-	]
+	];
 	ignore!
 	{
 		fn ignored_inside_macro() {}
@@ -88,26 +86,26 @@ fn main() {
 	fn nested() {}
 }
 
-struct Bar(int);
+struct Bar(isize);
 
-struct Baz(int);
+struct Baz(isize);
 
-struct Foo{foo_field_1:int}
+struct Foo{foo_field_1:isize}
 
 struct Foo2 {
-		x:int,
-		y:int
+		x:isize,
+		y:isize
 }
 
 impl Foo {
-	fn my_method(&self,_:int){ println("my_method of foo");}
+	fn my_method(&self,_:isize){ println!("{}", "my_method of foo");}
 }
 
 enum Animal {
-	a_anteater(int),
-	a_bear(int),
-	a_cat(int),
-	a_dog(int),
+	a_anteater(isize),
+	a_bear(isize),
+	a_cat(isize),
+	a_dog(isize),
 }
 
 trait Testable 
@@ -122,21 +120,21 @@ trait DoZ {
 
 impl Testable for Foo {
 	fn test(&self) {
-		println(self.foo_field_1.to_string().as_slice());
+		println!("{}", self.foo_field_1.to_string());
 	}
 
 	fn test1(&self) {
-		println(self.foo_field_1.to_string().as_slice());
+		println!("{}", self.foo_field_1.to_string());
 	}
 
 	fn test2(&self) {
-		println(self.foo_field_1.to_string().as_slice());
+		println!("{}", self.foo_field_1.to_string());
 	}
 }
 
 impl DoZ for Foo {
 	fn do_z(&self) {
-		println(self.foo_field_1.to_string().as_slice());
+		println!("{}", self.foo_field_1.to_string());
 	}
 }
 
@@ -144,10 +142,10 @@ trait SuperTraitTest:Testable+DoZ {
 }
 
 fn gfunc<X:Testable+DoZ>(x:&X) {
-	let a1=a_anteater(1);
-	let a2=a_bear(1);
-	let a3=a_cat(1);
-	let a4=a_dog(1);
+	let a1=Animal::a_anteater(1);
+	let a2=Animal::a_bear(1);
+	let a3=Animal::a_cat(1);
+	let a4=Animal::a_dog(1);
 	x.test();
 	x.do_z();
 }
@@ -167,8 +165,7 @@ impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {
 
 fn some2(a:Animal) {
 	match a {
-		a_cat(x)=> println("cat"),
-		_ => println("not a cat")
+		Animal::a_cat(x)=> println!("{}", "cat"),
+		_ => println!("{}", "not a cat")
 	}
-
 }

--- a/tests/ctags/test_input.rs
+++ b/tests/ctags/test_input.rs
@@ -28,6 +28,19 @@ pub struct B
 	bar: isize
 }
 
+pub struct C<T> where T: Send
+{
+	a: T
+}
+
+pub trait D<T> where T: Send
+{
+}
+
+impl<T> D<T> for C<T> where T: Send
+{
+}
+
 /*
  * fn ignored_in_comment() {}
  */

--- a/tests/ctags/test_input.rs
+++ b/tests/ctags/test_input.rs
@@ -2,8 +2,10 @@
 #![feature(globs)]
 #![feature(macro_rules)]
 use std::*;
-use test_input2::*;
-mod test_input2;
+mod test_input2
+{
+	pub struct SomeStruct;
+}
 
 fn lifetime_and_char<'lifetime>(_: &'lifetime isize)
 {
@@ -41,6 +43,10 @@ impl<T> D<T> for C<T> where T: Send
 {
 }
 
+pub fn where_foo<T>(a: T) where T: Send
+{
+}
+
 /*
  * fn ignored_in_comment() {}
  */
@@ -66,13 +72,12 @@ macro_rules! test_macro
 
 macro_rules! ignore {($($x:tt)*) => (())}
 
-fn yada(a:isize,c:Foo,b:test_input2::fruit::SomeStruct) -> String {
+fn yada(a:isize, c:Foo, b:test_input2::SomeStruct) -> String {
 	a.to_string()
 }
 
 fn main() {	
-	use test_input2::fruit::*;	
-	println!("{}", foo_bar_test_func(SomeStruct{red_value:1,green_value:2,blue_value:3},(4,5)).to_string());
+	use test_input2::*;
 	let a=Foo{foo_field_1:2};
 	a.my_method(1);
 	let c=Animal::a_cat(3);

--- a/tests/ctags/test_input.rs.tags
+++ b/tests/ctags/test_input.rs.tags
@@ -4,6 +4,9 @@ AnimalÌ2Ö0
 BÌ2048Ö0
 BarÌ2048Ö0
 BazÌ2048Ö0
+CÌ1Ö0
+CÌ2048Ö0
+DÌ32Ö0
 DoZÌ32Ö0
 FooÌ1Ö0
 FooÌ2048Ö0
@@ -14,6 +17,7 @@ SuperTraitTestÌ32Ö0
 TestableÌ32Ö0
 TraitedStructTestÌ1Ö0
 TraitedStructTestÌ2048Ö0
+aÌ8ÎCÖ0
 a_anteaterÌ4ÎAnimalÖ0
 a_bearÌ4ÎAnimalÖ0
 a_catÌ4ÎAnimalÖ0

--- a/tests/ctags/test_input.rs.tags
+++ b/tests/ctags/test_input.rs.tags
@@ -27,9 +27,9 @@ fooÌ8ÎBÖ0
 foo_field_1Ì8ÎFooÖ0
 gfuncÌ16Í<X:Testable+DoZ>(x:&X)Ö0
 ignoreÌ65536Ö0
-lifetime_and_charÌ16Í<'lifetime>(_: &'lifetime int)Ö0
+lifetime_and_charÌ16Í<'lifetime>(_: &'lifetime isize)Ö0
 mainÌ16Í()Ö0
-my_methodÌ128Í(&self,_:int)ÎFooÖ0
+my_methodÌ128Í(&self,_:isize)ÎFooÖ0
 nestedÌ16Í()ÎmainÖ0
 not_hidden_by_charÌ16Í()Îlifetime_and_charÖ0
 only_fieldÌ8ÎS1Ö0
@@ -49,4 +49,4 @@ test_macroÌ65536Ö0
 xÌ8ÎFoo2Ö0
 xÌ8ÎTraitedStructTestÖ0
 yÌ8ÎFoo2Ö0
-yadaÌ16Í(a:int,c:Foo,b:test_input2::fruit::SomeStruct) -> StringÖ0
+yadaÌ16Í(a:isize,c:Foo,b:test_input2::fruit::SomeStruct) -> StringÖ0

--- a/tests/ctags/test_input.rs.tags
+++ b/tests/ctags/test_input.rs.tags
@@ -13,6 +13,7 @@ FooÌ2048Ö0
 Foo2Ì2048Ö0
 ParametrizedTraitÌ32Ö0
 S1Ì2048Ö0
+SomeStructÌ2048Îtest_input2Ö0
 SuperTraitTestÌ32Ö0
 TestableÌ32Ö0
 TraitedStructTestÌ1Ö0
@@ -50,7 +51,8 @@ test2Ì128Í(&self)ÎFooÖ0
 test2Ì128Í(&self)ÎTestableÖ0
 test_input2Ì256Ö0
 test_macroÌ65536Ö0
+where_fooÌ16Í<T>(a: T) where T: SendÖ0
 xÌ8ÎFoo2Ö0
 xÌ8ÎTraitedStructTestÖ0
 yÌ8ÎFoo2Ö0
-yadaÌ16Í(a:isize,c:Foo,b:test_input2::fruit::SomeStruct) -> StringÖ0
+yadaÌ16Í(a:isize, c:Foo, b:test_input2::SomeStruct) -> StringÖ0

--- a/tests/ctags/test_input2.rs
+++ b/tests/ctags/test_input2.rs
@@ -42,3 +42,5 @@ mod mineral {
 	fn chalk() {
 	}
 }
+
+fn main() {}

--- a/tests/ctags/test_input2.rs
+++ b/tests/ctags/test_input2.rs
@@ -1,19 +1,18 @@
 #![cfg(not(test))] fn not_hashbang() {}
 
-pub fn foo_bar_test_func(apples:fruit::SomeStruct,(oranges,lemon):(int,int))->int{
-	use std::io::stdio::println;
+pub fn foo_bar_test_func(apples:fruit::SomeStruct,(oranges,lemon):(isize,isize))->isize{
 	let some_var_name=2*oranges;
 	let a=SomeLongStructName{v:0};
-	println("a");println("b");	println("c");
+	println!("{}", "a");
 	veg::another_function(apples.red_value,oranges,lemon);
 	some_var_name-apples.red_value+lemon+a.v
 }
 
 pub mod fruit {
 	pub struct SomeStruct{
-		pub red_value: int,
-		pub green_value: int,
-		pub blue_value: int
+		pub red_value: isize,
+		pub green_value: isize,
+		pub blue_value: isize
 	}
 }
 
@@ -27,10 +26,10 @@ impl SomeLongStructName {
 	}
 }
 
-pub struct SomeLongStructName {v:int}
+pub struct SomeLongStructName {v:isize}
 
 mod veg{
-	pub fn another_function(a:int,b:int,c:int)->int {
+	pub fn another_function(a:isize,b:isize,c:isize)->isize {
 		a+b+c
 	}
 }

--- a/tests/ctags/test_input2.rs.tags
+++ b/tests/ctags/test_input2.rs.tags
@@ -13,6 +13,7 @@ fruitÌ256Ö0
 graniteÌ16Í()ÎmineralÖ0
 green_valueÌ8Îfruit::SomeStructÖ0
 limestoneÌ16Í()ÎmineralÖ0
+mainÌ16Í()Ö0
 mineralÌ256Ö0
 not_hashbangÌ16Í()Ö0
 red_valueÌ8Îfruit::SomeStructÖ0

--- a/tests/ctags/test_input2.rs.tags
+++ b/tests/ctags/test_input2.rs.tags
@@ -2,11 +2,11 @@
 SomeLongStructNameÌ1Ö0
 SomeLongStructNameÌ2048Ö0
 SomeStructÌ2048ÎfruitÖ0
-another_functionÌ16Í(a:int,b:int,c:int)->intÎvegÖ0
+another_functionÌ16Í(a:isize,b:isize,c:isize)->isizeÎvegÖ0
 baazÌ128Í()ÎSomeLongStructNameÖ0
 blue_valueÌ8Îfruit::SomeStructÖ0
 chalkÌ16Í()ÎmineralÖ0
-foo_bar_test_funcÌ16Í(apples:fruit::SomeStruct,(oranges,lemon):(int,int))->intÖ0
+foo_bar_test_funcÌ16Í(apples:fruit::SomeStruct,(oranges,lemon):(isize,isize))->isizeÖ0
 foooÌ128Í()ÎSomeLongStructNameÖ0
 free_funcÌ16Í()Ö0
 fruitÌ256Ö0


### PR DESCRIPTION
- Update the keyword list (obtained from https://github.com/rust-lang/rust/blob/master/src/libsyntax/parse/token.rs#L546-L599).
- Update the ctags tests to compile with modern Rust.
- Handle some syntax changes (`where` bounds) that were made close to the 1.0 release.