### PR TITLE
Api tmtag

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -794,6 +794,7 @@ INPUT                  = @top_srcdir@/src/ \
                          @top_srcdir@/tagmanager/src/tm_source_file.h \
                          @top_srcdir@/tagmanager/src/tm_workspace.c \
                          @top_srcdir@/tagmanager/src/tm_workspace.h \
+                         @top_srcdir@/tagmanager/src/tm_tag.h \
                          @top_srcdir@/tagmanager/src/tm_parser.h
 
 # This tag can be used to specify the character encoding of the source files

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -97,7 +97,9 @@ doxygen_sources = \
 	$(top_srcdir)/src/*.[ch] \
 	$(top_srcdir)/plugins/geanyplugin.h \
 	$(top_srcdir)/tagmanager/src/tm_source_file.[ch] \
-	$(top_srcdir)/tagmanager/src/tm_workspace.[ch]
+	$(top_srcdir)/tagmanager/src/tm_workspace.[ch] \
+	$(top_srcdir)/tagmanager/src/tm_tag.h \
+	$(top_srcdir)/tagmanager/src/tm_parser.h
 
 Doxyfile.stamp: Doxyfile $(doxygen_sources)
 	$(AM_V_GEN)$(DOXYGEN) Doxyfile && echo "" > $@

--- a/tagmanager/src/tm_tag.h
+++ b/tagmanager/src/tm_tag.h
@@ -80,7 +80,10 @@ typedef enum
 #define TAG_IMPL_VIRTUAL 'v' /**< Virtual implementation */
 #define TAG_IMPL_UNKNOWN 'x' /**< Unknown implementation */
 
-typedef struct _TMTag
+/**
+ * The TMTag structure represents a single tag in the tag manager.
+ **/
+typedef struct TMTag
 {
 	char *name; /**< Name of tag */
 	TMTagType type; /**< Tag Type */

--- a/tagmanager/src/tm_workspace.h
+++ b/tagmanager/src/tm_workspace.h
@@ -25,10 +25,10 @@ G_BEGIN_DECLS
  **/
 typedef struct TMWorkspace
 {
-	GPtrArray *global_tags; /**< Global tags loaded at startup */
-	GPtrArray *source_files; /**< An array of TMSourceFile pointers */
-	GPtrArray *tags_array; /**< Sorted tags from all source files 
-		(just pointers to source file tags, the tag objects are owned by the source files) */
+	GPtrArray *global_tags; /**< Global tags loaded at startup. @elementtype{TMTag} */
+	GPtrArray *source_files; /**< An array of TMSourceFile pointers. @elementtype{TMSourceFile} */
+	GPtrArray *tags_array; /**< Sorted tags from all source files
+		(just pointers to source file tags, the tag objects are owned by the source files). @elementtype{TMTag} */
 	GPtrArray *typename_array; /* Typename tags for syntax highlighting (pointers owned by source files) */
 	GPtrArray *global_typename_array; /* Like above for global tags */
 } TMWorkspace;


### PR DESCRIPTION
Officially export TMTag which already contains documented members, and is in fact used by at least one plugin.