### PR TITLE
New instance improvements

### DIFF
--- a/src/libmain.c
+++ b/src/libmain.c
@@ -336,7 +336,7 @@ static void apply_settings(void)
 static void main_init(void)
 {
 	/* add our icon path in case we aren't installed in the system prefix */
-	gtk_icon_theme_append_search_path(gtk_icon_theme_get_default(), utils_resource_dir(RESOURCE_DIR_ICON));
+	gtk_icon_theme_append_search_path(gtk_icon_theme_get_default(), utils_resource_path(RESOURCE_PATH_ICON_DIR));
 
 	/* inits */
 	ui_init_stock_items();
@@ -507,8 +507,8 @@ static void change_working_directory_on_windows(void)
 static void setup_paths(void)
 {
 	/* convert path names to locale encoding */
-	app->datadir = utils_get_locale_from_utf8(utils_resource_dir(RESOURCE_DIR_DATA));
-	app->docdir = utils_get_locale_from_utf8(utils_resource_dir(RESOURCE_DIR_DOC));
+	app->datadir = utils_get_locale_from_utf8(utils_resource_path(RESOURCE_PATH_DATA_DIR));
+	app->docdir = utils_get_locale_from_utf8(utils_resource_path(RESOURCE_PATH_DOC_DIR));
 }
 
 
@@ -565,7 +565,7 @@ void main_locale_init(const gchar *locale_dir, const gchar *package)
 #endif
 
 #ifdef G_OS_WIN32
-	locale_dir = utils_resource_dir(RESOURCE_DIR_LOCALE);
+	locale_dir = utils_resource_path(RESOURCE_PATH_LOCALE_DIR);
 #endif
 	(void) bindtextdomain(package, locale_dir);
 	(void) bind_textdomain_codeset(package, "UTF-8");
@@ -1144,7 +1144,7 @@ gint main_lib(gint argc, gchar **argv)
 	setup_gtk2_styles();
 #endif
 #ifdef ENABLE_NLS
-	main_locale_init(utils_resource_dir(RESOURCE_DIR_LOCALE), GETTEXT_PACKAGE);
+	main_locale_init(utils_resource_path(RESOURCE_PATH_LOCALE_DIR), GETTEXT_PACKAGE);
 #endif
 	parse_command_line_options(&argc, &argv);
 

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -680,7 +680,7 @@ static void parse_command_line_options(gint *argc, gchar ***argv)
 	if (alternate_config)
 	{
 		geany_debug("alternate config: %s", alternate_config);
-		app->configdir = alternate_config;
+		app->configdir = g_strdup(alternate_config);
 	}
 	else
 	{

--- a/src/main.h
+++ b/src/main.h
@@ -65,6 +65,8 @@ GeanyStatus;
 extern GeanyStatus main_status;
 
 
+gchar **main_get_persistent_argv(void);
+
 const gchar *main_get_version_string(void);
 
 gchar *main_get_argv_filename(const gchar *filename);

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -883,7 +883,7 @@ load_plugins_from_path(const gchar *path)
 
 static gchar *get_plugin_path(void)
 {
-	return g_strdup(utils_resource_dir(RESOURCE_DIR_PLUGIN));
+	return g_strdup(utils_resource_path(RESOURCE_PATH_PLUGIN_DIR));
 }
 
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -32,6 +32,7 @@
 #include "app.h"
 #include "dialogs.h"
 #include "document.h"
+#include "main.h"
 #include "prefs.h"
 #include "prefix.h"
 #include "sciwrappers.h"
@@ -2108,20 +2109,21 @@ static gboolean is_osx_bundle(void)
 }
 
 
-const gchar *utils_resource_dir(GeanyResourceDirType type)
+const gchar *utils_resource_path(GeanyResourcePathType type)
 {
-	static const gchar *resdirs[RESOURCE_DIR_COUNT] = {NULL};
+	static const gchar *respaths[RESOURCE_PATH_COUNT] = {NULL};
 
-	if (!resdirs[RESOURCE_DIR_DATA])
+	if (!respaths[RESOURCE_PATH_DATA_DIR])
 	{
 #ifdef G_OS_WIN32
 		gchar *prefix = win32_get_installation_dir();
 
-		resdirs[RESOURCE_DIR_DATA] = g_build_filename(prefix, "data", NULL);
-		resdirs[RESOURCE_DIR_ICON] = g_build_filename(prefix, "share", "icons", NULL);
-		resdirs[RESOURCE_DIR_DOC] = g_build_filename(prefix, "doc", NULL);
-		resdirs[RESOURCE_DIR_LOCALE] = g_build_filename(prefix, "share", "locale", NULL);
-		resdirs[RESOURCE_DIR_PLUGIN] = g_build_filename(prefix, "lib", "geany", NULL);
+		respaths[RESOURCE_PATH_DATA_DIR] = g_build_filename(prefix, "data", NULL);
+		respaths[RESOURCE_PATH_ICON_DIR] = g_build_filename(prefix, "share", "icons", NULL);
+		respaths[RESOURCE_PATH_DOC_DIR] = g_build_filename(prefix, "doc", NULL);
+		respaths[RESOURCE_PATH_LOCALE_DIR] = g_build_filename(prefix, "share", "locale", NULL);
+		respaths[RESOURCE_PATH_PLUGIN_DIR] = g_build_filename(prefix, "lib", "geany", NULL);
+		respaths[RESOURCE_PATH_EXECUTABLE] = g_build_filename(prefix, "bin", "geany", NULL);
 		g_free(prefix);
 #else
 		if (is_osx_bundle())
@@ -2129,26 +2131,34 @@ const gchar *utils_resource_dir(GeanyResourceDirType type)
 # ifdef MAC_INTEGRATION
 			gchar *prefix = gtkosx_application_get_resource_path();
 			
-			resdirs[RESOURCE_DIR_DATA] = g_build_filename(prefix, "share", "geany", NULL);
-			resdirs[RESOURCE_DIR_ICON] = g_build_filename(prefix, "share", "icons", NULL);
-			resdirs[RESOURCE_DIR_DOC] = g_build_filename(prefix, "share", "doc", "geany", "html", NULL);
-			resdirs[RESOURCE_DIR_LOCALE] = g_build_filename(prefix, "share", "locale", NULL);
-			resdirs[RESOURCE_DIR_PLUGIN] = g_build_filename(prefix, "lib", "geany", NULL);
+			respaths[RESOURCE_PATH_DATA_DIR] = g_build_filename(prefix, "share", "geany", NULL);
+			respaths[RESOURCE_PATH_ICON_DIR] = g_build_filename(prefix, "share", "icons", NULL);
+			respaths[RESOURCE_PATH_DOC_DIR] = g_build_filename(prefix, "share", "doc", "geany", "html", NULL);
+			respaths[RESOURCE_PATH_LOCALE_DIR] = g_build_filename(prefix, "share", "locale", NULL);
+			respaths[RESOURCE_PATH_PLUGIN_DIR] = g_build_filename(prefix, "lib", "geany", NULL);
+			respaths[RESOURCE_PATH_EXECUTABLE] = gtkosx_application_get_executable_path();
 			g_free(prefix);
 # endif
 		}
 		else
 		{
-			resdirs[RESOURCE_DIR_DATA] = g_build_filename(GEANY_DATADIR, "geany", NULL);
-			resdirs[RESOURCE_DIR_ICON] = g_build_filename(GEANY_DATADIR, "icons", NULL);
-			resdirs[RESOURCE_DIR_DOC] = g_build_filename(GEANY_DOCDIR, "html", NULL);
-			resdirs[RESOURCE_DIR_LOCALE] = g_build_filename(GEANY_LOCALEDIR, NULL);
-			resdirs[RESOURCE_DIR_PLUGIN] = g_build_filename(GEANY_LIBDIR, "geany", NULL);
+			respaths[RESOURCE_PATH_DATA_DIR] = g_build_filename(GEANY_DATADIR, "geany", NULL);
+			respaths[RESOURCE_PATH_ICON_DIR] = g_build_filename(GEANY_DATADIR, "icons", NULL);
+			respaths[RESOURCE_PATH_DOC_DIR] = g_build_filename(GEANY_DOCDIR, "html", NULL);
+			respaths[RESOURCE_PATH_LOCALE_DIR] = g_build_filename(GEANY_LOCALEDIR, NULL);
+			respaths[RESOURCE_PATH_PLUGIN_DIR] = g_build_filename(GEANY_LIBDIR, "geany", NULL);
+			respaths[RESOURCE_PATH_EXECUTABLE] = g_build_filename(GEANY_PREFIX, "bin", "geany", NULL);
 		}
 #endif
 	}
 
-	return resdirs[type];
+	if (!respaths[RESOURCE_PATH_EXECUTABLE] ||
+		!g_file_test(respaths[RESOURCE_PATH_EXECUTABLE], G_FILE_TEST_IS_EXECUTABLE))
+	{
+		respaths[RESOURCE_PATH_EXECUTABLE] = "geany";
+	}
+
+	return respaths[type];
 }
 
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -2126,6 +2126,8 @@ const gchar *utils_resource_path(GeanyResourcePathType type)
 		respaths[RESOURCE_PATH_PLUGIN_DIR] = g_build_filename(prefix, "lib", "geany", NULL);
 		respaths[RESOURCE_PATH_EXECUTABLE] = g_build_filename(prefix, "bin", "geany", NULL);
 		g_free(prefix);
+		if (!g_file_test(respaths[RESOURCE_PATH_EXECUTABLE], G_FILE_TEST_IS_EXECUTABLE))
+			respaths[RESOURCE_PATH_EXECUTABLE] = "geany";
 #else
 		if (is_osx_bundle())
 		{
@@ -2139,6 +2141,8 @@ const gchar *utils_resource_path(GeanyResourcePathType type)
 			respaths[RESOURCE_PATH_PLUGIN_DIR] = g_build_filename(prefix, "lib", "geany", NULL);
 			respaths[RESOURCE_PATH_EXECUTABLE] = gtkosx_application_get_executable_path();
 			g_free(prefix);
+			if (!respaths[RESOURCE_PATH_EXECUTABLE])
+				respaths[RESOURCE_PATH_EXECUTABLE] = "geany";
 # endif
 		}
 		else
@@ -2149,14 +2153,10 @@ const gchar *utils_resource_path(GeanyResourcePathType type)
 			respaths[RESOURCE_PATH_LOCALE_DIR] = g_build_filename(GEANY_LOCALEDIR, NULL);
 			respaths[RESOURCE_PATH_PLUGIN_DIR] = g_build_filename(GEANY_LIBDIR, "geany", NULL);
 			respaths[RESOURCE_PATH_EXECUTABLE] = g_build_filename(GEANY_PREFIX, "bin", "geany", NULL);
+			if (!g_file_test(respaths[RESOURCE_PATH_EXECUTABLE], G_FILE_TEST_IS_EXECUTABLE))
+				respaths[RESOURCE_PATH_EXECUTABLE] = "geany";
 		}
 #endif
-	}
-
-	if (!respaths[RESOURCE_PATH_EXECUTABLE] ||
-		!g_file_test(respaths[RESOURCE_PATH_EXECUTABLE], G_FILE_TEST_IS_EXECUTABLE))
-	{
-		respaths[RESOURCE_PATH_EXECUTABLE] = "geany";
 	}
 
 	return respaths[type];

--- a/src/utils.h
+++ b/src/utils.h
@@ -202,14 +202,15 @@ const gchar *utils_find_open_xml_tag_pos(const gchar sel[], gint size);
 
 typedef enum
 {
-	RESOURCE_DIR_DATA,
-	RESOURCE_DIR_ICON,
-	RESOURCE_DIR_DOC,
-	RESOURCE_DIR_LOCALE,
-	RESOURCE_DIR_PLUGIN,
+	RESOURCE_PATH_DATA_DIR,
+	RESOURCE_PATH_ICON_DIR,
+	RESOURCE_PATH_DOC_DIR,
+	RESOURCE_PATH_LOCALE_DIR,
+	RESOURCE_PATH_PLUGIN_DIR,
+	RESOURCE_PATH_EXECUTABLE,
 
-	RESOURCE_DIR_COUNT
-} GeanyResourceDirType;
+	RESOURCE_PATH_COUNT
+} GeanyResourcePathType;
 
 
 gint utils_get_line_endings(const gchar* buffer, gsize size);
@@ -308,7 +309,7 @@ gchar *utils_parse_and_format_build_date(const gchar *input);
 
 gchar *utils_get_user_config_dir(void);
 
-const gchar *utils_resource_dir(GeanyResourceDirType type);
+const gchar *utils_resource_path(GeanyResourcePathType type);
 
 void utils_start_new_geany_instance(const gchar *doc_path);
 


### PR DESCRIPTION
This is an improved version of PR  #637.

No more "--" - not needed.
No guard for  is_osx_bundle() under Windows - does not belong here.
Split into proper sequential commits.
Fixed the encoding of options and doc_name.
Fixed the OSX bundle executable name.
Created a function to return the reproduced arguments instead of exposing global variables.
Re-tested under Windows and Linux.

There is only one problem left. As described in PR  #637, under Windows, mscvrt often breaks unquoted locale strings on 2+ pieces, considering some characters "spaces". So spawn should quote any argv elements containing locale. But that must obviously be a separate PR.
