### PR TITLE
Don't open more than one document for non-existing paths from the CLI

### DIFF
--- a/src/libmain.c
+++ b/src/libmain.c
@@ -804,7 +804,11 @@ gboolean main_handle_filename(const gchar *locale_filename)
 	{	/* create new file with the given filename */
 		gchar *utf8_filename = utils_get_utf8_from_locale(filename);
 
-		doc = document_new_file(utf8_filename, NULL, NULL);
+		doc = document_find_by_filename(utf8_filename);
+		if (doc)
+			document_show_tab(doc);
+		else
+			doc = document_new_file(utf8_filename, NULL, NULL);
 		if (doc != NULL)
 			ui_add_recent_document(doc);
 		g_free(utf8_filename);


### PR DESCRIPTION
When creating a new document for a non-existing file from the command line, check if we don't already have opened it and simply show the existing one if we do.  This avoids creating new documents that will be saved to the same location again and again.

Closes https://bugs.launchpad.net/linuxmint/+bug/1482558