### PR TITLE
Keybindings for custom commands 4-9 and support for passing the document file name as an argument

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -474,6 +474,18 @@ static void init_default_kb(void)
 		GDK_2, GEANY_PRIMARY_MOD_MASK, "edit_sendtocmd2", _("Send to Custom Command 2"), NULL);
 	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD3, NULL,
 		GDK_3, GEANY_PRIMARY_MOD_MASK, "edit_sendtocmd3", _("Send to Custom Command 3"), NULL);
+	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD4, NULL,
+		GDK_4, GEANY_PRIMARY_MOD_MASK, "edit_sendtocmd4", _("Send to Custom Command 4"), NULL);
+	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD5, NULL,
+		GDK_5, GEANY_PRIMARY_MOD_MASK, "edit_sendtocmd5", _("Send to Custom Command 5"), NULL);
+	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD6, NULL,
+		GDK_6, GEANY_PRIMARY_MOD_MASK, "edit_sendtocmd6", _("Send to Custom Command 6"), NULL);
+	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD7, NULL,
+		GDK_7, GEANY_PRIMARY_MOD_MASK, "edit_sendtocmd7", _("Send to Custom Command 7"), NULL);
+	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD8, NULL,
+		GDK_8, GEANY_PRIMARY_MOD_MASK, "edit_sendtocmd8", _("Send to Custom Command 8"), NULL);
+	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD9, NULL,
+		GDK_9, GEANY_PRIMARY_MOD_MASK, "edit_sendtocmd9", _("Send to Custom Command 9"), NULL);
 	/* may fit better in editor group */
 	add_kb(group, GEANY_KEYS_FORMAT_SENDTOVTE, NULL,
 		0, 0, "edit_sendtovte", _("_Send Selection to Terminal"), "send_selection_to_vte1");
@@ -2423,6 +2435,30 @@ static gboolean cb_func_format_action(guint key_id)
 		case GEANY_KEYS_FORMAT_SENDTOCMD3:
 			if (ui_prefs.custom_commands && g_strv_length(ui_prefs.custom_commands) > 2)
 				tools_execute_custom_command(doc, ui_prefs.custom_commands[2]);
+			break;
+		case GEANY_KEYS_FORMAT_SENDTOCMD4:
+			if (ui_prefs.custom_commands && g_strv_length(ui_prefs.custom_commands) > 3)
+				tools_execute_custom_command(doc, ui_prefs.custom_commands[3]);
+			break;
+		case GEANY_KEYS_FORMAT_SENDTOCMD5:
+			if (ui_prefs.custom_commands && g_strv_length(ui_prefs.custom_commands) > 4)
+				tools_execute_custom_command(doc, ui_prefs.custom_commands[4]);
+			break;
+		case GEANY_KEYS_FORMAT_SENDTOCMD6:
+			if (ui_prefs.custom_commands && g_strv_length(ui_prefs.custom_commands) > 5)
+				tools_execute_custom_command(doc, ui_prefs.custom_commands[5]);
+			break;
+		case GEANY_KEYS_FORMAT_SENDTOCMD7:
+			if (ui_prefs.custom_commands && g_strv_length(ui_prefs.custom_commands) > 6)
+				tools_execute_custom_command(doc, ui_prefs.custom_commands[6]);
+			break;
+		case GEANY_KEYS_FORMAT_SENDTOCMD8:
+			if (ui_prefs.custom_commands && g_strv_length(ui_prefs.custom_commands) > 7)
+				tools_execute_custom_command(doc, ui_prefs.custom_commands[7]);
+			break;
+		case GEANY_KEYS_FORMAT_SENDTOCMD9:
+			if (ui_prefs.custom_commands && g_strv_length(ui_prefs.custom_commands) > 8)
+				tools_execute_custom_command(doc, ui_prefs.custom_commands[8]);
 			break;
 		case GEANY_KEYS_FORMAT_SENDTOVTE:
 			on_send_selection_to_vte1_activate(NULL, NULL);

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -266,6 +266,12 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_GOTO_LINESTARTVISUAL,			/**< Keybinding. */
 	GEANY_KEYS_DOCUMENT_CLONE,					/**< Keybinding. */
 	GEANY_KEYS_FILE_QUIT,						/**< Keybinding. */
+	GEANY_KEYS_FORMAT_SENDTOCMD4,				/**< Keybinding. */
+	GEANY_KEYS_FORMAT_SENDTOCMD5,				/**< Keybinding. */
+	GEANY_KEYS_FORMAT_SENDTOCMD6,				/**< Keybinding. */
+	GEANY_KEYS_FORMAT_SENDTOCMD7,				/**< Keybinding. */
+	GEANY_KEYS_FORMAT_SENDTOCMD8,				/**< Keybinding. */
+	GEANY_KEYS_FORMAT_SENDTOCMD9,				/**< Keybinding. */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -203,8 +203,14 @@ void tools_execute_custom_command(GeanyDocument *doc, const gchar *command)
 	GString *output;
 	GString *errors;
 	gint status;
+	gchar *command_line;
 
 	g_return_if_fail(doc != NULL && command != NULL);
+
+	command_line = g_strdup(command);
+
+	if (doc->real_path)
+		utils_str_replace_all(&command_line, "%s", doc->real_path);
  
 	if (! sci_has_selection(doc->editor->sci))
 		editor_select_lines(doc->editor, FALSE);
@@ -214,9 +220,9 @@ void tools_execute_custom_command(GeanyDocument *doc, const gchar *command)
 	input.size = strlen(sel);
 	output = g_string_sized_new(256);
 	errors = g_string_new(NULL);
-	ui_set_statusbar(TRUE, _("Passing data and executing custom command: %s"), command);
+	ui_set_statusbar(TRUE, _("Passing data and executing custom command: %s"), command_line);
 
-	if (spawn_sync(NULL, command, NULL, NULL, &input, output, errors, &status, &error))
+	if (spawn_sync(NULL, command_line, NULL, NULL, &input, output, errors, &status, &error))
 	{
 		if (errors->len > 0)
 		{
@@ -246,6 +252,7 @@ void tools_execute_custom_command(GeanyDocument *doc, const gchar *command)
 
 	g_string_free(output, TRUE);
 	g_string_free(errors, TRUE);
+	g_free(command_line);
 	g_free(sel);
 }
 
@@ -554,6 +561,12 @@ static void cc_insert_custom_command_items(GtkMenu *me, const gchar *label, cons
 		case 0: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD1; break;
 		case 1: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD2; break;
 		case 2: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD3; break;
+		case 3: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD4; break;
+		case 4: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD5; break;
+		case 5: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD6; break;
+		case 6: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD7; break;
+		case 7: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD8; break;
+		case 8: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD9; break;
 	}
 
 	item = gtk_menu_item_new_with_label(label);


### PR DESCRIPTION
I've added additional keybindings so that one can have up to 9 custom commands.

Also added support for passing the document file name as a command line argument by substituting "%s" (as with the context action).