### PR TITLE
Latex ac

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -2294,15 +2294,38 @@ gboolean editor_start_auto_complete(GeanyEditor *editor, gint pos, gboolean forc
 	ret = autocomplete_check_html(editor, style, pos);
 
 	if (ft->id == GEANY_FILETYPES_LATEX)
-		wordchars = GEANY_WORDCHARS"\\"; /* add \ to word chars if we are in a LaTeX file */
+		wordchars = GEANY_WORDCHARS"@\\:"; /* add @\ for macros and : for labels */
 	else if (ft->id == GEANY_FILETYPES_CSS)
 		wordchars = GEANY_WORDCHARS"-"; /* add - because they are part of property names */
 	else
 		wordchars = GEANY_WORDCHARS;
 
 	read_current_word(editor, pos, cword, sizeof(cword), wordchars, TRUE);
-	root = cword;
-	rootlen = strlen(root);
+	/* in latex files, cut the word on the last \ found, if any exist
+	 * this is to treat cases like \def\macro or \\word */
+	if(ft->id == GEANY_FILETYPES_LATEX)
+	{
+		gint lastbl = 0;
+		gint i;
+		for(i=0 ; cword[i] != '\0';  i++)
+		{
+			/* only counts \ that are not escaping another \ like in \\  */
+			if(cword[i] == '\\' && cword[i+1] == '\\')
+			{
+				i++;
+				lastbl = i+1; /* next character after the \\ */
+			}
+			else if(cword[i] == '\\')
+				lastbl = i;
+		}
+		root = cword+lastbl;
+		rootlen = i-lastbl;
+	}
+	else
+	{
+		root = cword;
+		rootlen = strlen(root);
+	}
 
 	if (ret || force)
 	{
@@ -4975,7 +4998,7 @@ static ScintillaObject *create_new_sci(GeanyEditor *editor)
 
 	/* virtual space */
 	SSM(sci, SCI_SETVIRTUALSPACEOPTIONS, editor_prefs.show_virtual_space, 0);
-	
+
 #ifdef GDK_WINDOWING_QUARTZ
 	/* "retina" (HiDPI) display support on OS X - requires disabling buffered draw */
 	SSM(sci, SCI_SETBUFFEREDDRAW, 0, 0);

--- a/tagmanager/ctags/latex.c
+++ b/tagmanager/ctags/latex.c
@@ -149,6 +149,7 @@ static void findTeXTags(void)
 				if (getWord("newcommand", &cp)
 					|| getWord("providecommand", &cp)
 					|| getWord("renewcommand", &cp)
+					|| getWord("newlength", &cp)
 					)
 				{
 					createTag (TEX_BSLASH | TEX_BRACES, K_COMMAND, cp);

--- a/tagmanager/ctags/latex.c
+++ b/tagmanager/ctags/latex.c
@@ -1,7 +1,6 @@
 /*
  *   Copyright (c) 2000-2001, Jérôme Plût
  *   Copyright (c) 2006, Enrico Tröger
- *   Copyright (c) 2016, Marcelo Garlet Millani
  *
  *   This source code is released for free distribution under the terms of the
  *   GNU General Public License.

--- a/tagmanager/ctags/latex.c
+++ b/tagmanager/ctags/latex.c
@@ -175,6 +175,7 @@ static void findTeXTags(void)
 
 				/* \newenvironment{name} */
 				else if ( getWord("newenvironment", &cp)
+					|| getWord("renewenvironment", &cp)
 					|| getWord("newtheorem", &cp)
 					|| getWord("begin", &cp)
 					)

--- a/tagmanager/ctags/latex.c
+++ b/tagmanager/ctags/latex.c
@@ -60,7 +60,6 @@ static int getWord(const char * ref, const char **ptr)
 	while ((*ref != '\0') && (*p != '\0') && (*ref == *p))
 		ref++, p++;
 
-
 	if (*ref)
 		return FALSE;
 
@@ -76,7 +75,7 @@ static void createTag(int flags, TeXKind kind, const char * l)
 	vString *name = vStringNew ();
 
 	while ((*l == ' '))
-	l++;
+		l++;
 	if (flags & (TEX_BRACES | TEX_LABEL))
 	{
 		if (*l == '[')
@@ -87,16 +86,16 @@ static void createTag(int flags, TeXKind kind, const char * l)
 					goto no_tag;
 				l++;
 			}
-		l++; /* skip the closing square bracket */
-	}
-	if (*l != '{')
-		goto no_tag;
-	l++;
+			l++; /* skip the closing square bracket */
+		}
+		if (*l != '{')
+			goto no_tag;
+		l++;
 	}
 	if (flags & TEX_BSLASH)
 	{
-	if ((*(l++)) != '\\')
-		goto no_tag;
+		if ((*(l)) != '\\')
+			goto no_tag;
 	}
 	if (flags & TEX_LABEL)
 	{
@@ -115,7 +114,7 @@ static void createTag(int flags, TeXKind kind, const char * l)
 		{
 			vStringPut (name, (int) *l);
 			++l;
-		} while (isalpha((int) *l) || *l == '@' || *l == '\\');
+		} while (isalpha((int) *l) || *l == '@');
 		vStringTerminate(name);
 		makeSimpleTag(name, TeXKinds, kind);
 	}
@@ -153,7 +152,7 @@ static void findTeXTags(void)
 					|| getWord("renewcommand", &cp)
 					)
 				{
-					createTag (TEX_BRACES, K_COMMAND, cp);
+					createTag (TEX_BSLASH | TEX_BRACES, K_COMMAND, cp);
 					continue;
 				}
 

--- a/tagmanager/ctags/latex.c
+++ b/tagmanager/ctags/latex.c
@@ -1,6 +1,7 @@
 /*
  *   Copyright (c) 2000-2001, Jérôme Plût
  *   Copyright (c) 2006, Enrico Tröger
+ *   Copyright (c) 2016, Marcelo Garlet Millani
  *
  *   This source code is released for free distribution under the terms of the
  *   GNU General Public License.

--- a/tagmanager/ctags/latex.c
+++ b/tagmanager/ctags/latex.c
@@ -26,23 +26,23 @@
 *   DATA DEFINITIONS
 */
 typedef enum {
-     K_COMMAND,
-     K_ENVIRONMENT,
-     K_SECTION,
-     K_SUBSECTION,
-     K_SUBSUBSECTION,
-     K_CHAPTER,
-     K_LABEL
+	K_COMMAND,
+	K_ENVIRONMENT,
+	K_SECTION,
+	K_SUBSECTION,
+	K_SUBSUBSECTION,
+	K_CHAPTER,
+	K_LABEL
 } TeXKind;
 
 static kindOption TeXKinds[] = {
-     { TRUE, 'f', "function",      "command definitions" },
-     { TRUE, 'c', "class",         "environment definitions" },
-     { TRUE, 'm', "member",        "labels, sections and bibliography" },
-     { TRUE, 'd', "macro",         "subsections" },
-     { TRUE, 'v', "variable",      "subsubsections" },
-     { TRUE, 'n', "namespace",     "chapters"},
-     { TRUE, 's', "struct",        "labels and bibliography" }
+	{ TRUE, 'f', "function",      "command definitions" },
+	{ TRUE, 'c', "class",         "environment definitions" },
+	{ TRUE, 'm', "member",        "labels, sections and bibliography" },
+	{ TRUE, 'd', "macro",         "subsections" },
+	{ TRUE, 'v', "variable",      "subsubsections" },
+	{ TRUE, 'n', "namespace",     "chapters"},
+	{ TRUE, 's', "struct",        "labels and bibliography" }
 };
 
 #define TEX_BRACES (1<<0)
@@ -55,182 +55,182 @@ static kindOption TeXKinds[] = {
 
 static int getWord(const char * ref, const char **ptr)
 {
-    const char *p = *ptr;
+	const char *p = *ptr;
 
 	while ((*ref != '\0') && (*p != '\0') && (*ref == *p))
 		ref++, p++;
 
 
-    if (*ref)
+	if (*ref)
 		return FALSE;
 
 	if (*p == '*') /* to allow something like \section*{foobar} */
 		p++;
 
-    *ptr = p;
+	*ptr = p;
 	return TRUE;
 }
 
 static void createTag(int flags, TeXKind kind, const char * l)
 {
-    vString *name = vStringNew ();
+	vString *name = vStringNew ();
 
-    while ((*l == ' '))
- 	l++;
-    if (flags & (TEX_BRACES | TEX_LABEL))
-    {
-	if (*l == '[')
+	while ((*l == ' '))
+	l++;
+	if (flags & (TEX_BRACES | TEX_LABEL))
 	{
-	    while (*l != ']')
-	    {
-		if (*l == '\0')
-		    goto no_tag;
-		l++;
-	    }
-	    l++; /* skip the closing square bracket */
+		if (*l == '[')
+		{
+			while (*l != ']')
+			{
+				if (*l == '\0')
+					goto no_tag;
+				l++;
+			}
+		l++; /* skip the closing square bracket */
 	}
 	if (*l != '{')
- 	    goto no_tag;
+		goto no_tag;
 	l++;
-     }
-     if (flags & TEX_BSLASH)
-     {
- 	if ((*(l++)) != '\\')
- 	    goto no_tag;
-     }
-     if (flags & TEX_LABEL)
-     {
- 	do
- 	{
- 	    vStringPut(name, (int) *l);
- 	    ++l;
- 	} while ((*l != '\0') && (*l != '}'));
- 	vStringTerminate(name);
- 	if (name->buffer[0] != '}')
- 		makeSimpleTag(name, TeXKinds, kind);
-     }
-     else if (isalpha((int) *l) || *l == '@' || *l == '\\')
-     {
- 	do
- 	{
- 	    vStringPut (name, (int) *l);
- 	    ++l;
- 	} while (isalpha((int) *l) || *l == '@' || *l == '\\');
- 	vStringTerminate(name);
- 	makeSimpleTag(name, TeXKinds, kind);
-     }
-     else
-     {
- 	vStringPut(name, (int) *l);
- 	vStringTerminate(name);
- 	makeSimpleTag(name, TeXKinds, kind);
-     }
+	}
+	if (flags & TEX_BSLASH)
+	{
+	if ((*(l++)) != '\\')
+		goto no_tag;
+	}
+	if (flags & TEX_LABEL)
+	{
+		do
+		{
+			vStringPut(name, (int) *l);
+			++l;
+		} while ((*l != '\0') && (*l != '}'));
+		vStringTerminate(name);
+		if (name->buffer[0] != '}')
+			makeSimpleTag(name, TeXKinds, kind);
+	}
+	else if (isalpha((int) *l) || *l == '@' || *l == '\\')
+	{
+		do
+		{
+			vStringPut (name, (int) *l);
+			++l;
+		} while (isalpha((int) *l) || *l == '@' || *l == '\\');
+		vStringTerminate(name);
+		makeSimpleTag(name, TeXKinds, kind);
+	}
+	else
+	{
+		vStringPut(name, (int) *l);
+		vStringTerminate(name);
+		makeSimpleTag(name, TeXKinds, kind);
+	}
 
- no_tag:
-     vStringDelete(name);
+	no_tag:
+	vStringDelete(name);
 }
 
 static void findTeXTags(void)
 {
-    const char *line;
+	const char *line;
 
-    while ((line = (const char*)fileReadLine()) != NULL)
-    {
- 	const char *cp = line;
- 	/*int escaped = 0;*/
+	while ((line = (const char*)fileReadLine()) != NULL)
+	{
+		const char *cp = line;
+		/*int escaped = 0;*/
 
- 	for (; *cp != '\0'; cp++)
- 	{
- 	    if (*cp == '%')
-			break;
- 	    if (*cp == '\\')
- 	    {
- 		cp++;
+		for (; *cp != '\0'; cp++)
+		{
+			if (*cp == '%')
+				break;
+			if (*cp == '\\')
+			{
+				cp++;
 
- 		/* \newcommand{\command} */
- 		if (getWord("newcommand", &cp)
- 		    || getWord("providecommand", &cp)
- 		    || getWord("renewcommand", &cp)
- 		    )
- 		{
- 		    createTag (TEX_BRACES, K_COMMAND, cp);
- 		    continue;
- 		}
+				/* \newcommand{\command} */
+				if (getWord("newcommand", &cp)
+					|| getWord("providecommand", &cp)
+					|| getWord("renewcommand", &cp)
+					)
+				{
+					createTag (TEX_BRACES, K_COMMAND, cp);
+					continue;
+				}
 
- 		/* \DeclareMathOperator{\command} */
- 		else if (getWord("DeclareMathOperator", &cp))
- 		{
- 		    if (*cp == '*')
- 			cp++;
- 		    createTag(TEX_BRACES, K_COMMAND, cp);
- 		    continue;
- 		}
+				/* \DeclareMathOperator{\command} */
+				else if (getWord("DeclareMathOperator", &cp))
+				{
+					if (*cp == '*')
+						cp++;
+					createTag(TEX_BRACES, K_COMMAND, cp);
+					continue;
+				}
 
- 		/* \def\command */
- 		else if (getWord("def", &cp))
- 		{
- 		    createTag(0, K_COMMAND, cp);
- 		    continue;
- 		}
+				/* \def\command */
+				else if (getWord("def", &cp))
+				{
+					createTag(0, K_COMMAND, cp);
+					continue;
+				}
 
- 		/* \newenvironment{name} */
- 		else if ( getWord("newenvironment", &cp)
- 		    || getWord("newtheorem", &cp)
- 		    || getWord("begin", &cp)
- 		    )
- 		{
- 		    createTag(TEX_BRACES, K_ENVIRONMENT, cp);
- 		    continue;
- 		}
+				/* \newenvironment{name} */
+				else if ( getWord("newenvironment", &cp)
+					|| getWord("newtheorem", &cp)
+					|| getWord("begin", &cp)
+					)
+				{
+					createTag(TEX_BRACES, K_ENVIRONMENT, cp);
+					continue;
+				}
 
- 		/* \bibitem[label]{key} */
- 		else if (getWord("bibitem", &cp))
- 		{
- 		    while (*cp == ' ')
- 			cp++;
- 		    if (*(cp++) != '[')
- 			break;
- 		    while ((*cp != '\0') && (*cp != ']'))
- 			cp++;
- 		    if (*(cp++) != ']')
- 			break;
- 		    createTag(TEX_LABEL, K_LABEL, cp);
- 		    continue;
- 		}
+				/* \bibitem[label]{key} */
+				else if (getWord("bibitem", &cp))
+				{
+					while (*cp == ' ')
+						cp++;
+					if (*(cp++) != '[')
+						break;
+					while ((*cp != '\0') && (*cp != ']'))
+						cp++;
+					if (*(cp++) != ']')
+						break;
+					createTag(TEX_LABEL, K_LABEL, cp);
+					continue;
+				}
 
- 		/* \label{key} */
- 		else if (getWord("label", &cp))
- 		{
- 		    createTag(TEX_LABEL, K_LABEL, cp);
- 		    continue;
- 		}
- 		/* \section{key} */
- 		else if (getWord("section", &cp))
- 		{
- 		    createTag(TEX_LABEL, K_SECTION, cp);
- 		    continue;
- 		}
- 		/* \subsection{key} */
- 		else if (getWord("subsection", &cp))
- 		{
- 		    createTag(TEX_LABEL, K_SUBSECTION, cp);
- 		    continue;
- 		}
- 		/* \subsubsection{key} */
- 		else if (getWord("subsubsection", &cp))
- 		{
- 		    createTag(TEX_LABEL, K_SUBSUBSECTION, cp);
- 		    continue;
- 		}
- 		/* \chapter{key} */
- 		else if (getWord("chapter", &cp))
- 		{
- 		    createTag(TEX_LABEL, K_CHAPTER, cp);
- 		    continue;
- 		}
- 	    }
- 	}
-    }
+				/* \label{key} */
+				else if (getWord("label", &cp))
+				{
+					createTag(TEX_LABEL, K_LABEL, cp);
+					continue;
+				}
+				/* \section{key} */
+				else if (getWord("section", &cp))
+				{
+					createTag(TEX_LABEL, K_SECTION, cp);
+					continue;
+				}
+				/* \subsection{key} */
+				else if (getWord("subsection", &cp))
+				{
+					createTag(TEX_LABEL, K_SUBSECTION, cp);
+					continue;
+				}
+				/* \subsubsection{key} */
+				else if (getWord("subsubsection", &cp))
+				{
+					createTag(TEX_LABEL, K_SUBSUBSECTION, cp);
+					continue;
+				}
+				/* \chapter{key} */
+				else if (getWord("chapter", &cp))
+				{
+					createTag(TEX_LABEL, K_CHAPTER, cp);
+					continue;
+				}
+			}
+		}
+	}
 }
 
 extern parserDefinition* LaTeXParser (void)

--- a/tagmanager/ctags/latex.c
+++ b/tagmanager/ctags/latex.c
@@ -108,13 +108,13 @@ static void createTag(int flags, TeXKind kind, const char * l)
  	if (name->buffer[0] != '}')
  		makeSimpleTag(name, TeXKinds, kind);
      }
-     else if (isalpha((int) *l) || *l == '@')
+     else if (isalpha((int) *l) || *l == '@' || *l == '\\')
      {
  	do
  	{
  	    vStringPut (name, (int) *l);
  	    ++l;
- 	} while (isalpha((int) *l) || *l == '@');
+ 	} while (isalpha((int) *l) || *l == '@' || *l == '\\');
  	vStringTerminate(name);
  	makeSimpleTag(name, TeXKinds, kind);
      }
@@ -152,7 +152,7 @@ static void findTeXTags(void)
  		    || getWord("renewcommand", &cp)
  		    )
  		{
- 		    createTag (TEX_BRACES|TEX_BSLASH, K_COMMAND, cp);
+ 		    createTag (TEX_BRACES, K_COMMAND, cp);
  		    continue;
  		}
 
@@ -161,14 +161,14 @@ static void findTeXTags(void)
  		{
  		    if (*cp == '*')
  			cp++;
- 		    createTag(TEX_BRACES|TEX_BSLASH, K_COMMAND, cp);
+ 		    createTag(TEX_BRACES, K_COMMAND, cp);
  		    continue;
  		}
 
  		/* \def\command */
  		else if (getWord("def", &cp))
  		{
- 		    createTag(TEX_BSLASH, K_COMMAND, cp);
+ 		    createTag(0, K_COMMAND, cp);
  		    continue;
  		}
 

--- a/tagmanager/ctags/latex.c
+++ b/tagmanager/ctags/latex.c
@@ -166,7 +166,8 @@ static void findTeXTags(void)
 				}
 
 				/* \def\command */
-				else if (getWord("def", &cp))
+				else if (getWord("def", &cp)
+					|| getWord("let", &cp))
 				{
 					createTag(0, K_COMMAND, cp);
 					continue;

--- a/tests/ctags/3526726.tex.tags
+++ b/tests/ctags/3526726.tex.tags
@@ -136,6 +136,8 @@ Why does snort report ``Packet loss statistics are unavailable under Linux?''Ì65
 Why does the `error deleting alert' message occur when attempting to delete an alert with BASE?  Ì65536Ö0
 Why does the portscan plugin log ``stealth'' packets even though the host is in the portscan-ignorehosts list? Ì65536Ö0
 Why does the program generate alerts on packets that have pass rules?  Ì65536Ö0
+\myquoteÌ16Ö0
+\myrefÌ16Ö0
 barnyardÌ2048Ö0
 centerÌ1Ö0
 chrootÌ2048Ö0
@@ -144,8 +146,6 @@ documentÌ1Ö0
 enumerateÌ1Ö0
 itemizeÌ1Ö0
 latexonlyÌ1Ö0
-myquoteÌ16Ö0
-myrefÌ16Ö0
 quoteÌ1Ö0
 spoolersÌ2048Ö0
 stealthÌ2048Ö0

--- a/tests/ctags/bug2886870.tex.tags
+++ b/tests/ctags/bug2886870.tex.tags
@@ -11,6 +11,9 @@ TablesÌ64Ö0
 Test for ctagsÌ16384Ö0
 \color{redÌ64Ö0
 \label{morefigÌ64Ö0
+\lbÌ16Ö0
+\rbÌ16Ö0
+\rvÌ16Ö0
 alignÌ1Ö0
 casesÌ1Ö0
 centerÌ1Ö0
@@ -26,11 +29,8 @@ fig:qm/complexfunctionsÌ2048Ö0
 fig:typicalÌ2048Ö0
 figureÌ1Ö0
 itemizeÌ1Ö0
-lbÌ16Ö0
 morefigÌ2048Ö0
 pmatrixÌ1Ö0
-rbÌ16Ö0
-rvÌ16Ö0
 subequationsÌ1Ö0
 tab:5/tcÌ2048Ö0
 tableÌ1Ö0

--- a/tests/ctags/intro_orig.tex.tags
+++ b/tests/ctags/intro_orig.tex.tags
@@ -10,6 +10,9 @@ Special symbolsÌ65536Ö0
 TablesÌ64Ö0
 \color{redÌ64Ö0
 \label{morefigÌ64Ö0
+\lbÌ16Ö0
+\rbÌ16Ö0
+\rvÌ16Ö0
 alignÌ1Ö0
 casesÌ1Ö0
 centerÌ1Ö0
@@ -25,11 +28,8 @@ fig:qm/complexfunctionsÌ2048Ö0
 fig:typicalÌ2048Ö0
 figureÌ1Ö0
 itemizeÌ1Ö0
-lbÌ16Ö0
 morefigÌ2048Ö0
 pmatrixÌ1Ö0
-rbÌ16Ö0
-rvÌ16Ö0
 subequationsÌ1Ö0
 tab:5/tcÌ2048Ö0
 tableÌ1Ö0


### PR DESCRIPTION
Fixes issue #1000 . Geany now correctly autocompletes LaTeX macros.
The difference in behaviour can be illustrated with the following document:
````latex
\newcommand{\macroname}{}
% The following occurrences of \macro are now autocompleted to \macroname
\macro 
\alpha\macro
% The following is no longer autocompleted to macroname
macro
% Example with @
\newcommand{\@anothermacro}{}
% Gets autocompleted
\@another
````
The tests were updated to accept this behaviour (since macro tags now start with `\`).
This also identifies macros defined with `\let`, `\newlength` and environments defined with `\renewenvironment`.

Finally, `@` can be used sometimes in a macro name and mostly any character can be used in a label. I added `:@` to wordchars so that they can be used in autocomplete.