### PR TITLE
Fix missing progress bar during build runs

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -1160,7 +1160,8 @@ static void build_command(GeanyDocument *doc, GeanyBuildGroup grp, guint cmd, gc
 	if (cmd_cat != NULL)
 		g_free(full_command);
 	build_menu_update(doc);
-
+	if (build_info.pid)
+		ui_progress_bar_start(NULL);
 }
 
 


### PR DESCRIPTION
Restore progress bar pulsation while a build is running, as it was lost
by accident in 690cb922be902f023881d455ae0c0a87d1c62170.

Closes #765.