### PR TITLE
C/C++/C#/Java/Vera/Vala/D: Allow non-ASCII identifiers

### DIFF
--- a/tagmanager/ctags/get.h
+++ b/tagmanager/ctags/get.h
@@ -22,14 +22,14 @@
 /*  Is the character valid as a character of a C identifier?
  *  VMS allows '$' in identifiers.
  */
-#define isident(c)  (isalnum(c) || (c) == '_' || (c) == '$')
+#define isident(c)  (isalnum(c) || (c) == '_' || (c) == '$' || ((int) (c)) >= 0x80)
 
 /*  Is the character valid as the first character of a C identifier?
  *  C++ allows '~' in destructors.
  *  VMS allows '$' in identifiers.
  *  Vala allows '@' in identifiers.
  */
-#define isident1(c)  (isalpha(c) || (c) == '_' || (c) == '~' || (c) == '$' || (c) == '@')
+#define isident1(c)  (isalpha(c) || (c) == '_' || (c) == '~' || (c) == '$' || (c) == '@' || ((int) (c)) >= 0x80)
 
 /*
 *   FUNCTION PROTOTYPES

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -299,6 +299,7 @@ test_sources = \
 	traffic_signal.v				\
 	traits.php						\
 	ui5.controller.js				\
+	unicode-identifiers.java		\
 	union.f							\
 	value.f							\
 	whitespaces.php					\

--- a/tests/ctags/unicode-identifiers.java
+++ b/tests/ctags/unicode-identifiers.java
@@ -1,0 +1,3 @@
+class Θεσθ {
+  static int ρανδωμ() { return 7; /* fairly random dice roll */ }
+}

--- a/tests/ctags/unicode-identifiers.java.tags
+++ b/tests/ctags/unicode-identifiers.java.tags
@@ -1,0 +1,3 @@
+# format=tagmanager
+螛蔚蟽胃󉅞
+蟻伪谓未蠅渭�128�()挝樜迪兾钢0蟟nt


### PR DESCRIPTION
While it might only currently make sense for Java, it should be
harmless for other languages and is a lot easier and cleaner to
implement like that.

Also, note that this allows more things than Java actually allows, as
it accepts any non-ASCII byte as an identifier, while Java seems to
require a Unicode alphanumeric one.  Again, it should be harmless and
is a lot easier to implement than fully-fledged Unicode support.

Closes #691.