### PR TITLE
Use our generated GTK bundle for travis

### DIFF
--- a/scripts/cross-build-mingw.sh
+++ b/scripts/cross-build-mingw.sh
@@ -15,8 +15,10 @@
 
 # You may change those
 HOST=i686-w64-mingw32
-GTK2_BUNDLE_ZIP="http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-bundle_2.24.10-20120208_win32.zip"
-GTK3_BUNDLE_ZIP="http://win32builder.gnome.org/gtk+-bundle_3.8.2-20131001_win32.zip"
+#GTK2_BUNDLE_ZIP="http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-bundle_2.24.10-20120208_win32.zip"
+GTK2_BUNDLE_ZIP="https://oc.tmartitz.de/index.php/s/6ekbdk5UUQPpYpa/download"
+#GTK3_BUNDLE_ZIP="http://win32builder.gnome.org/gtk+-bundle_3.8.2-20131001_win32.zip"
+GTK3_BUNDLE_ZIP="https://oc.tmartitz.de/index.php/s/TIHtvtl8zTHC0mh/download"
 BUILDDIR=_build-cross-mingw
 GTK3=no
 CONFIGUREFLAGS="--enable-nls"

--- a/scripts/cross-build-mingw.sh
+++ b/scripts/cross-build-mingw.sh
@@ -88,6 +88,8 @@ mkdir _deps
 fetch_and_unzip "$BUNDLE_ZIP" _deps
 # fixup the prefix= in the pkg-config files
 sed -i "s%^\(prefix=\).*$%\1$PWD/_deps%" _deps/lib/pkgconfig/*.pc
+# mingw-w64 doesn't know -pthread
+sed -i -e 's%-pthread%%g' _deps/lib/pkgconfig/*.pc
 
 export PKG_CONFIG_PATH="$PWD/_deps/lib/pkgconfig/"
 export CPPFLAGS="-I$PWD/_deps/include"

--- a/scripts/gtk-bundle-from-msys2.sh
+++ b/scripts/gtk-bundle-from-msys2.sh
@@ -36,6 +36,7 @@ libpng
 gettext
 glib2
 libwinpthread-git
+graphite2
 harfbuzz
 fontconfig
 freetype
@@ -171,14 +172,9 @@ cleanup_unnecessary_files() {
 	rmdir var/cache
 	rmdir var
 	# cleanup development and other unnecessary files
-	rm -rf include
 	rm -rf lib/gettext
 	rm -rf lib/libffi-*
-	rm -rf lib/pkgconfig
-	find lib -name '*.a' -delete
-	find lib -name '*.typelib' -delete
-	find lib -name '*.def' -delete
-	find lib -name '*.h' -delete
+	find lib -name '*.a' ! -name "*.dll.a" -delete
 	find lib -name '*.sh' -delete
 	# cleanup other unnecessary files
 	rm -rf share/aclocal
@@ -197,8 +193,8 @@ cleanup_unnecessary_files() {
 	rm -rf share/info
 	rm -rf share/man
 	rm -rf share/xml
-	# cleanup binaries and libs (delete anything except *.dll)
-	find bin ! -name '*.dll' -type f -delete
+	# cleanup binaries and libs (delete anything except *.dll and pkg-config.exe)
+	find bin ! -name '*.dll' ! -name pkg-config.exe -type f -delete
 	# cleanup empty directories
 	find . -type d -empty -delete
 }


### PR DESCRIPTION
This enables travis to download and use the gtk bundles which we also use for the win32 installer images.

The last commit is just for testing. Do not merge. I expect we want to put the bundle on geany.org