### PR TITLE
tagmanager: Fix UB around sequencing of side effects

### DIFF
--- a/tagmanager/ctags/get.c
+++ b/tagmanager/ctags/get.c
@@ -203,7 +203,8 @@ static void readIdentifier (int c, vString *const name)
 	do
 	{
 		vStringPut (name, c);
-	} while (c = fileGetc (), (c != EOF  &&  isident (c)));
+		c = fileGetc ();
+	} while (c != EOF && isident (c));
 	fileUngetc (c);
 	vStringTerminate (name);
 }


### PR DESCRIPTION
Functions with side effects (`fileGetc` in this case) cannot be guaranteed
to operate correctly on the left-hand side of a comma.