### PR TITLE
Use 'g' as shortcut key for "Use multi-line matching" instead of 'l'.

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -319,7 +319,7 @@ static GtkWidget *add_find_checkboxes(GtkDialog *dialog)
 		_("Replace \\\\, \\t, \\n, \\r and \\uXXXX (Unicode characters) with the "
 		  "corresponding control characters"));
 
-	check_multiline = gtk_check_button_new_with_mnemonic(_("Use multi-_line matching"));
+	check_multiline = gtk_check_button_new_with_mnemonic(_("Use multi-line matchin_g"));
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check_multiline), FALSE);
 	gtk_widget_set_sensitive(check_multiline, FALSE);
 	ui_hookup_widget(dialog, check_multiline, "check_multiline");


### PR DESCRIPTION
The current shorcut key for "Use multi-line matching" conflicts with
"In Selection" when "Use regular expressions" is enabled.  It should be
convenient if we change it.

We choose 'g' since other letters are already in use:

   u: "Use regular expressions"
   s: "Search for"
   e: "Use escape sequences"
   m: "Mark"
   l: "In Selection"
   t: "Match from start of word"
   i: "In Document"
   n: "Replace & Find"
   a: "Case sensitive"
   c: "Close"
   h: "Replace with"