### PR TITLE
gtkdoc: fix gtkdoc header script for structs with inline types

### DIFF
--- a/scripts/gen-api-gtkdoc.py
+++ b/scripts/gen-api-gtkdoc.py
@@ -292,9 +292,9 @@ class DoxyStruct(DoxyElement):
     @staticmethod
     def from_compounddef(xml, typedefs=[]):
         name = xml.find("compoundname").text
-        section = xml.find("sectiondef")
         d = "struct %s {\n" % name
-        for p in section.findall("memberdef"):
+        memberdefs = xml.xpath(".//sectiondef[@kind='public-attrib']/memberdef")
+        for p in memberdefs:
             # workaround for struct members. g-ir-scanner can't properly map struct members
             # (beginning with struct GeanyFoo) to the typedef and assigns a generic type for them
             # thus we fix that up here and enforce usage of the typedef. These are written
@@ -314,7 +314,7 @@ class DoxyStruct(DoxyElement):
         d += "};\n"
         e = DoxyStruct(name, d)
         e.add_brief(xml.find("briefdescription"))
-        for p in section.findall("memberdef"):
+        for p in memberdefs:
             e.add_member(p)
         return e
 


### PR DESCRIPTION
Doxygen adds unhandled xml output for structs that define types inline, for
example `struct Foo { enum { FOO, BAR } baz; }`. A type definitions precedes the
members. The script wrongly assumed the first sectiondef child of compounddef
would contain all members, but actually this is the case for sectiondefs with
kind=public-attrib (the sectiondef defining the type has kind=public-type).