### PR TITLE
Fix known memory leak in win32_show_folder_dialog()

### DIFF
--- a/src/win32.c
+++ b/src/win32.c
@@ -284,7 +284,7 @@ INT CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM pData)
 gchar *win32_show_folder_dialog(GtkWidget *parent, const gchar *title, const gchar *initial_dir)
 {
 	BROWSEINFOW bi;
-	LPCITEMIDLIST pidl;
+	LPITEMIDLIST pidl;
 	gchar *result = NULL;
 	wchar_t fname[MAX_PATH];
 	wchar_t w_title[512];
@@ -305,14 +305,14 @@ gchar *win32_show_folder_dialog(GtkWidget *parent, const gchar *title, const gch
 	pidl = SHBrowseForFolderW(&bi);
 
 	/* convert the strange Windows folder list item something into an usual path string ;-) */
-	if (pidl != 0)
+	if (pidl != NULL)
 	{
 		if (SHGetPathFromIDListW(pidl, fname))
 		{
 			result = g_malloc0(MAX_PATH * 2);
 			WideCharToMultiByte(CP_UTF8, 0, fname, -1, result, MAX_PATH * 2, NULL, NULL);
 		}
-		/* SHBrowseForFolder() probably leaks memory here, but how to free the allocated memory? */
+		CoTaskMemFree(pidl);
 	}
 	return result;
 }


### PR DESCRIPTION
This is almost too trivial to make a PR but I'm no expert in Win32 COM and maybe I missed something (or the original author just missed something).

According to the [MSDN docs](https://msdn.microsoft.com/en-us/library/windows/desktop/bb762115%28v=vs.85%29.aspx):

> It is the responsibility of the calling application to call CoTaskMemFree to free the IDList returned by SHBrowseForFolder when it is no longer needed.