### PR TITLE
Enhance detection of sh functions

### DIFF
--- a/ctags/parsers/sh.c
+++ b/ctags/parsers/sh.c
@@ -55,44 +55,118 @@ static void findShTags (void)
 
 	while ((line = readLineFromInputFile ()) != NULL)
 	{
-		const unsigned char* cp = line;
-		bool functionFound = false;
+		const unsigned char *cp = line;
 
-		if (line [0] == '#')
-			continue;
-
-		while (isspace (*cp))
-			cp++;
-		if (strncmp ((const char*) cp, "function", (size_t) 8) == 0  &&
-			isspace ((int) cp [8]))
-		{
-			functionFound = true;
-			cp += 8;
-			if (! isspace ((int) *cp))
-				continue;
-			while (isspace ((int) *cp))
-				++cp;
-		}
-		if (! (isalnum ((int) *cp) || *cp == '_'))
-			continue;
-		while (isalnum ((int) *cp)  ||  *cp == '_')
-		{
-			vStringPut (name, (int) *cp);
-			++cp;
-		}
 		while (isspace ((int) *cp))
 			++cp;
-		if (*cp++ == '(')
+
+		if (*cp == '#')
+			continue;
+
+		bool functionFound;
+		bool allAreDigits = true;
+
+		if (strncmp ((const char *) cp, "function", (size_t) 8) == 0  && isspace ((int) cp [8]))
 		{
+			cp += 9;
+
 			while (isspace ((int) *cp))
 				++cp;
-			if (*cp == ')'  && ! hackReject (name))
-				functionFound = true;
+
+			if (*cp == '\0')
+				continue;
+
+			functionFound = true;
+			const unsigned char *start = cp;
+
+			do
+			{
+				switch (*cp)
+				{
+				case '"':
+				case '$':
+				case '&':
+				case '\'':
+				case ')':
+				case ';':
+				case '<':
+				case '=':
+				case '>':
+				case '`':
+					functionFound = false;
+					break;
+				default:
+					if (allAreDigits && ! isdigit ((int) *cp))
+						allAreDigits = false;
+
+					vStringPut (name, (int) *cp);
+					++cp;
+				}
+			}
+			while (functionFound && *cp != '\0' && ! isspace ((int) *cp) && *cp != '(');
+
+			if (cp == start)
+				continue;
+
+			if (functionFound)
+			{
+				if (allAreDigits)
+					functionFound = false;
+				else
+				{
+					while (isspace ((int) *cp))
+						++cp;
+
+					if (*cp == '(')
+					{
+						while (isspace ((int) *++cp))
+							;
+
+						if (*cp != ')')
+							functionFound = false;
+					}
+				}
+			}
 		}
-		if (functionFound)
+		else
+		{
+			if (! (isalnum ((int) *cp) || *cp == '_'))
+				continue;
+
+			do
+			{
+				if (! isdigit ((int) *cp))
+					allAreDigits = false;
+
+				vStringPut (name, (int) *cp);
+				++cp;
+			}
+			while (isalnum ((int) *cp) || *cp == '_');
+
+			functionFound = false;
+
+			if (! allAreDigits)
+			{
+				while (isspace ((int) *cp))
+					++cp;
+
+				if (*cp == '(')
+				{
+					while (isspace ((int) *++cp))
+						;
+
+					if (*cp == ')')
+						functionFound = true;
+				}
+			}
+		}
+
+		if (functionFound && ! hackReject (name))
 			makeSimpleTag (name, ShKinds, K_FUNCTION);
+
 		vStringClear (name);
 	}
+
 	vStringDelete (name);
 }
 


### PR DESCRIPTION
Bash allows more characters besides `[[:alnum:]_]` when declaring
function names using the `function` keyword.  It also does not require
having a pair of parentheses after the name.  Some shells may actually
implement it differently but we don't have to be that strict since the
user explicitly specifies the `function` keyword anyway.

This update implements the ones described above, and also invalidates
function names that are completely made up of digits.
