### PR TITLE
Follow symlinks in find in files

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1559,7 +1559,7 @@ static GString *get_grep_options(void)
 	if (settings.fif_match_whole_word)
 		g_string_append_c(gstr, 'w');
 	if (settings.fif_recursive)
-		g_string_append_c(gstr, 'r');
+		g_string_append_c(gstr, 'R');
 
 	if (!settings.fif_regexp)
 		g_string_append_c(gstr, 'F');


### PR DESCRIPTION
Use the -R option instead of -r for grep.

See https://github.com/geany/geany-plugins/issues/327#issuecomment-180806977

Seems to work fine even with symlink loops (just writes some warning).