### PR TITLE
Avoid NULL dereference when typing a dot in a file without tags

### DIFF
--- a/tagmanager/src/tm_workspace.c
+++ b/tagmanager/src/tm_workspace.c
@@ -1053,7 +1053,7 @@ GPtrArray *
 tm_workspace_find_scope_members (TMSourceFile *source_file, const char *name,
 	gboolean function, gboolean member, const gchar *current_scope, gboolean search_namespace)
 {
-	TMParserType lang = source_file->lang;
+	TMParserType lang = source_file ? source_file->lang : TM_PARSER_NONE;
 	GPtrArray *tags, *member_tags = NULL;
 	TMTagType function_types = tm_tag_function_t | tm_tag_method_t |
 		tm_tag_macro_with_arg_t | tm_tag_prototype_t;


### PR DESCRIPTION
@techee `NULL` check was removed in 292383c197b72c56f44b68b14845093adfed7133, was that really expected?
Other solution would be early return in `autocomplete_scope()` when `doc->tm_file` is `NULL`, but that would mean that there wouldn't be scope completion in unsaved files.

We need a fix ASAP, as it happens whenever typing `.` in an unsaved file, or a file with no tags parser.  E.g. you can reproduce by opening a new geany `geany -vi` and typing `a.`, *boom*.