### PR TITLE
Improve Goto Symbol popup contents

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -2133,10 +2133,9 @@ static gboolean goto_tag(const gchar *name, gboolean definition)
 		definition = current_tag->type & forward_types;
 
 	filtered_tags = filter_tags(tags, current_tag, definition);
-	if (current_tag && filtered_tags->len == 0)
+	if (filtered_tags->len == 0)
 	{
-		/* if we previously swapped definition/declaration search and didn't
-		 * find anything, try again with the opposite type */
+		/* if we didn't find anything, try again with the opposite type */
 		g_ptr_array_free(filtered_tags, TRUE);
 		filtered_tags = filter_tags(tags, current_tag, !definition);
 	}

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -2080,8 +2080,8 @@ static GPtrArray *filter_tags(GPtrArray *tags, TMTag *current_tag, gboolean defi
 
 	foreach_ptr_array(tmtag, i, tags)
 	{
-		if (definition && !(tmtag->type & forward_types) ||
-			!definition && (tmtag->type & forward_types))
+		if ((definition && !(tmtag->type & forward_types)) ||
+			(!definition && (tmtag->type & forward_types)))
 		{
 			/* If there are typedefs of e.g. a struct such as
 			 * "typedef struct Foo {} Foo;", filter out the typedef unless


### PR DESCRIPTION
* always filter-out symbol from the current line from the list
* when clicked on a symbol on the current line always swap
  definition/declaration search even if there are more symbols from the
  current search direction

Fixes #950