### PR TITLE
Gi sci methods v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ Makefile.in
 /doc/*.toc
 /doc/reference
 /doc/geany-gtkdoc.h
+/doc/geany-sciwrappers-gtkdoc.h
 /doc/xml/
 
 #-----------------------------------------------------------------------

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -850,7 +850,8 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @top_srcdir@/doc/geany-gtkdoc.h
+EXCLUDE                = @top_srcdir@/doc/geany-gtkdoc.h \
+                         @top_srcdir@/doc/geany-sciwrappers-gtkdoc.h
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -129,16 +129,19 @@ Doxyfile-gi.stamp: Doxyfile-gi Doxyfile.stamp $(doxygen_sources)
 	$(AM_V_GEN)$(DOXYGEN) Doxyfile-gi && echo "" > $@
 
 geany-gtkdoc.h: Doxyfile-gi.stamp $(top_srcdir)/scripts/gen-api-gtkdoc.py
-	$(AM_V_GEN)$(top_srcdir)/scripts/gen-api-gtkdoc.py xml -d $(builddir) -o $@
+	$(AM_V_GEN)$(top_srcdir)/scripts/gen-api-gtkdoc.py xml -d $(builddir) -o $@ \
+			--sci-output geany-sciwrappers-gtkdoc.h
+
+geany-sciwrappers-gtkdoc.h: geany-gtkdoc.h
 
 geany_gtkdocincludedir = $(includedir)/geany/gtkdoc
-nodist_geany_gtkdocinclude_HEADERS = geany-gtkdoc.h
+nodist_geany_gtkdocinclude_HEADERS = geany-gtkdoc.h geany-sciwrappers-gtkdoc.h
 
-ALL_LOCAL_TARGETS += geany-gtkdoc.h
+ALL_LOCAL_TARGETS += geany-gtkdoc.h geany-sciwrappers-gtkdoc.h
 CLEAN_LOCAL_TARGETS += clean-gtkdoc-header-local
 
 clean-gtkdoc-header-local:
-	-rm -rf xml/ Doxyfile-gi Doxyfile-gi.stamp geany-gtkdoc.h
+	-rm -rf xml/ Doxyfile-gi Doxyfile-gi.stamp geany-gtkdoc.h geany-sciwrappers-gtkdoc.h
 
 endif
 


### PR DESCRIPTION
This generates a separate geany-scintilla-gtkdoc.h. It contains basically just the sci_* functions of geany-gtkdoc.h (which are still there also) to make it easier to implement a separate namespace for scintilla.

Also fixes to gen-api-gtkdoc