### PR TITLE
Win32: Add UI error message if an URL could not be opened

### DIFF
--- a/src/win32.c
+++ b/src/win32.c
@@ -799,7 +799,7 @@ void win32_open_browser(const gchar *uri)
 	if (ret <= 32)
 	{
 		gchar *err = g_win32_error_message(GetLastError());
-		/* TODO add a GUI warning that opening an URI failed */
+		ui_set_statusbar(TRUE, _("Failed to open URI \"%s\": %s"), uri, err);
 		g_warning("ShellExecute failed opening \"%s\" (code %d): %s", uri, ret, err);
 		g_free(err);
 	}


### PR DESCRIPTION
Followup of #937 to provide an error message in the UI when opening any URL in the browser on Windows failed.