### PR TITLE
Fix Haskell single line comments by adding space

### DIFF
--- a/data/filedefs/filetypes.haskell
+++ b/data/filedefs/filetypes.haskell
@@ -51,7 +51,7 @@ mime_type=text/x-haskell
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file
-comment_single=--
+comment_single=--\s
 # multiline comments
 comment_open={-
 comment_close=-}


### PR DESCRIPTION
Haskell single line comments consist of at least two dashes "--",
not followed by special symbol.
So in practice everywhere in code you will see a space following "--".
Reference: Haskell 2010 Language Report -> Chapter 2 -> Lexical Structure