### PR TITLE
Deprecate filetype_id

### DIFF
--- a/scripts/gen-api-gtkdoc.py
+++ b/scripts/gen-api-gtkdoc.py
@@ -370,7 +370,7 @@ def main(args):
     for f in h_files:
         if not (f.find("compoundname").text.endswith("private.h")):
             for n0 in f.xpath(".//*/memberdef[@kind='typedef' and @prot='public']"):
-                if not (n0.find("type").text.startswith("enum")):
+                if not (DoxygenProcess.stringify_children(n0.find("type")).startswith("enum")):
                     e = DoxyTypedef.from_memberdef(n0)
                     typedefs.append(e)
 

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -24,7 +24,7 @@
  * Filetype detection, file extensions and filetype menu items.
  */
 
-/* Note: we use filetype_id for some function arguments, but GeanyFiletype is better; we should
+/* Note: we use GeanyFiletypeID for some function arguments, but GeanyFiletype is better; we should
  * only use GeanyFiletype for API functions. */
 
 #ifdef HAVE_CONFIG_H
@@ -110,7 +110,7 @@ static gchar *filetype_make_title(const char *name, enum TitleType type)
 
 /* name argument (ie filetype name) must not be translated as it is used for
  * filetype lookup. Use filetypes_get_display_name() instead.*/
-static void ft_init(filetype_id ft_id, TMParserType lang, const char *name,
+static void ft_init(GeanyFiletypeID ft_id, TMParserType lang, const char *name,
 	const char *title_name, enum TitleType title_type,
 	GeanyFiletypeGroupID group_id)
 {
@@ -325,7 +325,7 @@ static void init_custom_filetypes(const gchar *path)
  * Warning: GTK isn't necessarily initialized yet. */
 void filetypes_init_types(void)
 {
-	filetype_id ft_id;
+	GeanyFiletypeID ft_id;
 	gchar *f;
 
 	g_return_if_fail(filetypes_array == NULL);
@@ -616,7 +616,7 @@ static GeanyFiletype *find_shebang(const gchar *utf8_filename, const gchar *line
 	{
 		static const struct {
 			const gchar *name;
-			filetype_id filetype;
+			GeanyFiletypeID filetype;
 		} intepreter_map[] = {
 			{ "sh",		GEANY_FILETYPES_SH },
 			{ "bash",	GEANY_FILETYPES_SH },

--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -111,7 +111,10 @@ typedef enum
 }
 GeanyFiletypeID;
 
-#define filetype_id GeanyFiletypeID /* compat define - should be removed in the future */
+#ifndef GEANY_DISABLE_DEPRECATED
+/* compat define - should be removed in the future */
+typedef GeanyFiletypeID filetype_id GEANY_DEPRECATED_FOR(GeanyFiletypeID);
+#endif /* GEANY_DISABLE_DEPRECATED */
 
 /** @gironly
  * Filetype categories

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -139,7 +139,7 @@ static struct
 symbol_menu;
 
 static void html_tags_loaded(void);
-static void load_user_tags(filetype_id ft_id);
+static void load_user_tags(GeanyFiletypeID ft_id);
 
 /* get the tags_ignore list, exported by tagmanager's options.c */
 extern gchar **c_tags_ignore;
@@ -524,7 +524,7 @@ tag_list_add_groups(GtkTreeStore *tree_store, ...)
 
 static void add_top_level_items(GeanyDocument *doc)
 {
-	filetype_id ft_id = doc->file_type->id;
+	GeanyFiletypeID ft_id = doc->file_type->id;
 	GtkTreeStore *tag_store = doc->priv->tag_store;
 
 	if (top_level_iter_names == NULL)
@@ -998,7 +998,7 @@ static gchar *get_symbol_tooltip(GeanyDocument *doc, const TMTag *tag)
 
 
 /* find the last word in "foo::bar::blah", e.g. "blah" */
-static const gchar *get_parent_name(const TMTag *tag, filetype_id ft_id)
+static const gchar *get_parent_name(const TMTag *tag, GeanyFiletypeID ft_id)
 {
 	const gchar *scope = tag->scope;
 	const gchar *separator = symbols_get_context_separator(ft_id);
@@ -1798,7 +1798,7 @@ static void init_user_tags(void)
 }
 
 
-static void load_user_tags(filetype_id ft_id)
+static void load_user_tags(GeanyFiletypeID ft_id)
 {
 	static guchar *tags_loaded = NULL;
 	static gboolean init_tags = FALSE;


### PR DESCRIPTION
Same as #931 but using a typedef.  Also, there's no conflict.

@kugel- I fixed the GtkDoc header generation script not to break if a typedef type contains a reference.  However, will the alias `filetype_id` confuse GIR or not?