### PR TITLE
tagmanager: make doxygen comments and typedefs gtkdoc generation frie…

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -793,7 +793,8 @@ INPUT                  = @top_srcdir@/src/ \
                          @top_srcdir@/tagmanager/src/tm_source_file.c \
                          @top_srcdir@/tagmanager/src/tm_source_file.h \
                          @top_srcdir@/tagmanager/src/tm_workspace.c \
-                         @top_srcdir@/tagmanager/src/tm_workspace.h
+                         @top_srcdir@/tagmanager/src/tm_workspace.h \
+                         @top_srcdir@/tagmanager/src/tm_parser.h
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/scripts/gen-api-gtkdoc.py
+++ b/scripts/gen-api-gtkdoc.py
@@ -402,8 +402,6 @@ def main(args):
         outfile.write("#include \"gtkcompat.h\"\n")
         outfile.write("#include \"Scintilla.h\"\n")
         outfile.write("#include \"ScintillaWidget.h\"\n")
-        outfile.write("typedef struct TMSourceFile TMSourceFile;\n")
-        outfile.write("typedef struct TMWorkspace TMWorkspace;\n")
 
         # write enums first, so typedefs to them are valid (as forward enum declaration
         # is invalid).  It's fine as an enum can't contain reference to other types.

--- a/scripts/gen-api-gtkdoc.py
+++ b/scripts/gen-api-gtkdoc.py
@@ -399,9 +399,9 @@ def main(args):
 
     try:
         outfile.write("/*\n * Automatically generated file - do not edit\n */\n\n")
-        outfile.write("#include <glib.h>\n")
-        outfile.write("#include <gtk/gtk.h>\n\n")
-        outfile.write("typedef struct _ScintillaObject ScintillaObject;\n")
+        outfile.write("#include \"gtkcompat.h\"\n")
+        outfile.write("#include \"Scintilla.h\"\n")
+        outfile.write("#include \"ScintillaWidget.h\"\n")
         outfile.write("typedef struct TMSourceFile TMSourceFile;\n")
         outfile.write("typedef struct TMWorkspace TMWorkspace;\n")
 

--- a/tagmanager/src/tm_parser.h
+++ b/tagmanager/src/tm_parser.h
@@ -10,6 +10,9 @@
 #ifndef TM_PARSER_H
 #define TM_PARSER_H
 
+/** @gironly
+ * A integral type which can hold known parser type IDs
+ **/
 typedef gint TMParserType;
 
 

--- a/tagmanager/src/tm_source_file.h
+++ b/tagmanager/src/tm_source_file.h
@@ -33,9 +33,9 @@ extern "C"
 
 
 /**
- The TMSourceFile structure represents the source file and its tags in the tag manager.
-*/
-typedef struct
+ * The TMSourceFile structure represents the source file and its tags in the tag manager.
+ **/
+typedef struct TMSourceFile
 {
 	TMParserType lang; /* Programming language used */
 	char *file_name; /**< Full file name (inc. path) */

--- a/tagmanager/src/tm_workspace.h
+++ b/tagmanager/src/tm_workspace.h
@@ -22,11 +22,11 @@ extern "C"
 
 
 /** The Tag Manager Workspace. This is a singleton object containing a list
- of individual source files. There is also a global tag list 
- which can be loaded or created. This contains global tags gleaned from 
- /usr/include, etc. and should be used for autocompletion, calltips, etc.
-*/
-typedef struct
+ * of individual source files. There is also a global tag list
+ * which can be loaded or created. This contains global tags gleaned from
+ * /usr/include, etc. and should be used for autocompletion, calltips, etc.
+ **/
+typedef struct TMWorkspace
 {
 	GPtrArray *global_tags; /**< Global tags loaded at startup */
 	GPtrArray *source_files; /**< An array of TMSourceFile pointers */


### PR DESCRIPTION
…ndly

Because of the missing "typedef struct TMFoo" it was missing from the gtkdoc
header (the struct listings are always without typedef). This is also
consistent with the rest of geany.

@gironly for TMParserType so it's picked up as well.

@b4n