### PR TITLE
Set close dialog and esc key events as cancel in show_prompt()

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -1354,7 +1354,7 @@ static gint show_prompt(GtkWidget *parent,
 	ret = gtk_dialog_run(GTK_DIALOG(dialog));
 	gtk_widget_destroy(dialog);
 
-	if (ret == GTK_RESPONSE_CANCEL)
+	if (ret == GTK_RESPONSE_CANCEL || ret == GTK_RESPONSE_DELETE_EVENT)
 		ret = response_2;
 	return ret;
 }


### PR DESCRIPTION
Line dialogs.c:1347 says "/* For a cancel button, use cancel response so user can press escape to cancel */" however in line 1357 only GTK_RESPONSE_CANCEL is linked to response_2, but esc KEY triggers a GTK_RESPONSE_DELETE_EVEN; hence it should be included also in 1357.

I found it because of a strange behaviour when cancelling a keybinding override in preferences dialog. You can reproduce it like so: go to prefs>keybindings, set a keybinding which is already used for another command, then Geany will show up a dialog saying that the combination is already used. Once there, if you press <kbd>Esc</kbd> key, you'll see that it does the "Allow" action, instead of -what the user would expect- the "Cancel" action.

I'm testing it and dialogs work fine as well as the issue exposed above is fixed.