### PR TITLE
Add SPAWN_LEAVE_STDIN_OPEN flag for dynamic stdin output

### DIFF
--- a/src/spawn.h
+++ b/src/spawn.h
@@ -59,7 +59,9 @@ typedef enum
 	SPAWN_STDIN_RECURSIVE      = 0x08,  /**< The stdin callback is recursive. */
 	SPAWN_STDOUT_RECURSIVE     = 0x10,  /**< The stdout callback is recursive. */
 	SPAWN_STDERR_RECURSIVE     = 0x20,  /**< The stderr callback is recursive. */
-	SPAWN_RECURSIVE            = 0x38   /**< All callbacks are recursive. */
+	SPAWN_RECURSIVE            = 0x38,  /**< All callbacks are recursive. */
+	/* other flags */
+	SPAWN_LEAVE_STDIN_OPEN     = 0x40   /**< Leave stdin channel open on callback removal. */
 } SpawnFlags;
 
 /**


### PR DESCRIPTION
For applications which need to send data to the child not constantly, but only from time to time, possibly after sending some startup data. Does not close the channel when stdin_cb exits, letting you ref it and create send sources as needed.