### PR TITLE
Avoid possible invalid memory access when activating plugin

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1478,6 +1478,9 @@ static void pm_plugin_toggled(GtkCellRendererToggle *cell, gchar *pth, gpointer 
 		/* save shortcuts (only need this group, but it doesn't take long) */
 		keybindings_write_to_file();
 
+	/* plugin_new() below may cause a tree view refresh with invalid p - set to NULL */
+	gtk_tree_store_set(pm_widgets.store, &store_iter,
+		PLUGIN_COLUMN_PLUGIN, NULL, -1);
 	plugin_free(p);
 
 	/* reload plugin module and initialize it if item is checked */


### PR DESCRIPTION
It may happen (and happens on OS X) that plugin activation using
plugin_new() triggers some action which causes the tree view to
update. However, as the old plugin was freed before, the tree view
contains an invalid pointer to p which causes invalid memory access.

After freeing the old pointer, set the tree view value to NULL - the
plugin pointer is checked at other places for NULL value so it
doesn't crash.