### PR TITLE
Allow calls to plugin_module_make_resident() from geany_load_module()

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -284,6 +284,7 @@ void plugin_cleanup(void);
  *  - main_locale_init()
  *  - geany_plugin_register() (and GEANY_PLUGIN_REGISTER())
  *  - geany_plugin_register_full() (and GEANY_PLUGIN_REGISTER_FULL())
+ *  - plugin_module_make_resident()
  *
  * @param plugin The unique plugin handle to your plugin. You must set some fields here.
  *

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -613,6 +613,10 @@ static gpointer plugin_load_gmodule(GeanyPlugin *proxy, GeanyPlugin *subplugin, 
 	g_module_symbol(module, "geany_load_module", (void *) &p_geany_load_module);
 	if (p_geany_load_module)
 	{
+		/* set this here already so plugins can call i.e. plugin_module_make_resident()
+		 * right from their geany_load_module() */
+		subplugin->priv->proxy_data = module;
+
 		/* This is a new style plugin. It should fill in plugin->info and then call
 		 * geany_plugin_register() in its geany_load_module() to successfully load.
 		 * The ABI and API checks are performed by geany_plugin_register() (i.e. by us).


### PR DESCRIPTION
This is useful if a plugin registers i.e. GTypes from its
geany_load_module(), i.e. to implement plugin functions as GObject
class methods.

The implementation can be considered a slight hack, but we need the
module to be know already in geany_load_module(), which is called too
early for the normal process to set it.

Closes #719.

---

This is the "hackish" way as mentioned in https://github.com/geany/geany/pull/719#issuecomment-152766371, but it actually looks quite better than altering the documentation like with #759, and it's more convenient for users.

It's a trivial change, and tested working.

@kugel- how do you feel about this?