### PR TITLE
Add error reporting for opening URIs on Windows

### DIFF
--- a/src/win32.c
+++ b/src/win32.c
@@ -785,6 +785,7 @@ gint win32_check_write_permission(const gchar *dir)
 /* Just a simple wrapper function to open a browser window */
 void win32_open_browser(const gchar *uri)
 {
+	gint ret;
 	if (strncmp(uri, "file://", 7) == 0)
 	{
 		uri += 7;
@@ -794,7 +795,14 @@ void win32_open_browser(const gchar *uri)
 				uri++;
 		}
 	}
-	ShellExecute(NULL, "open", uri, NULL, NULL, SW_SHOWNORMAL);
+	ret = (gint) ShellExecute(NULL, "open", uri, NULL, NULL, SW_SHOWNORMAL);
+	if (ret <= 32)
+	{
+		gchar *err = g_win32_error_message(GetLastError());
+		/* TODO add a GUI warning that opening an URI failed */
+		g_warning("ShellExecute failed opening \"%s\" (code %d): %s", uri, ret, err);
+		g_free(err);
+	}
 }
 
 


### PR DESCRIPTION
Before it silently failed if there was any error. Now at least a
console warning is logged.

The TODO is meant for post-1.27 to add a GUI message box or a log entry in the Status messages window to tell the user about the error. But since we are in string freeze, add at least a console warning.

I noticed the `plugin_help` functionality of some plugins is broken on Windows because the affected plugins use DOCDIR to construct the URL to the local help file. But on Windows we need some more advanced logic, probably based on `app->docdir` or so.

This log message helps identifying those problems.