### PR TITLE
Fix 60 typos, point out 38 more

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -64,7 +64,7 @@ current Git (see `Committing`_)::
 
 We also accept patches against other releases, but it's more work for us.
 
-If you're not using Git, although you're strongly suggested to used it,
+If you're not using Git, although you're strongly suggested to use it,
 you can use the diff command::
 
     $ diff -u originalpath modifiedpath > new-feature.patch

--- a/HACKING
+++ b/HACKING
@@ -51,7 +51,7 @@ See `Rules to contribute`_ for more information.
 
 Patches
 -------
-We are happy to receive patches, but the prefered way is to make a pull
+We are happy to receive patches, but the preferred way is to make a pull
 request on our Github repository. If you don't want to make a pull request,
 you can send your patches on the devel mailing list, but the rules are the same:
 see `Rules to contribute`_ for more information.

--- a/README.Packagers
+++ b/README.Packagers
@@ -30,7 +30,7 @@ Geany still has a fallback mechanism for syntax highlighting (if
 filetypes.common is installed) but several other features for certain
 filetypes will fail (mainly build support).
 
-For 32 bit builds targetting systems which support large filesystems
+For 32 bit builds targeting systems which support large filesystems
 (eg XFS) it may be necessary to build with -D_FILE_OFFSET_BITS=64.
 
 

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1682,7 +1682,7 @@ EXTRA_PACKAGES         =
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
 # $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3189,7 +3189,7 @@ configure with a nothing in the label but at least one character in the command.
 Substitutions in commands and working directories
 `````````````````````````````````````````````````
 
-The first occurence of each of the following character sequences in each of the
+The first occurrence of each of the following character sequences in each of the
 command and working directory fields is substituted by the items specified below
 before the command is run.
 
@@ -3596,9 +3596,9 @@ Find Next                       Ctrl-G                    Finds next result.
 
 Find Previous                   Ctrl-Shift-G              Finds previous result.
 
-Find Next Selection                                       Finds next occurence of selected text.
+Find Next Selection                                       Finds next occurrence of selected text.
 
-Find Previous Selection                                   Finds previous occurence of selected text.
+Find Previous Selection                                   Finds previous occurrence of selected text.
 
 Replace                         Ctrl-H  (C)               Opens the Replace dialog.
 
@@ -4426,7 +4426,7 @@ For example::
     [named_styles]
     foo=my_red_color;my_blue_color;false;true
 
-This allows to define a color pallete by name so that to change a color
+This allows to define a color palette by name so that to change a color
 scheme-wide only involves changing the hex value in a single location.
 
 [styling] section

--- a/doc/plugins.dox
+++ b/doc/plugins.dox
@@ -634,7 +634,7 @@ parameters which you may use or not.
   - plugin_configure() => GeanyPlugin->funcs->configure
 
 @note @ref GeanyPluginFuncs::init() should return a boolean value: whether or not the plugin loaded
-succesfully. Since legacy plugins couldn't fail in plugin_init() you should return @c TRUE
+successfully. Since legacy plugins couldn't fail in plugin_init() you should return @c TRUE
 unconditionally.
 
 @note Again, plugin_configure_single() is not supported anymore.
@@ -797,7 +797,7 @@ storing a per-sub-plugin interpreter context.
 GEANY_PLUGIN_REGISTER_FULL() then you must pass NULL as free_func, because that would be invoked
 prior to unloading. Insert the corresponding code into GeanyProxyFuncs::unload.
 
-@section proxy_compat_guideline Guideline for Checking Compatiblity
+@section proxy_compat_guideline Guideline for Checking Compatibility
 
 Determining if a plugin candidate is compatible is not a single test. There are multiple levels and
 each should be handled differently in order to give the user a consistent feedback.
@@ -826,7 +826,7 @@ treatment of native plugins by Geany.
 3) The sub-plugin is also depending on Geany's API version (whether it is or not depends on the
 design of the proxy). In this case do not do anything special but forward the API version the
 sub-plugin is written/compiled against to GEANY_PLUGIN_REGISTER(). Here, Geany will perform its own
-compatiblity check, allowing for a consistent user feedback. The result is again that the
+compatibility check, allowing for a consistent user feedback. The result is again that the
 sub-plugin is hidden from the Plugin Manager, like in case 2. But Geany will print a debug message
 so you can skip that.
 
@@ -1029,7 +1029,7 @@ static gpointer demoproxy_load(GeanyPlugin *proxy, GeanyPlugin *plugin,
 }
 @endcode
 
-demoproxy_unload() simply releases all resources aquired in demoproxy_load(). It does not have to
+demoproxy_unload() simply releases all resources acquired in demoproxy_load(). It does not have to
 do anything else in for unloading.
 
 @code{.c}

--- a/geany.spec.in
+++ b/geany.spec.in
@@ -34,7 +34,7 @@ Requires:      glib2, gtk2, pango
 BuildRequires: glib2-devel, gtk2-devel, pango-devel, gettext, intltool
 
 %description
-Geany is a small and fast integrated development enviroment with basic
+Geany is a small and fast integrated development environment with basic
 features and few dependencies to other packages or Desktop Environments.
 
 Some features:

--- a/scintilla/lexers/LexCaml.cxx
+++ b/scintilla/lexers/LexCaml.cxx
@@ -112,7 +112,7 @@ long Platform::SendScintillaPointer(WindowID w, unsigned int msg, unsigned long 
 void EXT_LEXER_DECL Fold(unsigned int lexer, Sci_PositionU startPos, Sci_Position length,
 	int initStyle, char *words[], WindowID window, char *props)
 {
-	// below useless evaluation(s) to supress "not used" warnings
+	// below useless evaluation(s) to suppress "not used" warnings
 	lexer;
 	// build expected data structures and do the Fold
 	InternalLexOrFold(1, startPos, length, initStyle, words, window, props);
@@ -126,7 +126,7 @@ int EXT_LEXER_DECL GetLexerCount()
 
 void EXT_LEXER_DECL GetLexerName(unsigned int Index, char *name, int buflength)
 {
-	// below useless evaluation(s) to supress "not used" warnings
+	// below useless evaluation(s) to suppress "not used" warnings
 	Index;
 	// return as much of our lexer name as will fit (what's up with Index?)
 	if (buflength > 0) {
@@ -141,7 +141,7 @@ void EXT_LEXER_DECL GetLexerName(unsigned int Index, char *name, int buflength)
 void EXT_LEXER_DECL Lex(unsigned int lexer, Sci_PositionU startPos, Sci_Position length,
 	int initStyle, char *words[], WindowID window, char *props)
 {
-	// below useless evaluation(s) to supress "not used" warnings
+	// below useless evaluation(s) to suppress "not used" warnings
 	lexer;
 	// build expected data structures and do the Lex
 	InternalLexOrFold(0, startPos, length, initStyle, words, window, props);

--- a/scintilla/lexers/LexCmake.cxx
+++ b/scintilla/lexers/LexCmake.cxx
@@ -54,7 +54,7 @@ static bool CmakeNextLineHasElse(Sci_PositionU start, Sci_PositionU end, Accesso
         }
     }
 
-    if ( nNextLine == -1 ) // We never foudn the next line...
+    if ( nNextLine == -1 ) // We never found the next line...
         return false;
 
     for ( Sci_PositionU firstChar = nNextLine; firstChar < end; firstChar++ ) {

--- a/scintilla/src/SVector.h
+++ b/scintilla/src/SVector.h
@@ -101,7 +101,7 @@ public:
 		len = 0;
 	}
 	/** @brief Grow vector size.
-	 * Doesn't allow a vector to be shrinked. */
+	 * Doesn't allow a vector to be shrunk. */
 	void SetLength(unsigned int newLength) {
 		if (newLength > len) {
 			if (newLength >= size) {

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -328,7 +328,7 @@ gboolean geany_plugin_register_full(GeanyPlugin *plugin, gint api_version,
                                     gpointer data, GDestroyNotify free_func);
 void geany_plugin_set_data(GeanyPlugin *plugin, gpointer data, GDestroyNotify free_func);
 
-/** Convinience macro to register a plugin.
+/** Convenience macro to register a plugin.
  *
  * It simply calls geany_plugin_register() with GEANY_API_VERSION and GEANY_ABI_VERSION.
  *
@@ -339,7 +339,7 @@ void geany_plugin_set_data(GeanyPlugin *plugin, gpointer data, GDestroyNotify fr
 	geany_plugin_register((plugin), GEANY_API_VERSION, \
 	                      (min_api_version), GEANY_ABI_VERSION)
 
-/** Convinience macro to register a plugin with data.
+/** Convenience macro to register a plugin with data.
  *
  * It simply calls geany_plugin_register_full() with GEANY_API_VERSION and GEANY_ABI_VERSION.
  *

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1013,7 +1013,7 @@ static gboolean check_plugin_path(const gchar *fname)
 }
 
 
-/* Retuns NULL if this ain't a plugin,
+/* Returns NULL if this ain't a plugin,
  * otherwise it returns the appropriate PluginProxy instance to load it */
 static PluginProxy* is_plugin(const gchar *file)
 {
@@ -2002,7 +2002,7 @@ gboolean geany_plugin_register_proxy(GeanyPlugin *plugin, const gchar **extensio
 	g_return_val_if_fail(plugin->proxy_funcs->unload != NULL, FALSE);
 
 	p = plugin->priv;
-	/* Check if this was called aready. We want to reserve for the use case of calling
+	/* Check if this was called already. We want to reserve for the use case of calling
 	 * this again to set new supported extensions (for example, based on proxy configuration). */
 	foreach_list(node, active_proxies.head)
 	{

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -573,8 +573,8 @@ void geany_plugin_set_data(GeanyPlugin *plugin, gpointer pdata, GDestroyNotify f
 	 * In the future we want to support proxy plugins (which bind non-C plugins to
 	 * Geany's plugin api). These proxy plugins might need to own the data pointer
 	 * on behalf of the proxied plugin. However, if not, then the plugin should be
-	 * free to use it. This way we can make sure the plugin doesn't accidently trash
-	 * its proxy.
+	 * free to use it. This way we can make sure the plugin doesn't accidentally
+	 * trash its proxy.
 	 *
 	 * Better a more limited API now that can be opened up later than a potentially
 	 * wrong one that can only be replaced by another one. */

--- a/tagmanager/ctags/actionscript.c
+++ b/tagmanager/ctags/actionscript.c
@@ -85,7 +85,7 @@ static void installActionScriptRegex (const langType language)
 	    "\\1", "p,prototype", NULL);
 }
 
-/* Create parser definition stucture */
+/* Create parser definition structure */
 extern parserDefinition* ActionScriptParser (void)
 
 {

--- a/tagmanager/ctags/c.c
+++ b/tagmanager/ctags/c.c
@@ -855,7 +855,7 @@ static boolean isContextualStatement (const statementInfo *const st)
 	{
 		if (isLanguage (Lang_vala))
 		{
-			/* All can be a contextual statment as properties can be of any type */
+			/* All can be a contextual statement as properties can be of any type */
 			result = TRUE;
 		}
 		else
@@ -977,7 +977,7 @@ static void reinitStatementWithToken (statementInfo *const st,
 	token = activeToken (st);
 	copyToken (token, save);
 	deleteToken (save);
-	++st->tokenIndex;	/* this is quite save becouse current tokenIndex = 0 */
+	++st->tokenIndex;	/* this is quite safe because current tokenIndex = 0 */
 }
 
 static void initStatement (statementInfo *const st, statementInfo *const parent)

--- a/tagmanager/ctags/ctags.c
+++ b/tagmanager/ctags/ctags.c
@@ -186,7 +186,7 @@
 # define S_IWUSR 0200
 #endif
 
-/*  Hack for rediculous practice of Microsoft Visual C++.
+/*  Hack for ridiculous practice of Microsoft Visual C++.
  */
 #if defined (WIN32)
 # if defined (_MSC_VER)

--- a/tagmanager/ctags/entry.c
+++ b/tagmanager/ctags/entry.c
@@ -59,7 +59,7 @@
 # define USE_REPLACEMENT_TRUNCATE
 #endif
 
-/*  Hack for rediculous practice of Microsoft Visual C++.
+/*  Hack for ridiculous practice of Microsoft Visual C++.
  */
 #if defined (WIN32) && defined (_MSC_VER)
 # define chsize		_chsize

--- a/tagmanager/ctags/entry.h
+++ b/tagmanager/ctags/entry.h
@@ -58,7 +58,7 @@ typedef struct sTagEntryInfo {
     MIOPos	filePosition;	/* file position of line containing tag */
     int bufferPosition;		/* buffer position of line containing tag */
     const char*	language;	/* language of source file */
-    boolean	isFileScope;	/* is tag visibile only within source file? */
+    boolean	isFileScope;	/* is tag visible only within source file? */
     boolean	isFileEntry;	/* is this just an entry for a file name? */
     boolean	truncateLine;	/* truncate tag line at end of tag name? */
     const char *sourceFileName;	/* name of source file */

--- a/tagmanager/ctags/haxe.c
+++ b/tagmanager/ctags/haxe.c
@@ -212,7 +212,7 @@ another:
 }
 
 
-/* Create parser definition stucture */
+/* Create parser definition structure */
 extern parserDefinition* HaxeParser (void)
 {
 	static const char *const extensions [] = { "hx", NULL };

--- a/tagmanager/ctags/html.c
+++ b/tagmanager/ctags/html.c
@@ -55,7 +55,7 @@ static void installHtmlRegex (const langType language)
 		"\\2", "v,variable,H3 heading", "i");
 }
 
-/* Create parser definition stucture */
+/* Create parser definition structure */
 extern parserDefinition* HtmlParser (void)
 {
 	static const char *const extensions [] = { "htm", "html", NULL };

--- a/tagmanager/ctags/js.c
+++ b/tagmanager/ctags/js.c
@@ -1298,7 +1298,7 @@ static boolean parseStatement (tokenInfo *const token, tokenInfo *const parent, 
 	if ( is_inside_class )
 		is_class = TRUE;
 	/*
-	 * var can preceed an inner function
+	 * var can precede an inner function
 	 */
 	if ( isKeyword(token, KEYWORD_var) ||
 		 isKeyword(token, KEYWORD_let) ||
@@ -1914,7 +1914,7 @@ static void findJsTags (void)
 	deleteToken (token);
 }
 
-/* Create parser definition stucture */
+/* Create parser definition structure */
 extern parserDefinition* JavaScriptParser (void)
 {
 	static const char *const extensions [] = { "js", NULL };

--- a/tagmanager/ctags/json.c
+++ b/tagmanager/ctags/json.c
@@ -377,7 +377,7 @@ static void initialize (const langType language)
 	addKeyword ("null", language, KEYWORD_null);
 }
 
-/* Create parser definition stucture */
+/* Create parser definition structure */
 extern parserDefinition* JsonParser (void)
 {
 	static const char *const extensions [] = { "json", NULL };

--- a/tagmanager/ctags/sql.c
+++ b/tagmanager/ctags/sql.c
@@ -673,7 +673,7 @@ getNextChar:
 }
 
 /*
- * reads an indentifier, possibly quoted:
+ * reads an identifier, possibly quoted:
  * 		identifier
  * 		"identifier"
  * 		[identifier]
@@ -1186,7 +1186,7 @@ static void parseDeclareANSI (tokenInfo *const token, const boolean local)
 	 *		 DECLARE varname2 datatype;
 	 *		 ...
 	 *
-	 * This differ from PL/SQL where DECLARE preceeds the BEGIN block
+	 * This differ from PL/SQL where DECLARE precedes the BEGIN block
 	 * and the DECLARE keyword is not repeated.
 	 */
 	while (isKeyword (token, KEYWORD_declare))

--- a/tagmanager/src/tm_tag.c
+++ b/tagmanager/src/tm_tag.c
@@ -1291,7 +1291,7 @@ static const char *tm_tag_access_name(TMTag *tag)
 /*
   Prints information about a tag to the given file pointer.
   @param tag The tag whose info is required.
-  @param fp The file pointer of teh file to print the info to.
+  @param fp The file pointer of the file to print the info to.
 */
 void tm_tag_print(TMTag *tag, FILE *fp)
 {

--- a/tagmanager/src/tm_workspace.c
+++ b/tagmanager/src/tm_workspace.c
@@ -477,7 +477,7 @@ static gchar *create_temp_file(const gchar *tpl)
 
 
 /* Creates a list of global tags. Ideally, this should be created once during
- installations so that all users can use the same file. Thsi is because a full
+ installations so that all users can use the same file. This is because a full
  scale global tag list can occupy several megabytes of disk space.
  @param pre_process The pre-processing command. This is executed via system(),
  so you can pass stuff like 'gcc -E -dD -P `gnome-config --cflags gnome`'.

--- a/tests/ctags/3526726.tex
+++ b/tests/ctags/3526726.tex
@@ -553,7 +553,7 @@ available.
 
 As for OS selection, use what you like. When we implement Data Acquisition
 Plugin's in Snort 2.0 this may become more of a factor, but for now I'm hearing
-about a lot of people seeing alot of success using Snort on Solaris, Linux,
+about a lot of people seeing a lot of success using Snort on Solaris, Linux,
 *BSD and Windows 2000. Personally, I develop Snort on FreeBSD and Sourcefire
 uses OpenBSD for our sensor appliance OS, but I've been hearing some good
 things about the RedHat Turbo Packet interface (which would require mods for
@@ -640,7 +640,7 @@ these steps at your OWN risk.
 \item In a command prompt, run 'ipconfig' to verify the interface does not have an IP bound to it.
 \end{enumerate}
 
-If you do not recieve an IP address listing from the interface you
+If you do not receive an IP address listing from the interface you
 modified, you are good to go.  To run snort with the specified interface,
 use the -i flag such as 'snort -v -d -p -i1'
  
@@ -1604,7 +1604,7 @@ were detected by snort when a communications session attempt fails.
 
 The default order that the rules are applied in is alerts first, then pass
 rules, then log rules. This ordering ensures that you don't write 50 great
-alert rules and then disable them all accidently with an errant pass rule. If
+alert rules and then disable them all accidentally with an errant pass rule. If
 you really want to change this order so that the pass rules are applied first,
 use the ``-o'' command line switch, or the ``order'' config directive.
 
@@ -2403,7 +2403,7 @@ Try this script to archive the files:
   * []#!/bin/sh
 
     # 
-    # Logfile rotation script for snort writen by jameso@elwood.net.
+    # Logfile rotation script for snort written by jameso@elwood.net.
     # 
     # This script is pretty basic. We start out by setting some vars.
     # Its job is tho rotate the days logfiles, e-mail you with what 
@@ -2464,7 +2464,7 @@ Try this script to archive the files:
     fi
     
     # Move the log files into todays log dir. This is done with
-    # a for loop right now, because I am afriad that if alot is
+    # a for loop right now, because I am afriad that if a lot is
     # logged there may be to many items to move with a "mv *"
     # type command. There may a better way to do this, but I don't
     # know it yet.
@@ -2706,7 +2706,7 @@ adapter basically mediating the 10 up to 100 and vice versa.
 The bad thing about hubs that {\em don't} have this ``feature,'' is that
 in order to support 10bt devices, they throttle the entire hub speed
 down to 10bt if there is one or more 10bt only devices hooked up to it.
-I have seen this behavior (and did the bandwidth tests to proove it) on
+I have seen this behavior (and did the bandwidth tests to prove it) on
 old 3com office connect 10/100 hubs (newer ones do the 2 hubs with a switch
 thing.)  So, the point of what I am saying is, since these old hubs have
 no switching capabilities, and they don't know which port the traffic is
@@ -2752,7 +2752,7 @@ traffic (telnet,http for example).  You set up a port to mirror
 traffic from the ports that have the devices your interested in to the
 port you have your analysis device plugged into.  Without doing so,
 you don't see the unicast conversations because the traffic is getting
-"switched" accross the backplane so pc on port 1 talks to server on
+"switched" across the backplane so pc on port 1 talks to server on
 port 2 and no other ports get this traffic. If server on port 2
 broadcasts or multicasts, the information is flooded out all ports.
 (multicast can be controlled on some switches so only those ports that
@@ -2763,7 +2763,7 @@ An excellent book on the topic is Interconnections by Radia Perlman.
 (Bridges and Routers).
   
 Additional caveat: if you deal with full duplex on a switched port,
-only a tap would save you - users have succesfully used Shomiti's
+only a tap would save you - users have successfully used Shomiti's
 ones on 100MB FD ports, and used two Snort instances, capturing
 traffic on both directions. Port mirroring didn't work in that case ...
 

--- a/tests/ctags/bug1111214.v
+++ b/tests/ctags/bug1111214.v
@@ -2,7 +2,7 @@
 //
 // Below is an example of a comment that is mis-parsed by exuberant ctags.
 // It uses the multi-line comment format, i.e. /* ... */ except that in
-// this case, the character sequence immediately preceeding the closing
+// this case, the character sequence immediately preceding the closing
 // delimiter is an asterisk. (Any even number of asterisks would have the
 // same problem.
 // The line immediately afterwards is used to demonstrate the problem.

--- a/tests/ctags/bug612019.pas
+++ b/tests/ctags/bug612019.pas
@@ -16,7 +16,7 @@ Initial Comment:
 In attached sample there are some lines from tags file
 generated for object pascal sources.
 There are some problems with this lines.
-Generaly speaking they are parsed incorrectly.
+Generally speaking they are parsed incorrectly.
 *)
 unit a;
 

--- a/tests/ctags/bug852368.cpp
+++ b/tests/ctags/bug852368.cpp
@@ -16,8 +16,8 @@ Summary: c/c++ unabalanced template brackets in signature
 Initial Comment:
 hi,
 
-ctags 5.5x generates unbalanced tempalte brackets in 
-the  method/function signature if a funtion parameter 
+ctags 5.5x generates unbalanced template brackets in 
+the  method/function signature if a function parameter 
 is a template.
 
 i.e.

--- a/tests/ctags/jsFunc_tutorial.js
+++ b/tests/ctags/jsFunc_tutorial.js
@@ -122,7 +122,7 @@ var multiply=D5("*");           // created "multiply" function
 
 // test the functions
 alert("result of add="+add(10,2));            // result is 12
-alert("result of substract="+subtract(10,2)); // result is 8
+alert("result of subtract="+subtract(10,2));  // result is 8
 alert("result of multiply="+multiply(10,2));  // result is 20
 alert(add);
 

--- a/tests/ctags/lanus.for
+++ b/tests/ctags/lanus.for
@@ -8,7 +8,7 @@
 * 
 * I'm trying to set ctags to work with some old FORTRAN 77 programs.
 * I'm in Windows 2000, vim 6.1 and exuberant ctags 5.3.1.
-* The programs are for VAX FORTRAN 77 as of 1988. Writen with tabs and 132 columns line length.
+* The programs are for VAX FORTRAN 77 as of 1988. Written with tabs and 132 columns line length.
 * 
 * [...]
 * 

--- a/tests/ctags/members.f90
+++ b/tests/ctags/members.f90
@@ -2,7 +2,7 @@ module Members
   implicit none
 
   type HasMembers
-    ! a "derived type" in Fortran is analagous to a "class" in other languages
+    ! a "derived type" in Fortran is analogous to a "class" in other languages
     integer, kind :: kind_member
     integer, len  :: len_member
     integer       :: member

--- a/tests/ctags/misc_types.f
+++ b/tests/ctags/misc_types.f
@@ -12,7 +12,7 @@
 	VIRTUAL M(10,10), Y(100) 
 	VOLATILE V, Z, MAT, /INI/ 
 
-	EXTERNAL ABS ! varations of external and global
+	EXTERNAL ABS ! variations of external and global
 	CEXTERNAL ABS1 ! not supported
 	CGLOBAL ABS2 ! not supported
 	PEXTERNAL ABS3 ! not supported

--- a/tests/ctags/moniker.x68.asm
+++ b/tests/ctags/moniker.x68.asm
@@ -23,7 +23,7 @@ START   	MOVEA.L #PROMPT1,A1             Pointer to start of prompt text
         
 *       	Get firstname
 *		=============
-        	MOVEA.L #F_NAME,A1              Pointer to store the sentance
+        	MOVEA.L #F_NAME,A1              Pointer to store the sentence
         	MOVE.B  #READSTR,D0             Set up readstring function
         	TRAP    #15                     Get string from KB
         	MOVE.W  D1,D4                   Save length of input string to d4
@@ -38,7 +38,7 @@ START   	MOVEA.L #PROMPT1,A1             Pointer to start of prompt text
       	MOVEA.L #F_NAME,A0              Move the first char to A0
        	JSR     CHECK2                  Check if uppercase
         
-        	CMPI.B  #1,D5                   See if all the sentance is CAPS
+        	CMPI.B  #1,D5                   See if all the sentence is CAPS
         	BCS     START                   if it is'nt then re-enter                          
 
 
@@ -51,7 +51,7 @@ SURNAME 	MOVEA.L #PROMPT2,A1             Pointer to start of prompt text
         
 *       	Get surname
 *		===========
-        	MOVEA.L #S_NAME,A1              Pointer to store the sentance
+        	MOVEA.L #S_NAME,A1              Pointer to store the sentence
         	MOVE.B  #READSTR,D0             Set up readstring function
         	TRAP    #15                     Get string from KB
         	MOVE.W  D1,D4                   Save length on input string
@@ -66,7 +66,7 @@ SURNAME 	MOVEA.L #PROMPT2,A1             Pointer to start of prompt text
         	MOVEA.L #S_NAME,A0              Move the first char to A0  
         	JSR     CHECK2                  Check if uppercase        
         
-        	CMPI.B  #1,D5                   See if all the sentance is CAPS
+        	CMPI.B  #1,D5                   See if all the sentence is CAPS
         	BCS     SURNAME                 if it is'nt then re-enter     
 
 *       	Move the first char for fname and prints it (Initial Bit)
@@ -94,7 +94,7 @@ CHECK2  	CMPI.B  #'A',(A0)               Is Char > A ?
         	CMP.B   #('Z'+1),(A0)+          Check if char is < Z
         	BCC     RETURNFALSE             If it is then it must be a cap
         	SUBI.B  #1,D4                   Decrease s_name / f_name Length
-        	BNE     CHECK2                  jump if the sentance is not = 0
+        	BNE     CHECK2                  jump if the sentence is not = 0
 
 RETURNTRUE  MOVE.B  #1,D5			  Moves a one to D5 to make CAPS ture
             RTS					  Jump back to the main program

--- a/tests/ctags/moniker.x68.asm
+++ b/tests/ctags/moniker.x68.asm
@@ -23,7 +23,7 @@ START   	MOVEA.L #PROMPT1,A1             Pointer to start of prompt text
         
 *       	Get firstname
 *		=============
-        	MOVEA.L #F_NAME,A1              Pointer to store teh sentance
+        	MOVEA.L #F_NAME,A1              Pointer to store the sentance
         	MOVE.B  #READSTR,D0             Set up readstring function
         	TRAP    #15                     Get string from KB
         	MOVE.W  D1,D4                   Save length of input string to d4
@@ -46,7 +46,7 @@ START   	MOVEA.L #PROMPT1,A1             Pointer to start of prompt text
 *		=======================================
 SURNAME 	MOVEA.L #PROMPT2,A1             Pointer to start of prompt text
         	MOVE.B  #PRTSTR,D0              Set up print string function
-        	MOVE.W  #(F_NAME-PROMPT2),D1    The prompt string lenght
+        	MOVE.W  #(F_NAME-PROMPT2),D1    The prompt string length
         	TRAP    #15                     Print Prompt
         
 *       	Get surname
@@ -78,7 +78,7 @@ INITIAL 	MOVEA.L #F_NAME,A1              Move the first char to A1
 
 PRNSURNAME	MOVEA.L #S_NAME,A1              Pointer to start of prompt text
         	MOVE.B  #0,D0                   Set up print string function
-        	MOVE.W  D3,D1                   The prompt string lenght
+        	MOVE.W  D3,D1                   The prompt string length
         	TRAP    #15                     Print Prompt
 
 QUIT    	STOP    #$2700                  Stop the prorgam


### PR DESCRIPTION
Please note that all except two typos were found by the tool `codespell`. However, I have verified and correct them all by myself and am now going blind -- err, I mean, I won't do the rest by hand.

Some of these corrections may need special attention, most importantly:

	# Logfile rotation script for snort writen by jameso@elwood.net.
	./tests/ctags/3526726.tex:2406

This sounds like it was taken from a third-party script, and *that* script should be fixed, too.

These are the codespell results that look like a true positive, but were ignored by me for some reason:

	(ignored, because these are't trivial to correct)
	./tagmanager/ctags/vhdl.c:71: atribute  ==> attribute
	./tagmanager/ctags/vhdl.c:71: atributes  ==> attributes
	./data/filetypes.fortran:7: inot  ==> into
	./data/php.tags:3358: lenght  ==> length
	./data/filetypes.f77:23: inot  ==> into

	(ignored, because these are "ancient" changelogs)
	./ChangeLog.pre-1-22:3811: everytime  ==> every time
	./ChangeLog.pre-1-22:5139: accidently  ==> accidentally
	./ChangeLog.pre-0-17:441: occurences  ==> occurrences
	./ChangeLog.pre-0-17:2448: accessable  ==> accessible
	./ChangeLog.pre-0-17:3134: supress  ==> suppress
	./ChangeLog.pre-0-17:3211: contributers  ==> contributors
	./ChangeLog.pre-0-17:4732: translaters  ==> translators
	./ChangeLog.pre-0-17:5851: improvments  ==> improvements
	./ChangeLog.pre-0-17:9771: entitity  ==> entity

	(ignored, because these are very consistent)
	./tests/ctags/3526726.tex:2421: todays  ==> today's  | disable because of var names
	./tests/ctags/3526726.tex:2423: todays  ==> today's  | disable because of var names
	./tests/ctags/3526726.tex:2432: Todays  ==> Today's  | disable because of var names
	./tests/ctags/3526726.tex:2433: Todays  ==> Today's  | disable because of var names
	./tests/ctags/3526726.tex:2460: todays  ==> today's  | disable because of var names
	./tests/ctags/3526726.tex:2466: todays  ==> today's  | disable because of var names

	(ignored, because these are variable names)
	./tests/ctags/test.vhd:360: scaleable  ==> scalable
	./tests/ctags/test.vhd:4475: scaleable  ==> scalable
	./tests/ctags/test.vhd:4492: scaleable  ==> scalable
	./tests/ctags/test.vhd:4502: scaleable  ==> scalable
	./tests/ctags/test.vhd:4518: scaleable  ==> scalable
	./tests/ctags/test.vhd:4661: scaleable  ==> scalable
	./tests/ctags/test.vhd:4688: scaleable  ==> scalable
	./tests/ctags/test.vhd:4700: scaleable  ==> scalable
	./tests/ctags/test.vhd:4761: scaleable  ==> scalable
	./tests/ctags/test.vhd:6427: scaleable  ==> scalable
	./tests/ctags/test.vhd:6434: scaleable  ==> scalable
	./tests/ctags/test.vhd:6448: scaleable  ==> scalable
	./tests/ctags/test.vhd:6483: scaleable  ==> scalable

	(ignored, because I don't wanna go full grammar-nazi on you)
	./tests/ctags/3526726.tex:688: wont  ==> won't, wont
	./tests/ctags/bug726712.f90:70: wont  ==> won't, wont
	./tests/ctags/mode.php:97: WONT  ==> WON'T, WONT
	./scintilla/src/ScintillaBase.cxx:279: Wont  ==> Won't, wont
	./scintilla/src/ScintillaBase.cxx:308: Wont  ==> Won't, wont
	./tagmanager/src/tm_workspace.c:1172: wanna  ==> want to  | disabled because one might want to allow informal pronunciation

Furthermore, please look at this:

	alert("result of substract="+subtract(10,2)); // result is 8
	./tests/ctags/jsFunc_tutorial.js:125

Nothing important about it, I just wanted to point out that the author named the function correctly (`subtract`) but made a typo in the debug string (`subStract`). I find it funny :)