### PR TITLE
Allow to set a keybinding for File->Properties

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -6407,7 +6407,7 @@
                           </object>
                         </child>
                         <child>
-                          <object class="GtkImageMenuItem" id="preferences2">
+                          <object class="GtkImageMenuItem" id="properties1">
                             <property name="label">gtk-properties</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1134,7 +1134,7 @@ static void on_comments_fileheader_activate(GtkMenuItem *menuitem, gpointer user
 }
 
 
-static void on_file_properties_activate(GtkMenuItem *menuitem, gpointer user_data)
+void on_file_properties_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();
 	g_return_if_fail(doc != NULL);

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -117,6 +117,8 @@ void on_menu_remove_indicators1_activate(GtkMenuItem *menuitem, gpointer user_da
 
 void on_print1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
+void on_file_properties_activate(GtkMenuItem *menuitem, gpointer user_data);
+
 void on_menu_select_all1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_menu_show_sidebar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data);

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -282,6 +282,8 @@ static void init_default_kb(void)
 	add_kb(group, GEANY_KEYS_FILE_SAVEALL, NULL,
 		GDK_s, GDK_SHIFT_MASK | GEANY_PRIMARY_MOD_MASK, "menu_saveall", _("Save all"),
 		"menu_save_all1");
+	add_kb(group, GEANY_KEYS_FILE_PROPERTIES, NULL,
+		0, 0, "file_properties", _("Properties"), "properties1");
 	add_kb(group, GEANY_KEYS_FILE_PRINT, NULL,
 		GDK_p, GEANY_PRIMARY_MOD_MASK, "menu_print", _("Print"), "print1");
 	add_kb(group, GEANY_KEYS_FILE_CLOSE, NULL,
@@ -1358,6 +1360,9 @@ static gboolean cb_func_file_action(guint key_id)
 			break;
 		case GEANY_KEYS_FILE_PRINT:
 			on_print1_activate(NULL, NULL);
+			break;
+		case GEANY_KEYS_FILE_PROPERTIES:
+			on_file_properties_activate(NULL, NULL);
 			break;
 		case GEANY_KEYS_FILE_QUIT:
 			main_quit();

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -245,6 +245,7 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_GOTO_LINESTARTVISUAL,			/**< Keybinding. */
 	GEANY_KEYS_DOCUMENT_CLONE,					/**< Keybinding. */
 	GEANY_KEYS_FILE_QUIT,						/**< Keybinding. */
+	GEANY_KEYS_FILE_PROPERTIES,					/**< Keybinding. */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -875,7 +875,7 @@ static void init_document_widgets(void)
 	add_doc_widget("add_comments1");
 	add_doc_widget("menu_paste1");
 	add_doc_widget("menu_undo2");
-	add_doc_widget("preferences2");
+	add_doc_widget("properties1");
 	add_doc_widget("menu_reload1");
 	add_doc_widget("menu_document1");
 	add_doc_widget("menu_choose_color1");


### PR DESCRIPTION
Closes #622.

---
While a very common keybinding for this would be `Alt+Return`, I didn't set any default because:

1. `Alt+Return` might be in use by a plugin already, and Geany would steal it;
2. Properties don't seem to be important enough to me to really need a default keybinding.