### PR TITLE
Cast windows HANDLE to intptr_t, not long

### DIFF
--- a/src/win32.c
+++ b/src/win32.c
@@ -812,7 +812,7 @@ static FILE *open_std_handle(DWORD handle, const char *mode)
 		g_free(err);
 		return NULL;
 	}
-	hConHandle = _open_osfhandle((long)lStdHandle, _O_TEXT);
+	hConHandle = _open_osfhandle(((intptr_t))lStdHandle, _O_TEXT);
 	if (hConHandle == -1)
 	{
 		gchar *err = g_win32_error_message(GetLastError());

--- a/src/win32.c
+++ b/src/win32.c
@@ -812,7 +812,7 @@ static FILE *open_std_handle(DWORD handle, const char *mode)
 		g_free(err);
 		return NULL;
 	}
-	hConHandle = _open_osfhandle(((intptr_t))lStdHandle, _O_TEXT);
+	hConHandle = _open_osfhandle((intptr_t)lStdHandle, _O_TEXT);
 	if (hConHandle == -1)
 	{
 		gchar *err = g_win32_error_message(GetLastError());


### PR DESCRIPTION
The cast in g_warning is not fixed. It's unimportant, displaying a
handle value does not provide any meaningful information anyway.