### PR TITLE
Add parfor to Matlab keyword list

### DIFF
--- a/data/filedefs/filetypes.matlab
+++ b/data/filedefs/filetypes.matlab
@@ -13,7 +13,7 @@ doublequotedstring=string_2
 
 [keywords]
 # all items must be in one line
-primary=break case catch classdef continue else elseif end enumeration events for function global if methods otherwise persistent properties return switch try while
+primary=break case catch classdef continue else elseif end enumeration events for function global if methods otherwise persistent properties return switch try while parfor
 
 [settings]
 # default extension used when saving files

--- a/data/filedefs/filetypes.matlab
+++ b/data/filedefs/filetypes.matlab
@@ -13,7 +13,7 @@ doublequotedstring=string_2
 
 [keywords]
 # all items must be in one line
-primary=break case catch classdef continue else elseif end enumeration events for function global if methods otherwise persistent properties return switch try while parfor
+primary=break case catch classdef continue else elseif end enumeration events for function global if methods otherwise parfor persistent properties return switch try while
 
 [settings]
 # default extension used when saving files


### PR DESCRIPTION
Add `parfor` to the list of keywords to be highlighted in Matlab script sources. `parfor` is a Matlab keyword that can be used in place of `for` to achieve parallel processing.

Although `parfor` is technically a function, its use is syntactically equivalent to traditional `for`, and therefore it should be treated the same in terms of syntax highlighting.
