### PR TITLE
Update msgid for "Use multi-line matchin_g"

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -4058,7 +4058,7 @@ msgid ""
 msgstr ""
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/ast.po
+++ b/po/ast.po
@@ -4313,7 +4313,7 @@ msgstr ""
 "carauteres de control correspondientes"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/be.po
+++ b/po/be.po
@@ -4197,7 +4197,7 @@ msgstr ""
 "кіруючыя сімвалы"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr "Выкарыстоўваць шматрадковы пошук"
 
 #: ../src/search.c:327

--- a/po/bg.po
+++ b/po/bg.po
@@ -4522,7 +4522,7 @@ msgstr ""
 "контролни символи."
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/ca.po
+++ b/po/ca.po
@@ -4218,7 +4218,7 @@ msgstr ""
 "seqüències de control corresponents"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/cs.po
+++ b/po/cs.po
@@ -4214,7 +4214,7 @@ msgstr ""
 "kontrolními znaky."
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/de.po
+++ b/po/de.po
@@ -4277,7 +4277,7 @@ msgstr ""
 "entsprechenden Sonderzeichen"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr "_Mehrzeilen-Erkennung (multi-line matching) benutzen"
 
 #: ../src/search.c:327

--- a/po/el.po
+++ b/po/el.po
@@ -4280,7 +4280,7 @@ msgstr ""
 "αντίστοιχους χαρακτήρες ελέγχου"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4207,7 +4207,7 @@ msgstr ""
 "corresponding control characters"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/es.po
+++ b/po/es.po
@@ -4255,7 +4255,7 @@ msgstr ""
 "de control correspondiente"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr "Usar coincidencias multi_líneas"
 
 #: ../src/search.c:327

--- a/po/et.po
+++ b/po/et.po
@@ -4076,7 +4076,7 @@ msgid ""
 msgstr "Asenda \\\\, \\t, \\n, \\r ja \\uXXXX (Unicode sümbolid) juhtmärkidega"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/eu.po
+++ b/po/eu.po
@@ -4087,7 +4087,7 @@ msgstr ""
 "kontrol-karaktereekin"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/fa.po
+++ b/po/fa.po
@@ -4270,7 +4270,7 @@ msgstr ""
 "corresponding control characters"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/fi.po
+++ b/po/fi.po
@@ -4235,7 +4235,7 @@ msgstr ""
 "ohjausmerkeillä"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/gl.po
+++ b/po/gl.po
@@ -4254,7 +4254,7 @@ msgstr ""
 "correspondentes caracteres de control"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/he.po
+++ b/po/he.po
@@ -4113,7 +4113,7 @@ msgid ""
 msgstr "מחליף ‎\\\\, \\t, \\n, \\r ו-‎\\uXXXX (תווי יוניקוד) בתווי בקרה מתאימים"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/hi.po
+++ b/po/hi.po
@@ -4023,7 +4023,7 @@ msgid ""
 msgstr ""
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/hu.po
+++ b/po/hu.po
@@ -4236,7 +4236,7 @@ msgstr ""
 "a megfelelő vezérlőkarakterekkel."
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/id.po
+++ b/po/id.po
@@ -4249,7 +4249,7 @@ msgstr ""
 "kontrol penggantinya"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/it.po
+++ b/po/it.po
@@ -4306,7 +4306,7 @@ msgstr ""
 "corrispondenti caratteri di controllo"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/ja.po
+++ b/po/ja.po
@@ -4171,7 +4171,7 @@ msgstr ""
 "ます"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/kk.po
+++ b/po/kk.po
@@ -4072,7 +4072,7 @@ msgid ""
 msgstr ""
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/ko.po
+++ b/po/ko.po
@@ -4333,7 +4333,7 @@ msgstr ""
 "다."
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/lb.po
+++ b/po/lb.po
@@ -4357,7 +4357,7 @@ msgstr ""
 "entspriechend Zeechen"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/lt.po
+++ b/po/lt.po
@@ -4194,7 +4194,7 @@ msgstr ""
 "valdymo simboliais"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/mn.po
+++ b/po/mn.po
@@ -4360,7 +4360,7 @@ msgstr ""
 
 #: ../src/search.c:322
 #, fuzzy
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr "Автомат догол мөрийг _хэрэглэ"
 
 #: ../src/search.c:327

--- a/po/nl.po
+++ b/po/nl.po
@@ -4227,7 +4227,7 @@ msgstr ""
 "stuurtekens"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr "Gebruik _meerregelige matching"
 
 #: ../src/search.c:327

--- a/po/nn.po
+++ b/po/nn.po
@@ -4030,7 +4030,7 @@ msgid ""
 msgstr ""
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/pl.po
+++ b/po/pl.po
@@ -4231,7 +4231,7 @@ msgstr ""
 "kontrolnymi."
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/pt.po
+++ b/po/pt.po
@@ -4229,7 +4229,7 @@ msgstr ""
 "caracteres de controlo correspondentes"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr "Usar comparação multi_Linha"
 
 #: ../src/search.c:327

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4234,7 +4234,7 @@ msgstr ""
 "caracteres de controle correspondentes"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr "Utilizar casamento multi_linhas"
 
 #: ../src/search.c:327

--- a/po/ro.po
+++ b/po/ro.po
@@ -4366,7 +4366,7 @@ msgstr ""
 "caracterele de control corespunzătoare."
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/ru.po
+++ b/po/ru.po
@@ -4217,7 +4217,7 @@ msgstr ""
 "управляющими символами"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr "_Многострочный поиск"
 
 #: ../src/search.c:327

--- a/po/sk.po
+++ b/po/sk.po
@@ -4183,7 +4183,7 @@ msgstr ""
 "znakom"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/sl.po
+++ b/po/sl.po
@@ -4253,7 +4253,7 @@ msgstr ""
 "z ustreznimi kontrolnimi znaki"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/sr.po
+++ b/po/sr.po
@@ -4104,7 +4104,7 @@ msgid ""
 msgstr ""
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/sv.po
+++ b/po/sv.po
@@ -4183,7 +4183,7 @@ msgstr ""
 "specialtecken."
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr "Använd flerraders matchning"
 
 #: ../src/search.c:327

--- a/po/tr.po
+++ b/po/tr.po
@@ -4188,7 +4188,7 @@ msgstr ""
 "karakterleri ile yer değiştir"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/uk.po
+++ b/po/uk.po
@@ -4424,7 +4424,7 @@ msgstr ""
 "керівними символами."
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/vi.po
+++ b/po/vi.po
@@ -4307,7 +4307,7 @@ msgstr ""
 "Unicode) bằng ký tự điều khiển tương ứng"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4066,8 +4066,8 @@ msgid ""
 msgstr "替换 \\\\、\\t、\\n、\\r 和 \\uXXXX (Unicode字符串) 为对应的控制字符。"
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
-msgstr "使用多行匹配(_L)"
+msgid "Use multi-line matchin_g"
+msgstr "使用多行匹配(_G)"
 
 #: ../src/search.c:327
 msgid ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4140,7 +4140,7 @@ msgid ""
 msgstr "以相應的控制字元置換 \\\\，\\t,\\n，\\r 和 \\uXXXX (萬國碼字元) "
 
 #: ../src/search.c:322
-msgid "Use multi-_line matching"
+msgid "Use multi-line matchin_g"
 msgstr ""
 
 #: ../src/search.c:327


### PR DESCRIPTION
This also includes obvious changes to msgstr of some languages.
Languages that didn't explicitly use 'l' as previous shortcut or
didn't have 'g' on their translation were left untouched.