### PR TITLE
plugins: pass GModule * to geany_load_module()

### DIFF
--- a/doc/plugins.dox
+++ b/doc/plugins.dox
@@ -328,7 +328,7 @@ static void hello_cleanup(GeanyPlugin *plugin, gpointer pdata)
 
 
 G_MODULE_EXPORT
-void geany_load_module(GeanyPlugin *plugin)
+void geany_load_module(GeanyPlugin *plugin, GModule *module)
 {
 	/* Step 1: Set metadata */
 	plugin->info->name = "HelloWorld";
@@ -357,7 +357,7 @@ as <c> extern "C" </c>, for example:
 
 @code
 
-extern "C" void geany_load_module(GeanyPlugin *plugin)
+extern "C" void geany_load_module(GeanyPlugin *plugin, GModule *module)
 {
 }
 
@@ -507,7 +507,7 @@ static void hello_cleanup(GeanyPlugin *plugin, gpointer pdata)
 
 
 G_MODULE_EXPORT
-void geany_load_module(GeanyPlugin *plugin)
+void geany_load_module(GeanyPlugin *plugin, GModule *module)
 {
 	plugin->info->name = "HelloWorld";
 	plugin->info->description = "Just another tool to say hello world";
@@ -659,7 +659,7 @@ becomes
 
 @code
 G_MODULE_EXPORT
-void geany_load_module(GeanyPlugin *plugin)
+void geany_load_module(GeanyPlugin *plugin, GModule *module)
 {
 // ...
 	plugin->info->name = "HelloWorld";
@@ -716,7 +716,7 @@ static gboolean on_editor_notify_cb(GObject *object, GeanyEditor *editor,
 
 
 G_MODULE_EXPORT
-void geany_load_module(GeanyPlugin *plugin)
+void geany_load_module(GeanyPlugin *plugin, GModule *module)
 {
 // ...
 	plugin->funcs->callbacks = plugin_callbacks;
@@ -914,7 +914,7 @@ static void demoproxy_cleanup(GeanyPlugin *plugin, gpointer data)
 
 
 G_MODULE_EXPORT
-void geany_load_module(GeanyPlugin *plugin)
+void geany_load_module(GeanyPlugin *plugin, GModule *module)
 {
 	plugin->info->name = _("Demo Proxy");
 	plugin->info->description = _("Example Proxy.");

--- a/plugins/demoplugin.c
+++ b/plugins/demoplugin.c
@@ -214,7 +214,7 @@ static void demo_cleanup(GeanyPlugin *plugin, gpointer data)
 	g_free(welcome_text);
 }
 
-void geany_load_module(GeanyPlugin *plugin)
+void geany_load_module(GeanyPlugin *plugin, GModule *module)
 {
 	/* main_locale_init() must be called for your package before any localization can be done */
 	main_locale_init(LOCALEDIR, GETTEXT_PACKAGE);

--- a/plugins/demoproxy.c
+++ b/plugins/demoproxy.c
@@ -188,7 +188,7 @@ static void demoproxy_cleanup(GeanyPlugin *plugin, gpointer data)
 
 
 G_MODULE_EXPORT
-void geany_load_module(GeanyPlugin *plugin)
+void geany_load_module(GeanyPlugin *plugin, GModule *module)
 {
 	plugin->info->name = _("Demo Proxy");
 	plugin->info->description = _("Example Proxy.");

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -286,11 +286,12 @@ void plugin_cleanup(void);
  *  - geany_plugin_register_full() (and GEANY_PLUGIN_REGISTER_FULL())
  *
  * @param plugin The unique plugin handle to your plugin. You must set some fields here.
+ * @param module The GModule that corresponds to the plugin's loadable module.
  *
  * @since 1.26 (API 225)
  * @see @ref howto
  */
-void geany_load_module(GeanyPlugin *plugin);
+void geany_load_module(GeanyPlugin *plugin, GModule *module);
 
 #endif
 

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -593,7 +593,7 @@ plugin_load(Plugin *plugin)
 static gpointer plugin_load_gmodule(GeanyPlugin *proxy, GeanyPlugin *subplugin, const gchar *fname, gpointer pdata)
 {
 	GModule *module;
-	void (*p_geany_load_module)(GeanyPlugin *);
+	void (*p_geany_load_module)(GeanyPlugin *, GModule *);
 
 	g_return_val_if_fail(g_module_supported(), NULL);
 	/* Don't use G_MODULE_BIND_LAZY otherwise we can get unresolved symbols at runtime,
@@ -618,7 +618,7 @@ static gpointer plugin_load_gmodule(GeanyPlugin *proxy, GeanyPlugin *subplugin, 
 		 * The ABI and API checks are performed by geany_plugin_register() (i.e. by us).
 		 * We check the LOADED_OK flag separately to protect us against buggy plugins
 		 * who ignore the result of geany_plugin_register() and register anyway */
-		p_geany_load_module(subplugin);
+		p_geany_load_module(subplugin, module);
 	}
 	else
 	{


### PR DESCRIPTION
This is rquired to enable the plugin to call g_module_make_resident() within
its geany_load_module(). This must be done if the plugin registers new
GTypes within that function.

plugin_module_make_resident() doesn't work because it's not an allowed API
function to call from there. Simply allowing it doesn't suffice because
internally the built-in plugin loader isn't fully set up yet:
plugin->proxy_data isn't set to the GModule at this point (by design), and
plugin_module_make_resident() requires that to be set.

This changes a public API, but it is unreleased so far, so not a problem (by
definition).