### PR TITLE
Fix warnings about casting pointer from/to different size integer

### DIFF
--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -970,7 +970,7 @@ void sci_get_text_range(ScintillaObject *sci, gint start, gint end, gchar *text)
 	tr.chrg.cpMin = start;
 	tr.chrg.cpMax = end;
 	tr.lpstrText = text;
-	SSM(sci, SCI_GETTEXTRANGE, 0, (long) &tr);
+	SSM(sci, SCI_GETTEXTRANGE, 0, (sptr_t) &tr);
 }
 
 

--- a/src/win32.c
+++ b/src/win32.c
@@ -816,7 +816,7 @@ static FILE *open_std_handle(DWORD handle, const char *mode)
 	if (hConHandle == -1)
 	{
 		gchar *err = g_win32_error_message(GetLastError());
-		g_warning("_open_osfhandle(%ld, _O_TEXT) failed: %s", (long)lStdHandle, err);
+		g_warning("_open_osfhandle(handle(%ld), _O_TEXT) failed: %s", (long)handle, err);
 		g_free(err);
 		return NULL;
 	}

--- a/tagmanager/src/tm_workspace.c
+++ b/tagmanager/src/tm_workspace.c
@@ -398,7 +398,7 @@ static guint tm_file_inode_hash(gconstpointer key)
 #ifdef TM_DEBUG
 		g_message ("Hash for '%s' is '%d'\n", filename, file_stat.st_ino);
 #endif
-		return g_direct_hash ((gpointer)(gulong)file_stat.st_ino);
+		return g_direct_hash ((gpointer)(intptr_t)file_stat.st_ino);
 	} else {
 		return 0;
 	}


### PR DESCRIPTION
Note that the PR is tested under Win64 only. If warnings appear under Win32 or Unix, we will need to find even more compatible integer types.