### PR TITLE
Comment-out some options not available on older doxygen versions

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1032,7 +1032,7 @@ VERBATIM_HEADERS       = NO
 # compiled with the --with-libclang option.
 # The default value is: NO.
 
-CLANG_ASSISTED_PARSING = NO
+# CLANG_ASSISTED_PARSING = NO
 
 # If clang assisted parsing is enabled you can provide the compiler with command
 # line options that you would normally use when invoking the compiler. Note that
@@ -1040,7 +1040,7 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          =
+# CLANG_OPTIONS          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
@@ -1910,7 +1910,7 @@ DOCBOOK_OUTPUT         = docbook
 # The default value is: NO.
 # This tag requires that the tag GENERATE_DOCBOOK is set to YES.
 
-DOCBOOK_PROGRAMLISTING = NO
+# DOCBOOK_PROGRAMLISTING = NO
 
 #---------------------------------------------------------------------------
 # Configuration options for the AutoGen Definitions output
@@ -2337,7 +2337,7 @@ DIAFILE_DIRS           =
 # will not generate output for the diagram.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-PLANTUML_JAR_PATH      =
+# PLANTUML_JAR_PATH      =
 
 # The DOT_GRAPH_MAX_NODES tag can be used to set the maximum number of nodes
 # that will be shown in the graph. If the number of nodes in a graph becomes


### PR DESCRIPTION
This eliminates some warnings with doxygen 1.8.7 on Ubuntu 14.04.4 LTS
based system. The default values of these options are equal to the
commented-out values so nothing should be broken by this change.

Without this I get

```
Warning: Tag `CLANG_ASSISTED_PARSING' at line 1034 of file `Doxyfile' belongs to an option that was not enabled at compile time.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u", or recompile doxygen with this feature enabled.
Warning: Tag `CLANG_OPTIONS' at line 1042 of file `Doxyfile' belongs to an option that was not enabled at compile time.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u", or recompile doxygen with this feature enabled.
Warning: ignoring unsupported tag `DOCBOOK_PROGRAMLISTING =' at line 1912, file Doxyfile
Warning: ignoring unsupported tag `PLANTUML_JAR_PATH      =' at line 2339, file Doxyfile
```