### PR TITLE
CUDA: Use C++ ctags parser

### DIFF
--- a/data/filetypes.CUDA.conf
+++ b/data/filetypes.CUDA.conf
@@ -21,6 +21,7 @@ preprocessor.end.$(file.patterns.cpp)=endif
 
 [settings]
 lexer_filetype=C
+tag_parser=C++
 
 # default extension used when saving files
 extension=cu


### PR DESCRIPTION
Fixes http://lists.geany.org/pipermail/users/2015-December/009845.html

Using C++ and not C is based on https://en.wikipedia.org/wiki/CUDA#Limitations and linked notes.