### PR TITLE
Fix non-exiting property parser

### DIFF
--- a/tagmanager/ctags/objc.c
+++ b/tagmanager/ctags/objc.c
@@ -702,6 +702,7 @@ static void parseProperty (vString * const ident, objcToken what)
 	case Tok_semi:
 		addTag (tempName, K_PROPERTY);
 		vStringClear (tempName);
+		toDoNext = &parseMethods;
 		break;
 
 	default:

--- a/tests/ctags/objectivec_property.mm.tags
+++ b/tests/ctags/objectivec_property.mm.tags
@@ -1,5 +1,5 @@
 # format=tagmanager
-PersonÃŒ32Ã–0
-initWithAge:ÃŒ128ÃPersonÃ–0
-m_ageÃŒ8ÃPersonÃ–0
-m_nameÃŒ8ÃPersonÃ–0
+PersonÌ32Ö0
+initWithAge:Ì128ÎPersonÖ0
+m_ageÌ8ÎPersonÖ0
+m_nameÌ8ÎPersonÖ0

--- a/tests/ctags/objectivec_property.mm.tags
+++ b/tests/ctags/objectivec_property.mm.tags
@@ -1,4 +1,5 @@
 # format=tagmanager
-PersonÌ32Ö0
-m_ageÌ8ÎPersonÖ0
-m_nameÌ8ÎPersonÖ0
+PersonÃŒ32Ã–0
+initWithAge:ÃŒ128ÃPersonÃ–0
+m_ageÃŒ8ÃPersonÃ–0
+m_nameÃŒ8ÃPersonÃ–0


### PR DESCRIPTION
This fixes the issue where the property parser would never exist, causing @property directives to confuse Objective-C parsing.