### PR TITLE
Alter spawn to return the error message only in error->message

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -909,8 +909,8 @@ static void build_run_cmd(GeanyDocument *doc, guint cmdindex)
 		}
 		else
 		{
-			geany_debug("spawn_async() failed: %s", error->message);
-			ui_set_statusbar(TRUE, _("Process failed (%s)"), error->message);
+			ui_set_statusbar(TRUE, _("Cannot execute terminal command \"%s\": %s. "
+				"Check the path setting in Preferences."), tool_prefs.term_cmd, error->message);
 			g_error_free(error);
 			g_unlink(run_cmd);
 			run_info[cmdindex].pid = (GPid) 0;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1452,7 +1452,7 @@ void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	gchar *word, *command;
 	GError *error = NULL;
 	GeanyDocument *doc = document_get_current();
-	const gchar *format;
+	const gchar *check_msg;
 
 	g_return_if_fail(doc != NULL);
 
@@ -1470,14 +1470,12 @@ void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 		!EMPTY(doc->file_type->context_action_cmd))
 	{
 		command = g_strdup(doc->file_type->context_action_cmd);
-		format = _("Cannot execute context action command \"%s\": %s. "
-			"Check the path setting in Preferences.");
+		check_msg = _("Check the path setting in Filetype configuration.");
 	}
 	else
 	{
 		command = g_strdup(tool_prefs.context_action_cmd);
-		format = _("Cannot execute context action command \"%s\": %s. "
-			"Check the path setting in Filetype configuration.");
+		check_msg = _("Check the path setting in Preferences.");
 	}
 
 	/* substitute the wildcard %s and run the command if it is non empty */
@@ -1489,7 +1487,10 @@ void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 		if (!spawn_async(NULL, command_line, NULL, NULL, NULL, &error))
 		{
-			ui_set_statusbar(TRUE, format, command, error->message);
+			/* G_SHELL_ERROR is parsing error, it may be caused by %s word with quotes */
+			ui_set_statusbar(TRUE, _("Cannot execute context action command \"%s\": %s. %s"),
+				error->domain == G_SHELL_ERROR ? command_line : command, error->message,
+				check_msg);
 			g_error_free(error);
 		}
 		g_free(command_line);

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1452,6 +1452,7 @@ void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	gchar *word, *command;
 	GError *error = NULL;
 	GeanyDocument *doc = document_get_current();
+	const gchar *format;
 
 	g_return_if_fail(doc != NULL);
 
@@ -1469,22 +1470,29 @@ void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 		!EMPTY(doc->file_type->context_action_cmd))
 	{
 		command = g_strdup(doc->file_type->context_action_cmd);
+		format = _("Cannot execute context action command \"%s\": %s. "
+			"Check the path setting in Preferences.");
 	}
 	else
 	{
 		command = g_strdup(tool_prefs.context_action_cmd);
+		format = _("Cannot execute context action command \"%s\": %s. "
+			"Check the path setting in Filetype configuration.");
 	}
 
 	/* substitute the wildcard %s and run the command if it is non empty */
 	if (G_LIKELY(!EMPTY(command)))
 	{
-		utils_str_replace_all(&command, "%s", word);
+		gchar *command_line = g_strdup(command);
 
-		if (!spawn_async(NULL, command, NULL, NULL, NULL, &error))
+		utils_str_replace_all(&command_line, "%s", word);
+
+		if (!spawn_async(NULL, command_line, NULL, NULL, NULL, &error))
 		{
-			ui_set_statusbar(TRUE, "Context action command failed: %s", error->message);
+			ui_set_statusbar(TRUE, format, command, error->message);
 			g_error_free(error);
 		}
+		g_free(command_line);
 	}
 	g_free(word);
 	g_free(command);

--- a/src/printing.c
+++ b/src/printing.c
@@ -612,8 +612,9 @@ static void print_external(GeanyDocument *doc)
 	#endif
 		{
 			dialogs_show_msgbox(GTK_MESSAGE_ERROR,
-				_("Printing of \"%s\" failed (return code: %s)."),
-				doc->file_name, error->message);
+				_("Cannot execute print command \"%s\": %s. "
+				"Check the path setting in Preferences."),
+				printing_prefs.external_print_cmd, error->message);
 			g_error_free(error);
 		}
 		else

--- a/src/search.c
+++ b/src/search.c
@@ -1715,8 +1715,8 @@ search_find_in_files(const gchar *utf8_search_text, const gchar *utf8_dir, const
 	}
 	else
 	{
-		geany_debug("%s: spawn_with_callbacks() failed: %s", G_STRFUNC, error->message);
-		ui_set_statusbar(TRUE, _("Process failed (%s)"), error->message);
+		ui_set_statusbar(TRUE, _("Cannot execute grep tool \"%s\": %s. "
+			"Check the path setting in Preferences."), tool_prefs.grep_cmd, error->message);
 		g_error_free(error);
 	}
 

--- a/src/templates.c
+++ b/src/templates.c
@@ -617,7 +617,8 @@ static gchar *run_command(const gchar *command, const gchar *file_name,
 	}
 	else
 	{
-		g_warning("templates_replace_command: %s", error->message);
+		g_warning(_("Cannot execute template replacement command \"%s\": %s. "
+			"Check the path setting in template."), command, error->message);
 		g_error_free(error);
 	}
 

--- a/src/templates.c
+++ b/src/templates.c
@@ -617,8 +617,8 @@ static gchar *run_command(const gchar *command, const gchar *file_name,
 	}
 	else
 	{
-		g_warning(_("Cannot execute template replacement command \"%s\": %s. "
-			"Check the path setting in template."), command, error->message);
+		g_warning(_("Cannot execute command \"%s\" from the template: %s. "
+			"Check the path in the template."), command, error->message);
 		g_error_free(error);
 	}
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -239,8 +239,9 @@ void tools_execute_custom_command(GeanyDocument *doc, const gchar *command)
 	}
 	else
 	{
-		geany_debug("spawn_sync() failed: %s", error->message);
-		ui_set_statusbar(TRUE, _("Custom command failed: %s"), error->message);
+		ui_set_statusbar(TRUE, _("Cannot execute custom command \"%s\": %s. "
+			"Check the path setting in Preferences."), command, error->message);
+		g_error_free(error);
 		g_error_free(error);
 	}
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -240,8 +240,7 @@ void tools_execute_custom_command(GeanyDocument *doc, const gchar *command)
 	else
 	{
 		ui_set_statusbar(TRUE, _("Cannot execute custom command \"%s\": %s. "
-			"Check the path setting in Preferences."), command, error->message);
-		g_error_free(error);
+			"Check the path setting in Custom Commands."), command, error->message);
 		g_error_free(error);
 	}
 


### PR DESCRIPTION
The goal of this PR is to improve the spawning error message, in both the spawn itself and most of it's callers, as described in issue #541.