### PR TITLE
g_[l]stat require a GStatBuf argument, not struct stat

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -1152,7 +1152,7 @@ void dialogs_show_file_properties(GeanyDocument *doc)
 	gchar *file_size, *title, *base_name, *time_changed, *time_modified, *time_accessed, *enctext;
 	gchar *short_name;
 #ifdef HAVE_SYS_TYPES_H
-	struct stat st;
+	GStatBuf st;
 	off_t filesize;
 	mode_t mode;
 	gchar *locale_filename;

--- a/src/document.c
+++ b/src/document.c
@@ -935,7 +935,7 @@ static gboolean load_text_file(const gchar *locale_filename, const gchar *displa
 	FileData *filedata, const gchar *forced_enc)
 {
 	GError *err = NULL;
-	struct stat st;
+	GStatBuf st;
 
 	filedata->data = NULL;
 	filedata->len = 0;
@@ -1586,7 +1586,7 @@ gboolean document_reload_prompt(GeanyDocument *doc, const gchar *forced_enc)
 static gboolean document_update_timestamp(GeanyDocument *doc, const gchar *locale_filename)
 {
 #ifndef USE_GIO_FILEMON
-	struct stat st;
+	GStatBuf st;
 
 	g_return_val_if_fail(doc != NULL, FALSE);
 
@@ -3583,7 +3583,7 @@ gboolean document_check_disk_status(GeanyDocument *doc, gboolean force)
 	gboolean ret = FALSE;
 	gboolean use_gio_filemon;
 	time_t cur_time = 0;
-	struct stat st;
+	GStatBuf st;
 	gchar *locale_filename;
 	FileDiskStatus old_status;
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -225,7 +225,7 @@ static void socket_get_document_list(gint sock)
 #ifndef G_OS_WIN32
 static void check_socket_permissions(void)
 {
-	struct stat socket_stat;
+	GStatBuf socket_stat;
 
 	if (g_lstat(socket_info.file_name, &socket_stat) == 0)
 	{	/* If the user id of the process is not the same as the owner of the socket

--- a/tagmanager/ctags/ctags.c
+++ b/tagmanager/ctags/ctags.c
@@ -49,6 +49,7 @@
 
 
 
+#ifndef GLIB_MAJOR_VERSION
 /*  To declare "struct stat" and stat ().
  */
 #if defined (HAVE_SYS_TYPES_H)
@@ -64,6 +65,7 @@
 # ifdef HAVE_STAT_H
 #  include <stat.h>
 # endif
+#endif
 #endif
 
 /*  To provide directory searching for recursion feature.
@@ -421,7 +423,7 @@ extern char* newUpperString (const char* str)
 
 extern long unsigned int getFileSize (const char *const name)
 {
-    struct stat fileStatus;
+    GStatBuf fileStatus;
     unsigned long size = 0;
 
     if (g_stat (name, &fileStatus) == 0)
@@ -436,7 +438,7 @@ static boolean isSymbolicLink (const char *const name)
 #if defined (MSDOS) || defined (WIN32) || defined (VMS) || defined (__EMX__) || defined (AMIGA)
     return FALSE;
 #else
-    struct stat fileStatus;
+    GStatBuf fileStatus;
     boolean result = FALSE;
 
     if (g_lstat (name, &fileStatus) == 0)
@@ -448,7 +450,7 @@ static boolean isSymbolicLink (const char *const name)
 
 static boolean isNormalFile (const char *const name)
 {
-    struct stat fileStatus;
+    GStatBuf fileStatus;
     boolean result = FALSE;
 
     if (g_stat (name, &fileStatus) == 0)
@@ -460,7 +462,7 @@ static boolean isNormalFile (const char *const name)
 
 extern boolean isExecutable (const char *const name)
 {
-    struct stat fileStatus;
+    GStatBuf fileStatus;
     boolean result = FALSE;
 
     if (g_stat (name, &fileStatus) == 0)
@@ -473,7 +475,7 @@ extern boolean isSameFile (const char *const name1, const char *const name2)
 {
     boolean result = FALSE;
 #ifdef HAVE_STAT_ST_INO
-    struct stat stat1, stat2;
+    GStatBuf stat1, stat2;
 
     if (g_stat (name1, &stat1) == 0  &&  g_stat (name2, &stat2) == 0)
 	result = (boolean) (stat1.st_ino == stat2.st_ino);
@@ -488,7 +490,7 @@ static boolean isSetUID (const char *const name)
 #if defined (VMS) || defined (MSDOS) || defined (WIN32) || defined (__EMX__) || defined (AMIGA)
     return FALSE;
 #else
-    struct stat fileStatus;
+    GStatBuf fileStatus;
     boolean result = FALSE;
 
     if (g_stat (name, &fileStatus) == 0)
@@ -520,7 +522,7 @@ static boolean isDirectory (const char *const name)
 	eFree (fib);
     }
 #else
-    struct stat fileStatus;
+    GStatBuf fileStatus;
 
     if (g_stat (name, &fileStatus) == 0)
 	result = (boolean) S_ISDIR (fileStatus.st_mode);
@@ -531,7 +533,7 @@ static boolean isDirectory (const char *const name)
 
 extern boolean doesFileExist (const char *const fileName)
 {
-    struct stat fileStatus;
+    GStatBuf fileStatus;
 
     return (boolean) (g_stat (fileName, &fileStatus) == 0);
 }

--- a/tagmanager/src/tm_source_file.c
+++ b/tagmanager/src/tm_source_file.c
@@ -142,7 +142,7 @@ static void tm_source_file_set_tag_arglist(const char *tag_name, const char *arg
 static gboolean tm_source_file_init(TMSourceFile *source_file, const char *file_name, 
 	const char* name)
 {
-	struct stat s;
+	GStatBuf s;
 	int status;
 
 #ifdef TM_DEBUG
@@ -269,7 +269,7 @@ gboolean tm_source_file_parse(TMSourceFile *source_file, guchar* text_buf, gsize
 	
 	if (!use_buffer)
 	{
-		struct stat s;
+		GStatBuf s;
 		
 		/* load file to memory and parse it from memory unless the file is too big */
 		if (g_stat(file_name, &s) != 0 || s.st_size > 10*1024*1024)

--- a/tagmanager/src/tm_workspace.c
+++ b/tagmanager/src/tm_workspace.c
@@ -391,7 +391,7 @@ gboolean tm_workspace_load_global_tags(const char *tags_file, gint mode)
 
 static guint tm_file_inode_hash(gconstpointer key)
 {
-	struct stat file_stat;
+	GStatBuf file_stat;
 	const char *filename = (const char*)key;
 	if (g_stat(filename, &file_stat) == 0)
 	{


### PR DESCRIPTION
Especially under Windows, there are 32-bit and 64-bit stat, and
g_[l]stat may use the non-default one.