### PR TITLE
Added multiline comment for filetypes.haskell

### DIFF
--- a/data/filetypes.haskell
+++ b/data/filetypes.haskell
@@ -53,8 +53,8 @@ mime_type=text/x-haskell
 # single comments, like # in this file
 comment_single=--
 # multiline comments
-#comment_open=
-#comment_close=
+comment_open={-
+comment_close=-}
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d


### PR DESCRIPTION
I've added missing multiline comment for haskell, its syntax is on the haskell wiki: https://wiki.haskell.org/Reference_card#Comments