### PR TITLE
Gi sci methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   # try not to install doxygen-latex because we don't need it and it's huge
   - sudo apt-get install -y --no-install-recommends doxygen
   - sudo apt-get install -y python-lxml
+  - sudo apt-get install -y python-pycparser
 before_script:
   - export CFLAGS="-g -O2 -Werror=pointer-arith -Werror=aggregate-return -Werror=implicit-function-declaration"
 script:

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -129,16 +129,17 @@ Doxyfile-gi.stamp: Doxyfile-gi Doxyfile.stamp $(doxygen_sources)
 	$(AM_V_GEN)$(DOXYGEN) Doxyfile-gi && echo "" > $@
 
 geany-gtkdoc.h: Doxyfile-gi.stamp $(top_srcdir)/scripts/gen-api-gtkdoc.py
-	$(AM_V_GEN)$(top_srcdir)/scripts/gen-api-gtkdoc.py xml -d $(builddir) -o $@
+	$(AM_V_GEN)$(top_srcdir)/scripts/gen-api-gtkdoc.py xml -d $(builddir) -o $@ \
+			--sci-output geany-scintilla-gtkdoc.h
 
 geany_gtkdocincludedir = $(includedir)/geany/gtkdoc
-nodist_geany_gtkdocinclude_HEADERS = geany-gtkdoc.h
+nodist_geany_gtkdocinclude_HEADERS = geany-gtkdoc.h geany-scintilla-gtkdoc.h
 
-ALL_LOCAL_TARGETS += geany-gtkdoc.h
+ALL_LOCAL_TARGETS += geany-gtkdoc.h geany-scintilla-gtkdoc.h
 CLEAN_LOCAL_TARGETS += clean-gtkdoc-header-local
 
 clean-gtkdoc-header-local:
-	-rm -rf xml/ Doxyfile-gi Doxyfile-gi.stamp geany-gtkdoc.h
+	-rm -rf xml/ Doxyfile-gi Doxyfile-gi.stamp geany-gtkdoc.h geany-scintilla-gtkdoc.h
 
 endif
 

--- a/m4/geany-gtkdoc-header.m4
+++ b/m4/geany-gtkdoc-header.m4
@@ -22,19 +22,24 @@ AC_DEFUN([GEANY_CHECK_GTKDOC_HEADER],
 	[
 		dnl python
 		AM_PATH_PYTHON([2.7], [have_python=yes], [have_python=no])
-		dnl lxml module
+		dnl additional modules
 		AS_IF([test "x$have_python" = xyes],
-		      [have_python_and_lxml=yes
+		      [have_python_and_modules=yes
 		       AC_MSG_CHECKING([for python lxml package])
 		       AS_IF([$PYTHON -c 'import lxml' >/dev/null 2>&1],
-		             [have_python_and_lxml=yes],
-		             [have_python_and_lxml=no])
-		       AC_MSG_RESULT([$have_python_and_lxml])],
-		      [have_python_and_lxml=no])
+		             [have_python_and_modules=yes],
+		             [have_python_and_modules=no])
+		       AC_MSG_RESULT([$have_python_and_modules])
+		       AC_MSG_CHECKING([for python pycparser package])
+		       AS_IF([$PYTHON -c 'import pycparser' >/dev/null 2>&1],
+		             [have_python_and_modules=yes],
+		             [have_python_and_modules=no])
+		       AC_MSG_RESULT([$have_python_and_modules])
+		       ],[have_python_and_modules=no])
 		dnl final result
-		AS_IF([test "x$geany_enable_gtkdoc_header$have_python_and_lxml" = "xyesno"],
+		AS_IF([test "x$geany_enable_gtkdoc_header$have_python_and_modules" = "xyesno"],
 		      [_GEANY_CHECK_GTKDOC_HEADER_ERROR([python or its lxml module not found])],
-		      [geany_enable_gtkdoc_header=$have_python_and_lxml])
+		      [geany_enable_gtkdoc_header=$have_python_and_modules])
 	])
 
 	AM_CONDITIONAL([ENABLE_GTKDOC_HEADER], [test "x$geany_enable_gtkdoc_header" = "xyes"])

--- a/scripts/gen-sci-methods.py
+++ b/scripts/gen-sci-methods.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+#
+#  Copyright 2015-2016 Thomas Martitz <kugel@rockbox.org>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+
+import sys
+import os
+from collections import OrderedDict
+from pycparser import c_parser, c_ast, parse_file
+from optparse import OptionParser
+
+
+# this function was taken from the cdecl.py example from the upstream pycparser project
+# and modified to suit this script
+def _explain_type(decl):
+    """ Recursively explains a type decl node
+    """
+    typ = type(decl)
+
+    if typ == c_ast.TypeDecl:
+        quals = ' '.join(decl.quals) + ' ' if decl.quals else ''
+        return quals + _explain_type(decl.type)
+    elif typ == c_ast.Typename or typ == c_ast.Decl:
+        return _explain_type(decl.type)
+    elif typ == c_ast.IdentifierType:
+        return ' '.join(decl.names)
+    elif typ == c_ast.Struct:
+        return 'struct ' + decl.name
+    elif typ == c_ast.PtrDecl:
+        quals = ' '.join(decl.quals) + ' ' if decl.quals else ''
+        return quals + _explain_type(decl.type) + ' *'
+    elif typ == c_ast.ArrayDecl:
+        arr = '[]'
+        if decl.dim:
+            arr = '[%s]' % decl.dim.value
+        return _explain_type(decl.type) + arr
+
+    elif typ == c_ast.FuncDecl:
+        if decl.args:
+            params = [_explain_type(param) for param in decl.args.params]
+            args = ', '.join(params)
+        else:
+            args = ''
+
+        return ("%s %s(%s)" % (_explain_type(decl.type), decl.name, args))
+
+
+class Function(object):
+    def __init__(self, decl):
+        self.decl = decl
+
+    def name(self):
+        return self.decl.name
+
+    def new_name(self):
+        return self.decl.name.replace("sci_", "scintilla_object_", 1)
+
+    def type(self):
+        return _explain_type(self.decl.type.type)
+
+    def params(self):
+        d = OrderedDict()
+        for param in self.decl.type.args.params:
+            d[param.name] = _explain_type(param)
+        return d
+
+    def declaration(self):
+        params = []
+        for k, v in self.params().items():
+            params += [v + " " + k]
+        if (len(params) == 0):
+            return "%s %s(void)" %  (self.type(), self.new_name())
+        return "%s %s(%s)" % ( self.type(), self.new_name(), ', '.join(params) )
+
+    def wrapper(self):
+        call = ""
+        if (self.type() != "void"):
+            call += "return "
+        call += self.name()
+        call += "(%s)" % ', '.join(self.params().keys())
+        return "{\n\t%s;\n}" % call
+
+# A simple visitor for FuncDef nodes that prints the names and
+# locations of function definitions.
+class FuncDefVisitor(c_ast.NodeVisitor):
+    def __init__(self):
+        self.funcs = []
+
+    def visit_FuncDef(self, node):
+        if ("extern" in node.decl.storage):
+            func = Function(node.decl)
+            self.funcs += [func]
+
+    def print_funcs(self, output=sys.stdout):
+        for f in self.funcs:
+            output.write("\nGEANY_API_SYMBOL\n" + f.declaration() + "\n" + f.wrapper() + "\n\n")
+
+def main(args):
+    outfile = None
+    
+    parser = OptionParser(usage="usage: %prog [options] INPUT")
+    parser.add_option("-o", "--output", metavar="FILE", help="Write output to FILE",
+                      action="store", dest="outfile")
+    opts, args = parser.parse_args(args[1:])
+
+    source_file = args[0]
+    if not (os.path.exists(source_file)):
+        sys.stderr.write("invalid input file (pass path to sciwrappers.c)\n")
+        return 1
+
+    ast = parse_file(source_file, use_cpp=True, cpp_args=r'-DPYCPARSER')
+    v = FuncDefVisitor()
+    v.visit(ast)
+
+    if (opts.outfile):
+        try:
+            outfile = open(opts.outfile, "w+")
+        except OSError as err:
+            sys.stderr.write("failed to open \"%s\" for writing (%s)\n" % (opts.outfile, err.strerror))
+            return 1
+    else:
+        outfile = sys.stdout
+    
+    outfile.write("/*\n * Automatically generated file - do not edit\n */\n\n")
+    outfile.write("#include \"sciwrappers.h\"\n")
+    v.print_funcs(outfile)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -107,6 +107,14 @@ libgeany_la_SOURCES = \
 	ui_utils.c ui_utils.h \
 	utils.c utils.h
 
+# tell automake we have a C++ file so it uses the C++ linker we need for Scintilla
+nodist_EXTRA_libgeany_la_SOURCES = dummy1.cxx
+
+if ENABLE_GTKDOC_HEADER
+# generated, see below
+nodist_EXTRA_libgeany_la_SOURCES += scimethods.c
+endif
+
 if ENABLE_BINRELOC
 libgeany_la_SOURCES += prefix.c prefix.h
 endif
@@ -127,9 +135,6 @@ libgeany_la_LIBADD = \
 	@GTHREAD_LIBS@ \
 	$(MAC_INTEGRATION_LIBS) \
 	$(INTLLIBS)
-
-# tell automake we have a C++ file so it uses the C++ linker we need for Scintilla
-nodist_EXTRA_libgeany_la_SOURCES = dummy1.cxx
 
 CLEANFILES =
 
@@ -181,6 +186,16 @@ signallist.i: $(glade_file) Makefile
 		$(SED) -n 's/^.*handler="\([^"]\{1,\}\)".*$$/ITEM(\1)/p' "$(glade_file)" \
 			| $(SORT) | $(UNIQ) \
 	) > $@ || { $(RM) $@ && exit 1; }
+
+BUILT_SOURCES =
+
+if ENABLE_GTKDOC_HEADER
+scimethods.c: sciwrappers.c $(top_srcdir)/scripts/gen-sci-methods.py
+	$(AM_V_GEN)$(top_srcdir)/scripts/gen-sci-methods.py -o $@ $<
+
+BUILT_SOURCES += scimethods.c
+
+endif
 
 CLEANFILES += signallist.i
 

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -35,12 +35,34 @@
 # include "config.h"
 #endif
 
+#ifndef PYCPARSER
 #include "sciwrappers.h"
 
 #include "utils.h"
 
 #include <string.h>
+#else
 
+typedef struct ScintillaObject ScintillaObject;
+typedef unsigned long uptr_t;
+typedef long sptr_t;
+
+typedef char   gchar;
+typedef short  gshort;
+typedef long   glong;
+typedef int    gint;
+typedef gint   gboolean;
+
+typedef unsigned char   guchar;
+typedef unsigned short  gushort;
+typedef unsigned long   gulong;
+typedef unsigned int    guint;
+
+typedef float   gfloat;
+typedef double  gdouble;
+
+#define GEANY_API_SYMBOL extern
+#endif
 
 #define SSM(s, m, w, l) scintilla_send_message(s, m, w, l)
 


### PR DESCRIPTION
This PR implements generation of scintilla_object_* wrappers for each exported sci_* function. The intention is that scintilla_object_* can be used as true object methods for GeanyScintilla.

e.g. python: text = sci.get_text() instead of text = Geany.sci_get_text(sci)