### PR TITLE
Fix Haskell single line comments by adding space

### DIFF
--- a/data/filedefs/filetypes.haskell
+++ b/data/filedefs/filetypes.haskell
@@ -51,7 +51,7 @@ mime_type=text/x-haskell
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file
-comment_single=--
+comment_single=-- 
 # multiline comments
 comment_open={-
 comment_close=-}


### PR DESCRIPTION
Haskell single line comments consist of "-- " sequence of characters and not "--". For example, in many cases GHC considers "--" commented lines as not actually commented. Everywhere in code you will see a space following "--".