### PR TITLE
Add 'build_execute_autoclose' various pref

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -67,6 +67,8 @@
 #define GEANY_BUILD_ERR_HIGHLIGHT_MAX 50
 
 
+gboolean build_execute_autoclose = FALSE;
+
 GeanyBuildInfo build_info = {GEANY_GBG_FT, 0, 0, NULL, GEANY_FILETYPES_NONE, NULL, 0};
 
 static gchar *current_dir_entered = NULL;
@@ -794,7 +796,7 @@ static gchar *prepare_run_cmd(GeanyDocument *doc, gchar **working_dir, guint cmd
 {
 	GeanyBuildCommand *cmd = NULL;
 	const gchar *cmd_working_dir;
-	gboolean autoclose = FALSE;
+	gboolean autoclose = build_execute_autoclose;
 	gchar *cmd_string_utf8, *working_dir_utf8, *run_cmd, *cmd_string;
 	GError *error = NULL;
 

--- a/src/build.h
+++ b/src/build.h
@@ -179,6 +179,11 @@ typedef struct BuildDestination
 typedef struct BuildTableFields *BuildTableData;
 
 
+#ifdef GEANY_PRIVATE
+extern gboolean build_execute_autoclose;
+#endif
+
+
 void build_init(void);
 
 void build_finalize(void);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -259,6 +259,8 @@ static void init_pref_groups(void)
 		"number_non_ft_menu_items", 0);
 	stash_group_add_integer(group, &build_menu_prefs.number_exec_menu_items,
 		"number_exec_menu_items", 0);
+	stash_group_add_boolean(group, &build_execute_autoclose,
+		"build_execute_autoclose", FALSE);
 }
 
 


### PR DESCRIPTION
This is the minimum required to support my use case where I want the command prompt window to close when the target app is finished.

As separate PR I could imagine lifting the ["build menu" prefs here](https://github.com/geany/geany/blob/master/src/keyfile.c#L114) out of keybindings.c and sharing a namespace with this horrible new global variable. Misery loves company.

Tested on Win32/MSYS2/64-bit.