### PR TITLE
Rename socket_info_struct to SocketInfo

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -103,7 +103,7 @@
 #endif
 #define BUFFER_LENGTH 4096
 
-struct socket_info_struct socket_info;
+struct SocketInfo socket_info;
 
 
 #ifdef G_OS_WIN32

--- a/src/socket.h
+++ b/src/socket.h
@@ -27,7 +27,7 @@
 
 G_BEGIN_DECLS
 
-struct socket_info_struct
+struct SocketInfo
 {
 	gboolean	 ignore_socket;
 	gchar		*file_name;
@@ -36,7 +36,7 @@ struct socket_info_struct
 	guint 		 lock_socket_tag;
 };
 
-extern struct socket_info_struct socket_info;
+extern struct SocketInfo socket_info;
 
 gint socket_init(gint argc, gchar **argv);
 


### PR DESCRIPTION
After the filetype_id change I went through the Geany headers to check if other types use some strange naming convention and noticed this one (and no guarantees I didn't miss many others). Not that the rename really matters because it's not part of the API and isn't almost used but well, here it is...