### PR TITLE
Fix typename highlighting after using replace

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -4823,6 +4823,8 @@ static gboolean editor_check_colourise(GeanyEditor *editor)
 		sci_colourise(editor->sci, start, end);
 	}
 
+	doc->priv->full_colourise = FALSE;
+
 	return TRUE;
 }
 


### PR DESCRIPTION
At the moment we only re-colorize typenames at the visible part of the
screen (after full colorization when the file gets loaded). This works well
for normal editing but is insufficient for the replace operation as the
replaced text can be outside the visible area.

To fix this, perform full recolorization when performing replace.