### PR TITLE
Enable buffered draw on newer Gtk versions on OS X

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -4977,8 +4977,11 @@ static ScintillaObject *create_new_sci(GeanyEditor *editor)
 	SSM(sci, SCI_SETVIRTUALSPACEOPTIONS, editor_prefs.show_virtual_space, 0);
 	
 #ifdef GDK_WINDOWING_QUARTZ
-	/* "retina" (HiDPI) display support on OS X - requires disabling buffered draw */
+# if ! GTK_CHECK_VERSION(3,16,0)
+	/* "retina" (HiDPI) display support on OS X - requires disabling buffered draw
+	 * on older GTK versions */
 	SSM(sci, SCI_SETBUFFEREDDRAW, 0, 0);
+# endif
 #endif
 
 	/* only connect signals if this is for the document notebook, not split window */


### PR DESCRIPTION
Buffered draw seems to be faster and with newer Gtk versions
works correctly on HiDPI screens.

I haven't checked precisely since which Gtk version this works
(didn't work in 3.10, might have been fixed in a later version)
but it isn't as important because even with 3.16 the build
is highly unstable because of Gtk issues (Gtk 3.18 seems to
be promising though).

I don't plan using Gtk 3 for the OS X 1.27 release so this patch can be applied later.