### PR TITLE
Gi signals

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,14 +74,11 @@ AS_IF([test "x$enable_gtk3" = xyes],
 AM_CONDITIONAL([GTK3], [test "x$gtk_package" = "xgtk+-3.0"])
 
 # GTK/GLib/GIO checks
-gtk_modules="$gtk_package >= $gtk_min_version glib-2.0 >= 2.28"
-gtk_modules_private="gio-2.0 >= 2.28 gmodule-no-export-2.0"
+gtk_modules="$gtk_package >= $gtk_min_version glib-2.0 >= 2.32"
+gtk_modules_private="gio-2.0 >= 2.32 gmodule-no-export-2.0"
 PKG_CHECK_MODULES([GTK], [$gtk_modules $gtk_modules_private])
 AC_SUBST([DEPENDENCIES], [$gtk_modules])
-dnl Define minimum requirements to avoid warnings about symbols deprecated afterward.
-dnl Although GLIB_VERSION_2_28 is new in 2.32, older versions won't evaluate
-dnl GLIB_VERSION_MIN_REQUIRED so it won't be a problem.
-AS_VAR_APPEND([GTK_CFLAGS], [" -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_28"])
+AS_VAR_APPEND([GTK_CFLAGS], [" -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_32"])
 dnl Disable all GTK deprecations on 3.x so long as we want to keep 2.x support and only require 3.0.
 dnl No need on 2.x as we target the latest version.
 AM_COND_IF([GTK3], [AS_VAR_APPEND([GTK_CFLAGS], [" -DGDK_DISABLE_DEPRECATION_WARNINGS"])])

--- a/scintilla/gtk/ScintillaGTK.cxx
+++ b/scintilla/gtk/ScintillaGTK.cxx
@@ -3250,6 +3250,7 @@ void scintilla_release_resources(void) {
 static void *copy_(void *src) { return src; }
 static void free_(void *doc) { }
 
+GEANY_API_SYMBOL
 GType scnotification_get_type(void) {
 	static gsize type_id = 0;
 	if (g_once_init_enter(&type_id)) {

--- a/scintilla/scintilla_changes.patch
+++ b/scintilla/scintilla_changes.patch
@@ -50,6 +50,14 @@ index 0871ca2..49dc278 100644
  GtkWidget *scintilla_object_new() {
  	return scintilla_new();
  }
+@@ -3250,6 +3250,7 @@ void scintilla_release_resources(void) {
+ static void *copy_(void *src) { return src; }
+ static void free_(void *doc) { }
+ 
++GEANY_API_SYMBOL
+ GType scnotification_get_type(void) {
+ 	static gsize type_id = 0;
+ 	if (g_once_init_enter(&type_id)) {
 diff --git scintilla/src/Catalogue.cxx scintilla/src/Catalogue.cxx
 index ed47aa8..e58f1ab 100644
 --- scintilla/src/Catalogue.cxx

--- a/scripts/cross-build-mingw.sh
+++ b/scripts/cross-build-mingw.sh
@@ -54,7 +54,7 @@ fetch_and_unzip()
 {
   local basename=${1##*/}
   curl -L -# "$1" > "$basename"
-  unzip -q "$basename" -d "$2"
+  unzip -qn "$basename" -d "$2"
   rm -f "$basename"
 }
 
@@ -87,7 +87,8 @@ mkdir "$BUILDDIR"
 cd "$BUILDDIR"
 
 mkdir _deps
-fetch_and_unzip "$BUNDLE_ZIP" _deps
+fetch_and_unzip "$GTK3_BUNDLE_ZIP" _deps
+[ "$GTK3" = yes ] || fetch_and_unzip "$BUNDLE_ZIP" _deps
 # fixup the prefix= in the pkg-config files
 sed -i "s%^\(prefix=\).*$%\1$PWD/_deps%" _deps/lib/pkgconfig/*.pc
 

--- a/src/document.c
+++ b/src/document.c
@@ -3813,3 +3813,15 @@ void document_grab_focus(GeanyDocument *doc)
 
 	gtk_widget_grab_focus(GTK_WIDGET(doc->editor->sci));
 }
+
+static void        *copy_(void *src) { return src; }
+static void         free_(void *doc) { }
+
+/** @gironly
+ * Gets the GType of GeanyDocument
+ *
+ * @return the GeanyDocument type */
+GEANY_API_SYMBOL
+GType document_get_type (void);
+
+G_DEFINE_BOXED_TYPE(GeanyDocument, document, copy_, free_);

--- a/src/document.h
+++ b/src/document.h
@@ -70,6 +70,9 @@ typedef struct GeanyFilePrefs
 GeanyFilePrefs;
 
 
+#define GEANY_TYPE_DOCUMENT (document_get_type())
+GType document_get_type (void);
+
 /**
  *  Structure for representing an open tab with all its properties.
  **/

--- a/src/editor.c
+++ b/src/editor.c
@@ -5309,3 +5309,15 @@ void editor_insert_snippet(GeanyEditor *editor, gint pos, const gchar *snippet)
 	editor_insert_text_block(editor, pattern->str, pos, -1, -1, TRUE);
 	g_string_free(pattern, TRUE);
 }
+
+static void        *copy_(void *src) { return src; }
+static void         free_(void *doc) { }
+
+/** @gironly
+ * Gets the GType of GeanyEditor
+ *
+ * @return the GeanyEditor type */
+GEANY_API_SYMBOL
+GType editor_get_type (void);
+
+G_DEFINE_BOXED_TYPE(GeanyEditor, editor, copy_, free_);

--- a/src/editor.h
+++ b/src/editor.h
@@ -139,6 +139,10 @@ typedef struct GeanyEditorPrefs
 }
 GeanyEditorPrefs;
 
+
+#define GEANY_TYPE_EDITOR (editor_get_type())
+GType editor_get_type (void);
+
 /** Editor-owned fields for each document. */
 typedef struct GeanyEditor
 {

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -1585,3 +1585,15 @@ gboolean filetype_get_comment_open_close(const GeanyFiletype *ft, gboolean singl
 
 	return !EMPTY(*co);
 }
+
+static void        *copy_(void *src) { return src; }
+static void         free_(void *doc) { }
+
+/** @gironly
+ * Gets the GType of GeanyFiletype
+ *
+ * @return the GeanyFiletype type */
+GEANY_API_SYMBOL
+GType filetype_get_type (void);
+
+G_DEFINE_BOXED_TYPE(GeanyFiletype, filetype, copy_, free_);

--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -186,6 +186,9 @@ const gchar *filetypes_get_display_name(GeanyFiletype *ft);
 
 const GSList *filetypes_get_sorted_by_name(void);
 
+#define GEANY_TYPE_FILETYPE (filetype_get_type())
+
+GType filetype_get_type (void);
 
 #ifdef GEANY_PRIVATE
 

--- a/src/geanyobject.c
+++ b/src/geanyobject.c
@@ -62,68 +62,6 @@ GType geany_object_get_type(void);
 G_DEFINE_TYPE(GeanyObject, geany_object, G_TYPE_OBJECT)
 
 
-
-static void geany_cclosure_marshal_VOID__STRING_INT_POINTER(GClosure *closure, GValue *ret_val,
-				guint n_param_vals, const GValue *param_values, gpointer hint, gpointer mdata)
-{
-	typedef gboolean (*GeanyMarshalFunc_VOID__STRING_INT_POINTER)
-		(gpointer data1, gconstpointer arg_1, gint arg_2, gpointer arg_3, gpointer data2);
-
-	register GeanyMarshalFunc_VOID__STRING_INT_POINTER callback;
-	register GCClosure* cc = (GCClosure*) closure;
-	register gpointer data1, data2;
-
-	g_return_if_fail(n_param_vals == 4);
-
-	if (G_CCLOSURE_SWAP_DATA(closure))
-	{
-		data1 = closure->data;
-		data2 = g_value_peek_pointer(param_values + 0);
-	}
-	else
-	{
-		data1 = g_value_peek_pointer(param_values + 0);
-		data2 = closure->data;
-	}
-	callback = (GeanyMarshalFunc_VOID__STRING_INT_POINTER) (mdata ? mdata : cc->callback);
-	callback(data1,
-			  g_value_get_string(param_values + 1),
-			  g_value_get_int(param_values + 2),
-			  g_value_get_pointer(param_values + 3),
-			  data2);
-}
-
-
-static void geany_cclosure_marshal_VOID__POINTER_POINTER(GClosure *closure, GValue *ret_val,
-				guint n_param_vals, const GValue *param_values, gpointer hint, gpointer mdata)
-{
-	typedef gboolean (*GeanyMarshalFunc_VOID__POINTER_POINTER)
-		(gpointer data1, gconstpointer arg_1, gconstpointer arg_2, gpointer data2);
-
-	register GeanyMarshalFunc_VOID__POINTER_POINTER callback;
-	register GCClosure* cc = (GCClosure*) closure;
-	register gpointer data1, data2;
-
-	g_return_if_fail(n_param_vals == 3);
-
-	if (G_CCLOSURE_SWAP_DATA(closure))
-	{
-		data1 = closure->data;
-		data2 = g_value_peek_pointer(param_values + 0);
-	}
-	else
-	{
-		data1 = g_value_peek_pointer(param_values + 0);
-		data2 = closure->data;
-	}
-	callback = (GeanyMarshalFunc_VOID__POINTER_POINTER) (mdata ? mdata : cc->callback);
-	callback(data1,
-			  g_value_get_pointer(param_values + 1),
-			  g_value_get_pointer(param_values + 2),
-			  data2);
-}
-
-
 static gboolean boolean_handled_accumulator(GSignalInvocationHint *ihint, GValue *return_accu,
 											const GValue *handler_return, gpointer dummy)
 {
@@ -137,43 +75,6 @@ static gboolean boolean_handled_accumulator(GSignalInvocationHint *ihint, GValue
 }
 
 
-static void geany_cclosure_marshal_BOOL__POINTER_POINTER(GClosure *closure, GValue *return_value,
-								guint n_param_values, const GValue *param_values,
-								gpointer invocation_hint G_GNUC_UNUSED, gpointer marshal_data)
-{
-	typedef gboolean (*GeanyMarshalFunc_BOOLEAN__POINTER_POINTER)
-		(gpointer data1, gpointer arg_1, gpointer arg_2, gpointer data2);
-
-	register GeanyMarshalFunc_BOOLEAN__POINTER_POINTER callback;
-	register GCClosure *cc = (GCClosure*) closure;
-	register gpointer data1, data2;
-	gboolean v_return;
-
-	g_return_if_fail(return_value != NULL);
-	g_return_if_fail(n_param_values == 3);
-
-	if (G_CCLOSURE_SWAP_DATA(closure))
-	{
-		data1 = closure->data;
-		data2 = g_value_peek_pointer(param_values + 0);
-	}
-	else
-	{
-		data1 = g_value_peek_pointer(param_values + 0);
-		data2 = closure->data;
-	}
-	callback = (GeanyMarshalFunc_BOOLEAN__POINTER_POINTER)
-		(marshal_data ? marshal_data : cc->callback);
-
-	v_return = callback(data1,
-					   g_value_get_pointer(param_values + 1),
-					   g_value_get_pointer(param_values + 2),
-					   data2);
-
-	g_value_set_boolean(return_value, v_return);
-}
-
-
 static void create_signals(GObjectClass *g_object_class)
 {
 	/* Document signals */
@@ -181,166 +82,130 @@ static void create_signals(GObjectClass *g_object_class)
 		"document-new",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, document_new),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GEANY_TYPE_DOCUMENT);
 	geany_object_signals[GCB_DOCUMENT_OPEN] = g_signal_new (
 		"document-open",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, document_open),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GEANY_TYPE_DOCUMENT);
 	geany_object_signals[GCB_DOCUMENT_RELOAD] = g_signal_new (
 		"document-reload",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, document_reload),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GEANY_TYPE_DOCUMENT);
 	geany_object_signals[GCB_DOCUMENT_BEFORE_SAVE] = g_signal_new (
 		"document-before-save",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, document_before_save),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GEANY_TYPE_DOCUMENT);
 	geany_object_signals[GCB_DOCUMENT_SAVE] = g_signal_new (
 		"document-save",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, document_save),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GEANY_TYPE_DOCUMENT);
 	geany_object_signals[GCB_DOCUMENT_FILETYPE_SET] = g_signal_new (
 		"document-filetype-set",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, document_filetype_set),
-		NULL, NULL,
-		geany_cclosure_marshal_VOID__POINTER_POINTER,
+		0, NULL, NULL, NULL,
 		G_TYPE_NONE, 2,
-		G_TYPE_POINTER, G_TYPE_POINTER);
+		GEANY_TYPE_DOCUMENT, GEANY_TYPE_FILETYPE);
 	geany_object_signals[GCB_DOCUMENT_ACTIVATE] = g_signal_new (
 		"document-activate",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, document_activate),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GEANY_TYPE_DOCUMENT);
 	geany_object_signals[GCB_DOCUMENT_CLOSE] = g_signal_new (
 		"document-close",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, document_close),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GEANY_TYPE_DOCUMENT);
 
 	/* Project signals */
 	geany_object_signals[GCB_PROJECT_OPEN] = g_signal_new (
 		"project-open",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, project_open),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		G_TYPE_KEY_FILE);
 	geany_object_signals[GCB_PROJECT_SAVE] = g_signal_new (
 		"project-save",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, project_save),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		G_TYPE_KEY_FILE);
 	geany_object_signals[GCB_PROJECT_CLOSE] = g_signal_new (
 		"project-close",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, project_close),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__VOID,
+		0, NULL, NULL, g_cclosure_marshal_VOID__VOID,
 		G_TYPE_NONE, 0);
 	geany_object_signals[GCB_PROJECT_DIALOG_OPEN] = g_signal_new (
 		"project-dialog-open",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, project_dialog_open),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__OBJECT,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GTK_TYPE_NOTEBOOK);
 	geany_object_signals[GCB_PROJECT_DIALOG_CONFIRMED] = g_signal_new (
 		"project-dialog-confirmed",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, project_dialog_confirmed),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__OBJECT,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GTK_TYPE_NOTEBOOK);
 	geany_object_signals[GCB_PROJECT_DIALOG_CLOSE] = g_signal_new (
 		"project-dialog-close",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, project_dialog_close),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__OBJECT,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		GTK_TYPE_NOTEBOOK);
 
 	/* Editor signals */
 	geany_object_signals[GCB_UPDATE_EDITOR_MENU] = g_signal_new (
 		"update-editor-menu",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, update_editor_menu),
-		NULL, NULL,
-		geany_cclosure_marshal_VOID__STRING_INT_POINTER,
+		0, NULL, NULL, NULL,
 		G_TYPE_NONE, 3,
-		G_TYPE_STRING, G_TYPE_INT, G_TYPE_POINTER);
+		G_TYPE_STRING, G_TYPE_INT, GEANY_TYPE_DOCUMENT);
 	geany_object_signals[GCB_EDITOR_NOTIFY] = g_signal_new (
 		"editor-notify",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_LAST,
-		G_STRUCT_OFFSET (GeanyObjectClass, update_editor_menu),
-		boolean_handled_accumulator, NULL,
-		geany_cclosure_marshal_BOOL__POINTER_POINTER,
+		0, boolean_handled_accumulator, NULL, NULL,
 		G_TYPE_BOOLEAN, 2,
-		G_TYPE_POINTER, G_TYPE_POINTER);
+		GEANY_TYPE_EDITOR, SCINTILLA_TYPE_NOTIFICATION);
 
 	/* General signals */
 	geany_object_signals[GCB_GEANY_STARTUP_COMPLETE] = g_signal_new (
 		"geany-startup-complete",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, geany_startup_complete),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__VOID,
+		0, NULL, NULL, g_cclosure_marshal_VOID__VOID,
 		G_TYPE_NONE, 0);
 	geany_object_signals[GCB_BUILD_START] = g_signal_new (
 		"build-start",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, build_start),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__VOID,
+		0, NULL, NULL, g_cclosure_marshal_VOID__VOID,
 		G_TYPE_NONE, 0);
 
 	/* Core-only signals */
@@ -348,20 +213,16 @@ static void create_signals(GObjectClass *g_object_class)
 		"save-settings",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, save_settings),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		G_TYPE_KEY_FILE);
 	geany_object_signals[GCB_LOAD_SETTINGS] = g_signal_new (
 		"load-settings",
 		G_OBJECT_CLASS_TYPE (g_object_class),
 		G_SIGNAL_RUN_FIRST,
-		G_STRUCT_OFFSET (GeanyObjectClass, load_settings),
-		NULL, NULL,
-		g_cclosure_marshal_VOID__POINTER,
+		0, NULL, NULL, g_cclosure_marshal_VOID__BOXED,
 		G_TYPE_NONE, 1,
-		G_TYPE_POINTER);
+		G_TYPE_KEY_FILE);
 }
 
 

--- a/src/geanyobject.c
+++ b/src/geanyobject.c
@@ -52,6 +52,12 @@ struct _GeanyObjectPrivate
 	gchar dummy;
 };
 
+/** @gironly
+ * Get the GObject-derived GType for GeanyObject
+ *
+ * @return GeanyObject type */
+GEANY_API_SYMBOL
+GType geany_object_get_type(void);
 
 G_DEFINE_TYPE(GeanyObject, geany_object, G_TYPE_OBJECT)
 

--- a/src/geanyobject.h
+++ b/src/geanyobject.h
@@ -74,6 +74,8 @@ GeanyCallbackId;
 typedef struct _GeanyObject				GeanyObject;
 typedef struct _GeanyObjectClass			GeanyObjectClass;
 
+/** @gironly
+ * Instance structure for GeanyObject */
 struct _GeanyObject
 {
 	GObject parent;
@@ -82,30 +84,11 @@ struct _GeanyObject
 
 extern GObject *geany_object;
 
+/** @gironly
+ * Class structure for @a GeanyObject */
 struct _GeanyObjectClass
 {
 	GObjectClass parent_class;
-
-	void (*document_new)(GeanyDocument *doc);
-	void (*document_open)(GeanyDocument *doc);
-	void (*document_reload)(GeanyDocument *doc);
-	void (*document_before_save)(GeanyDocument *doc);
-	void (*document_save)(GeanyDocument *doc);
-	void (*document_filetype_set)(GeanyDocument *doc, GeanyFiletype *filetype_old);
-	void (*document_activate)(GeanyDocument *doc);
-	void (*document_close)(GeanyDocument *doc);
-	void (*project_open)(GKeyFile *keyfile);
-	void (*project_save)(GKeyFile *keyfile);
-	void (*project_close)(void);
-	void (*project_dialog_open)(GtkWidget *notebook);
-	void (*project_dialog_confirmed)(GtkWidget *notebook);
-	void (*project_dialog_close)(GtkWidget *notebook);
-	void (*update_editor_menu)(const gchar *word, gint click_pos, GeanyDocument *doc);
-	gboolean (*editor_notify)(GeanyEditor *editor, gpointer scnt);
-	void (*geany_startup_complete)(void);
-	void (*build_start)(void);
-	void (*save_settings)(GKeyFile *keyfile);
-	void (*load_settings)(GKeyFile *keyfile);
 };
 
 GType		geany_object_get_type	(void);

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -183,6 +183,12 @@ typedef struct GeanyData
 	struct GeanyTemplatePrefs	*template_prefs;	/**< Template settings */
 	gpointer					*_compat;			/* Remove field on next ABI break (abi-todo) */
 	GSList						*filetypes_by_title; /**< See filetypes.h#filetypes_by_title. */
+	/** @gironly
+	 * Global object signalling events via signals
+	 *
+	 * This is mostly for language bindings. Otherwise prefer to use
+	 * plugin_signal_connect() instead this which adds automatic cleanup. */
+	GObject						*object;
 }
 GeanyData;
 

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -120,7 +120,8 @@ geany_data_init(void)
 		&tool_prefs,
 		&template_prefs,
 		NULL, /* Remove field on next ABI break (abi-todo) */
-		filetypes_by_title
+		filetypes_by_title,
+		geany_object,
 	};
 
 	geany_data = gd;


### PR DESCRIPTION
This are the changes to geany that allow plugin signals to be used by GI-based plugins (e.g. through peasy).

- signal params must be boxed or gobject (I used gboxed)
- the GType must be passed to g_signal_new()
- since glib 2.30 there is a generic marshaller which can be used. otherwise we'd need a lot of duplicated, new marshaller code. I chosed to use the generic marshaller (by passing NULL to g_signal_new's marshall func)
- geanyobject must be exposed to connect to. I chosed to implement a get_instance() function (singleton pattern)

Please review and comment