### PR TITLE
ui-utils: Load per-version GTK+ CSS file

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -113,7 +113,10 @@ nobase_dist_pkgdata_DATA = \
 	geany.glade
 
 if GTK3
-nobase_dist_pkgdata_DATA += geany.css
+nobase_dist_pkgdata_DATA += \
+	geany-3.0.css \
+	geany-3.20.css \
+	geany.css
 else
 nobase_dist_pkgdata_DATA += geany.gtkrc
 endif

--- a/data/geany-3.0.css
+++ b/data/geany-3.0.css
@@ -1,0 +1,10 @@
+@import "geany.css";
+
+/* make close button on the editor's tabs smaller */
+#geany-close-tab-button {
+	-GtkWidget-focus-padding: 0;
+	-GtkWidget-focus-line-width: 0;
+	-GtkButton-default-border: 0;
+	-GtkButton-default-outside-border: 0;
+	-GtkButton-inner-border: 0;
+}

--- a/data/geany-3.20.css
+++ b/data/geany-3.20.css
@@ -1,0 +1,8 @@
+@import "geany.css";
+
+/* make close button on the editor's tabs smaller */
+#geany-close-tab-button {
+	outline-offset: 0;
+	outline-width: 0;
+	border: 0;
+}

--- a/data/geany.css
+++ b/data/geany.css
@@ -2,11 +2,6 @@
 
 /* make close button on the editor's tabs smaller */
 #geany-close-tab-button {
-	-GtkWidget-focus-padding: 0;
-	-GtkWidget-focus-line-width: 0;
-	-GtkButton-default-border: 0;
-	-GtkButton-default-outside-border: 0;
-	-GtkButton-inner-border: 0;
 	padding: 0;
 }
 #geany-close-tab-button GtkImage {

--- a/geany.nsi.in
+++ b/geany.nsi.in
@@ -138,6 +138,7 @@ Section "!Program Files" SEC01
 	File "${RESOURCEDIR}\data\filetype_extensions.conf"
 	File "${RESOURCEDIR}\data\geany.glade"
 !if ${GTK_VERSION} >= 3
+	File "${RESOURCEDIR}\data\geany-3.20.css"
 	File "${RESOURCEDIR}\data\geany.css"
 !else
 	File "${RESOURCEDIR}\data\geany.gtkrc"

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2477,10 +2477,28 @@ void ui_init_builder(void)
 static void init_custom_style(void)
 {
 #if GTK_CHECK_VERSION(3, 0, 0)
-	gchar *css_file = g_build_filename(app->datadir, "geany.css", NULL);
+	const struct {
+		guint version;
+		const gchar *file;
+	} css_files[] = {
+		/*
+		 * Keep these from newest to oldest,
+		 * and make sure 0 remains last
+		 */
+		{ 20, "geany-3.20.css" },
+		{ 0, "geany-3.0.css" },
+	};
+	guint gtk_version = gtk_get_minor_version();
+	gsize i = 0;
+	gchar *css_file;
 	GtkCssProvider *css = gtk_css_provider_new();
 	GError *error = NULL;
 
+	/* gtk_version will never be smaller than 0 */
+	while (css_files[i].version > gtk_version)
+		++i;
+
+	css_file = g_build_filename(app->datadir, css_files[i].file, NULL);
 	if (! gtk_css_provider_load_from_path(css, css_file, &error))
 	{
 		g_warning("Failed to load custom CSS: %s", error->message);


### PR DESCRIPTION
This way, we can avoid deprecation warnings, and fix the CSS when a new GTK+ version is released.