### PR TITLE
Highlight fix 2

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -512,6 +512,9 @@ static gint document_get_new_idx(void)
 
 static void queue_colourise(GeanyDocument *doc)
 {
+	if (doc->priv->colourise_needed)
+		return;
+
 	/* Colourise the editor before it is next drawn */
 	doc->priv->colourise_needed = TRUE;
 

--- a/src/document.c
+++ b/src/document.c
@@ -2750,10 +2750,17 @@ void document_highlight_tags(GeanyDocument *doc)
 	keywords_str = symbols_find_typenames_as_string(doc->file_type->lang, FALSE);
 	if (keywords_str)
 	{
+		guint hash;
+
 		keywords = g_string_free(keywords_str, FALSE);
-		sci_set_keywords(doc->editor->sci, keyword_idx, keywords);
+		hash = g_str_hash(keywords);
+		if (hash != doc->priv->keyword_hash)
+		{
+			sci_set_keywords(doc->editor->sci, keyword_idx, keywords);
+			queue_colourise(doc); /* force re-highlighting the entire document */
+			doc->priv->keyword_hash = hash;
+		}
 		g_free(keywords);
-		queue_colourise(doc); /* force re-highlighting the entire document */
 	}
 }
 

--- a/src/document.c
+++ b/src/document.c
@@ -510,12 +510,8 @@ static gint document_get_new_idx(void)
 }
 
 
-static void queue_colourise(GeanyDocument *doc, gboolean full_colourise)
+static void queue_colourise(GeanyDocument *doc)
 {
-	/* make sure we don't override previously set full_colourise=TRUE by FALSE */
-	if (!doc->priv->colourise_needed || !doc->priv->full_colourise)
-		doc->priv->full_colourise = full_colourise;
-
 	/* Colourise the editor before it is next drawn */
 	doc->priv->colourise_needed = TRUE;
 
@@ -1398,7 +1394,7 @@ GeanyDocument *document_open_file_full(GeanyDocument *doc, const gchar *filename
 		/* add the text to the ScintillaObject */
 		sci_set_readonly(doc->editor->sci, FALSE);	/* to allow replacing text */
 		sci_set_text(doc->editor->sci, filedata.data);	/* NULL terminated data */
-		queue_colourise(doc, TRUE);	/* Ensure the document gets colourised. */
+		queue_colourise(doc);	/* Ensure the document gets colourised. */
 
 		/* detect & set line endings */
 		editor_mode = utils_get_line_endings(filedata.data, filedata.len);
@@ -2754,7 +2750,7 @@ void document_highlight_tags(GeanyDocument *doc)
 		keywords = g_string_free(keywords_str, FALSE);
 		sci_set_keywords(doc->editor->sci, keyword_idx, keywords);
 		g_free(keywords);
-		queue_colourise(doc, FALSE); /* re-highlight the visible area */
+		queue_colourise(doc); /* force re-highlighting the entire document */
 	}
 }
 
@@ -2815,7 +2811,7 @@ static void document_load_config(GeanyDocument *doc, GeanyFiletype *type,
 		highlighting_set_styles(doc->editor->sci, type);
 		editor_set_indentation_guides(doc->editor);
 		build_menu_update(doc);
-		queue_colourise(doc, TRUE);
+		queue_colourise(doc);
 		if (type->priv->symbol_list_sort_mode == SYMBOLS_SORT_USE_PREVIOUS)
 			doc->priv->symbol_list_sort_mode = interface_prefs.symbols_sort_mode;
 		else

--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -90,6 +90,7 @@ typedef struct GeanyDocumentPrivate
 	/* Used so Undo/Redo works for encoding changes. */
 	FileEncoding	 saved_encoding;
 	gboolean		 colourise_needed;	/* use document.c:queue_colourise() instead */
+	guint			 keyword_hash;	/* hash of keyword string used for typename colourisation */
 	gint			 line_count;		/* Number of lines in the document. */
 	gint			 symbol_list_sort_mode;
 	/* indicates whether a file is on a remote filesystem, works only with GIO/GVfs */

--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -90,7 +90,6 @@ typedef struct GeanyDocumentPrivate
 	/* Used so Undo/Redo works for encoding changes. */
 	FileEncoding	 saved_encoding;
 	gboolean		 colourise_needed;	/* use document.c:queue_colourise() instead */
-	gboolean		 full_colourise;
 	gint			 line_count;		/* Number of lines in the document. */
 	gint			 symbol_list_sort_mode;
 	/* indicates whether a file is on a remote filesystem, works only with GIO/GVfs */

--- a/src/editor.c
+++ b/src/editor.c
@@ -4800,28 +4800,12 @@ static gboolean editor_check_colourise(GeanyEditor *editor)
 		return FALSE;
 
 	doc->priv->colourise_needed = FALSE;
+	sci_colourise(editor->sci, 0, -1);
 
-	if (doc->priv->full_colourise)
-	{
-		sci_colourise(editor->sci, 0, -1);
-
-		/* now that the current document is colourised, fold points are now accurate,
-		 * so force an update of the current function/tag. */
-		symbols_get_current_function(NULL, NULL);
-		ui_update_statusbar(NULL, -1);
-	}
-	else
-	{
-		gint start_line, end_line, start, end;
-
-		start_line = SSM(doc->editor->sci, SCI_GETFIRSTVISIBLELINE, 0, 0);
-		end_line = start_line + SSM(editor->sci, SCI_LINESONSCREEN, 0, 0);
-		start_line = SSM(editor->sci, SCI_DOCLINEFROMVISIBLE, start_line, 0);
-		end_line = SSM(editor->sci, SCI_DOCLINEFROMVISIBLE, end_line, 0);
-		start = sci_get_position_from_line(editor->sci, start_line);
-		end = sci_get_line_end_position(editor->sci, end_line);
-		sci_colourise(editor->sci, start, end);
-	}
+	/* now that the current document is colourised, fold points are now accurate,
+	 * so force an update of the current function/tag. */
+	symbols_get_current_function(NULL, NULL);
+	ui_update_statusbar(NULL, -1);
 
 	return TRUE;
 }


### PR DESCRIPTION
Alright, here's yet another fix of the colorization problem. I reverted the partial colorization patch completely and perform (full) recolorization when the typename list changes. I decided to detect the change of the typename list based on the string hash value - I believe it's sufficient and saves some memory per tab. The performance seems to be OK too (only when changing name of some type things get slower but there's no performance problem for normal code editing).

@elextr Could you test please?
@b4n Does it look OK to you?