### PR TITLE
api: restore elementtype annotation for GeanyData::documents_array

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -186,6 +186,7 @@ typedef struct GeanyData
 	 * One reason is that notebook tabs can be reordered.
 	 * Use @c document_get_from_page() to lookup a document from a notebook tab number.
 	 *
+	 * @elementtype{GeanyDocument}
 	 * @see documents. */
 	GPtrArray					*documents_array;
 	/** Dynamic array of filetype pointers


### PR DESCRIPTION
This was dropped accidentally by 76ede69ef49c6f4ac3e11068a3cd5ecdb4425d1b.