### PR TITLE
plugin api: export editor_set_indent_width()

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -4561,6 +4561,13 @@ void editor_set_indent_type(GeanyEditor *editor, GeanyIndentType type)
 }
 
 
+/** Sets the indent width for @a editor.
+ * @param editor Editor.
+ * @param width New indent width.
+ *
+ * @since 1.27 (API 227)
+ */
+GEANY_API_SYMBOL
 void editor_set_indent_width(GeanyEditor *editor, gint width)
 {
 	editor_set_indent(editor, editor->indent_type, width);

--- a/src/editor.h
+++ b/src/editor.h
@@ -167,6 +167,8 @@ void editor_indicator_clear(GeanyEditor *editor, gint indic);
 
 void editor_set_indent_type(GeanyEditor *editor, GeanyIndentType type);
 
+void editor_set_indent_width(GeanyEditor *editor, gint width);
+
 gchar *editor_get_word_at_pos(GeanyEditor *editor, gint pos, const gchar *wordchars);
 
 const gchar *editor_get_eol_char_name(GeanyEditor *editor);
@@ -306,8 +308,6 @@ void editor_strip_trailing_spaces(GeanyEditor *editor, gboolean ignore_selection
 void editor_ensure_final_newline(GeanyEditor *editor);
 
 void editor_insert_color(GeanyEditor *editor, const gchar *colour);
-
-void editor_set_indent_width(GeanyEditor *editor, gint width);
 
 void editor_set_indent(GeanyEditor *editor, GeanyIndentType type, gint width);
 

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 226
+#define GEANY_API_VERSION 227
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */


### PR DESCRIPTION
Plugins can now change the indentation width of an editor.