### PR TITLE
add View -> Show Statusbar check menu item, plus key binding to show/hide statusbar

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -7444,6 +7444,16 @@
                           </object>
                         </child>
                         <child>
+                          <object class="GtkCheckMenuItem" id="menu_show_statusbar1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Show Statusbar</property>
+                            <property name="use_underline">True</property>
+                            <property name="active">True</property>
+                            <signal name="toggled" handler="on_menu_show_statusbar1_toggled" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
                           <object class="GtkSeparatorMenuItem" id="menu_separator5">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3635,6 +3635,8 @@ Toggle Messages Window                                    Toggles the message wi
 
 Toggle Sidebar                                            Shows or hides the sidebar.
 
+Toggle Statusbar                                          Shows or hides the statusbar.
+
 Toggle all additional widgets                             Hide and show all additional widgets like the
                                                           notebook tabs, the toolbar, the messages window
                                                           and the status bar.

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1228,6 +1228,13 @@ void on_menu_show_sidebar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer use
 	ui_sidebar_show_hide();
 }
 
+void on_menu_show_statusbar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data)
+{
+	if (ignore_callback)
+		return;
+
+	ui_statusbar_toggle(FALSE);
+}
 
 static void on_menu_write_unicode_bom1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data)
 {
@@ -1521,7 +1528,7 @@ void on_menu_toggle_all_additional_widgets1_activate(GtkMenuItem *menuitem, gpoi
 		interface_prefs.show_notebook_tabs = FALSE;
 		gtk_notebook_set_show_tabs(GTK_NOTEBOOK(main_widgets.notebook), interface_prefs.show_notebook_tabs);
 
-		ui_statusbar_showhide(FALSE);
+		ui_statusbar_showhide(FALSE, TRUE);
 
 		if (gtk_check_menu_item_get_active(toolbari))
 			gtk_check_menu_item_set_active(toolbari, ! gtk_check_menu_item_get_active(toolbari));
@@ -1535,7 +1542,7 @@ void on_menu_toggle_all_additional_widgets1_activate(GtkMenuItem *menuitem, gpoi
 		interface_prefs.show_notebook_tabs = TRUE;
 		gtk_notebook_set_show_tabs(GTK_NOTEBOOK(main_widgets.notebook), interface_prefs.show_notebook_tabs);
 
-		ui_statusbar_showhide(TRUE);
+		ui_statusbar_showhide(TRUE, TRUE);
 
 		if (! gtk_check_menu_item_get_active(toolbari))
 			gtk_check_menu_item_set_active(toolbari, ! gtk_check_menu_item_get_active(toolbari));

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1526,7 +1526,6 @@ void on_menu_toggle_all_additional_widgets1_activate(GtkMenuItem *menuitem, gpoi
 			gtk_check_menu_item_set_active(msgw, ! gtk_check_menu_item_get_active(msgw));
 
 		interface_prefs.show_notebook_tabs = FALSE;
-		gtk_notebook_set_show_tabs(GTK_NOTEBOOK(main_widgets.notebook), interface_prefs.show_notebook_tabs);
 
 		interface_prefs.statusbar_visible = FALSE;
 
@@ -1540,7 +1539,6 @@ void on_menu_toggle_all_additional_widgets1_activate(GtkMenuItem *menuitem, gpoi
 			gtk_check_menu_item_set_active(msgw, ! gtk_check_menu_item_get_active(msgw));
 
 		interface_prefs.show_notebook_tabs = TRUE;
-		gtk_notebook_set_show_tabs(GTK_NOTEBOOK(main_widgets.notebook), interface_prefs.show_notebook_tabs);
 
 		interface_prefs.statusbar_visible = TRUE;
 
@@ -1548,6 +1546,7 @@ void on_menu_toggle_all_additional_widgets1_activate(GtkMenuItem *menuitem, gpoi
 			gtk_check_menu_item_set_active(toolbari, ! gtk_check_menu_item_get_active(toolbari));
 	}
 
+	gtk_notebook_set_show_tabs(GTK_NOTEBOOK(main_widgets.notebook), interface_prefs.show_notebook_tabs);
 	ui_statusbar_showhide(interface_prefs.statusbar_visible, TRUE);
 }
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1528,7 +1528,7 @@ void on_menu_toggle_all_additional_widgets1_activate(GtkMenuItem *menuitem, gpoi
 		interface_prefs.show_notebook_tabs = FALSE;
 		gtk_notebook_set_show_tabs(GTK_NOTEBOOK(main_widgets.notebook), interface_prefs.show_notebook_tabs);
 
-		ui_statusbar_showhide(FALSE, TRUE);
+		interface_prefs.statusbar_visible = FALSE;
 
 		if (gtk_check_menu_item_get_active(toolbari))
 			gtk_check_menu_item_set_active(toolbari, ! gtk_check_menu_item_get_active(toolbari));
@@ -1542,11 +1542,13 @@ void on_menu_toggle_all_additional_widgets1_activate(GtkMenuItem *menuitem, gpoi
 		interface_prefs.show_notebook_tabs = TRUE;
 		gtk_notebook_set_show_tabs(GTK_NOTEBOOK(main_widgets.notebook), interface_prefs.show_notebook_tabs);
 
-		ui_statusbar_showhide(TRUE, TRUE);
+		interface_prefs.statusbar_visible = TRUE;
 
 		if (! gtk_check_menu_item_get_active(toolbari))
 			gtk_check_menu_item_set_active(toolbari, ! gtk_check_menu_item_get_active(toolbari));
 	}
+
+	ui_statusbar_showhide(interface_prefs.statusbar_visible, TRUE);
 }
 
 

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -123,6 +123,8 @@ void on_menu_select_all1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_menu_show_sidebar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data);
 
+void on_menu_show_statusbar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data);
+
 void on_menu_comment_line1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_menu_uncomment_line1_activate(GtkMenuItem *menuitem, gpointer user_data);

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -601,6 +601,8 @@ static void init_default_kb(void)
 		"menu_show_messages_window1");
 	add_kb(group, GEANY_KEYS_VIEW_SIDEBAR, NULL,
 		0, 0, "toggle_sidebar", _("Toggle Sidebar"), "menu_show_sidebar1");
+	add_kb(group, GEANY_KEYS_VIEW_STATUSBAR, NULL,
+		0, 0, "toggle_statusbar", _("Toggle Statusbar"), "menu_show_statusbar1");
 	add_kb(group, GEANY_KEYS_VIEW_ZOOMIN, NULL,
 		GDK_plus, GEANY_PRIMARY_MOD_MASK, "menu_zoomin", _("Zoom In"), "menu_zoom_in1");
 	add_kb(group, GEANY_KEYS_VIEW_ZOOMOUT, NULL,
@@ -1587,6 +1589,9 @@ static gboolean cb_func_view_action(guint key_id)
 			break;
 		case GEANY_KEYS_VIEW_SIDEBAR:
 			on_menu_show_sidebar1_toggled(NULL, NULL);
+			break;
+		case GEANY_KEYS_VIEW_STATUSBAR:
+			ui_statusbar_toggle(TRUE);
 			break;
 		case GEANY_KEYS_VIEW_ZOOMIN:
 			on_zoom_in1_activate(NULL, NULL);

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -273,6 +273,7 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_FORMAT_SENDTOCMD7,				/**< Keybinding. */
 	GEANY_KEYS_FORMAT_SENDTOCMD8,				/**< Keybinding. */
 	GEANY_KEYS_FORMAT_SENDTOCMD9,				/**< Keybinding. */
+	GEANY_KEYS_VIEW_STATUSBAR,					/**< Keybinding. */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -186,6 +186,13 @@ static void apply_settings(void)
 		gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(ui_lookup_widget(main_widgets.window, "menu_show_sidebar1")), FALSE);
 		ignore_callback = FALSE;
 	}
+	if (! interface_prefs.statusbar_visible)
+	{
+		ignore_callback = TRUE;
+		gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(ui_lookup_widget(main_widgets.window, "menu_show_statusbar1")), FALSE);
+		ignore_callback = FALSE;
+	}
+
 
 	toolbar_apply_settings();
 	toolbar_update_ui();

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -932,6 +932,9 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_sidebar_visible");
 		ui_prefs.sidebar_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_statusbar_visible");
+		interface_prefs.statusbar_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_list_symbol");
 		interface_prefs.sidebar_symbol_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
@@ -1272,7 +1275,7 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 #endif
 
 		/* apply the changes made */
-		ui_statusbar_showhide(interface_prefs.statusbar_visible);
+		ui_statusbar_showhide(interface_prefs.statusbar_visible, TRUE);
 		sidebar_openfiles_update_all(); /* to update if full path setting has changed */
 		toolbar_apply_settings();
 		toolbar_update_ui();

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -885,6 +885,7 @@ static void init_document_widgets(void)
 	add_doc_widget("menu_show_white_space1");
 	add_doc_widget("menu_show_line_endings1");
 	add_doc_widget("menu_show_indentation_guides1");
+	add_doc_widget("menu_show_statusbar1");
 	add_doc_widget("menu_zoom_in1");
 	add_doc_widget("menu_zoom_out1");
 	add_doc_widget("normal_size1");
@@ -1454,6 +1455,7 @@ void ui_update_view_editor_menu_items(void)
 	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(ui_lookup_widget(main_widgets.window, "menu_show_white_space1")), editor_prefs.show_white_space);
 	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(ui_lookup_widget(main_widgets.window, "menu_show_line_endings1")), editor_prefs.show_line_endings);
 	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(ui_lookup_widget(main_widgets.window, "menu_show_indentation_guides1")), editor_prefs.show_indent_guide);
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(ui_lookup_widget(main_widgets.window, "menu_show_statusbar1")), interface_prefs.statusbar_visible);
 	ignore_callback = FALSE;
 }
 
@@ -2038,9 +2040,9 @@ static void ui_path_box_open_clicked(GtkButton *button, gpointer user_data)
 	}
 }
 
-
-void ui_statusbar_showhide(gboolean state)
+void ui_statusbar_showhide(gboolean state, gboolean update_menu)
 {
+	GtkWidget *widget;
 	/* handle statusbar visibility */
 	if (state)
 	{
@@ -2049,8 +2051,23 @@ void ui_statusbar_showhide(gboolean state)
 	}
 	else
 		gtk_widget_hide(ui_widgets.statusbar);
+
+    if (update_menu) {
+	    widget = ui_lookup_widget(main_widgets.window, "menu_show_statusbar1");
+	    if (state != gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(widget)))
+	    {
+		    ignore_callback = TRUE;
+		    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widget), state);
+		    ignore_callback = FALSE;
+	    }
+    }
 }
 
+void ui_statusbar_toggle(gboolean update_menu)
+{
+	interface_prefs.statusbar_visible = ! interface_prefs.statusbar_visible;
+	ui_statusbar_showhide(interface_prefs.statusbar_visible, update_menu);
+}
 
 /** Packs all @c GtkWidgets passed after the row argument into a table, using
  * one widget per cell. The first widget is not expanded as the table grows,

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2052,15 +2052,16 @@ void ui_statusbar_showhide(gboolean state, gboolean update_menu)
 	else
 		gtk_widget_hide(ui_widgets.statusbar);
 
-    if (update_menu) {
-	    widget = ui_lookup_widget(main_widgets.window, "menu_show_statusbar1");
-	    if (state != gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(widget)))
-	    {
-		    ignore_callback = TRUE;
-		    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widget), state);
-		    ignore_callback = FALSE;
-	    }
-    }
+	if (update_menu)
+	{
+		widget = ui_lookup_widget(main_widgets.window, "menu_show_statusbar1");
+		if (state != gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(widget)))
+		{
+			ignore_callback = TRUE;
+			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widget), state);
+			ignore_callback = FALSE;
+		}
+	}
 }
 
 void ui_statusbar_toggle(gboolean update_menu)

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -341,7 +341,9 @@ gboolean ui_tree_view_find_previous(GtkTreeView *treeview, TVMatchCallback cb);
 
 gboolean ui_tree_model_iter_any_next(GtkTreeModel *model, GtkTreeIter *iter, gboolean down);
 
-void ui_statusbar_showhide(gboolean state);
+void ui_statusbar_showhide(gboolean state, gboolean update_menu);
+
+void ui_statusbar_toggle(gboolean update_menu);
 
 void ui_toggle_editor_features(GeanyUIEditorFeatures feature);
 


### PR DESCRIPTION
Also adding `update_menu` arg to `ui_statusbar_showhide` function, to fix "Toggle All Additional Widgets" problem and cleaner code

We should do the same for Sidebar too (adding `gboolean update_menu` to `ui_sidebar_show_hide` function), because when you click "Toggle All Additional Widgets" , the menu item (View -> Show Sidebar) is not checked