### PR TITLE
Windows installer: C and GTK runtime installation

### DIFF
--- a/geany.nsi.in
+++ b/geany.nsi.in
@@ -132,6 +132,10 @@ Section "!Program Files" SEC01
 	SetOutPath "$INSTDIR\bin"
 	File "${RESOURCEDIR}\bin\Geany.exe"
 	File "${RESOURCEDIR}\bin\*Geany*.dll"
+	# non-GTK dependencies
+	File "gtk\bin\libgcc_s_dw*.dll"
+	File "gtk\bin\libstdc++-*.dll"
+	File "gtk\bin\libwinpthread*.dll"
 
 	SetOutPath "$INSTDIR\data"
 	File "${RESOURCEDIR}\data\GPL-2"


### PR DESCRIPTION
This is a RFC:

currently, the Windows installer offers to automatically install the bundled GTK runtime environment or to skip the installation of the corresponding files.
Actually, this option refers not only to the GTK runtime environment but also to the C/C++ runtime environment (libgcc_s_dw2-1.dll, libstdc++-6.dll, libwinpthread-1.dll) but this is not mentioned in the installer.

Some days ago, a Geany user reported this fact via PM to me, it is also reported in #976.


https://github.com/geany/geany/commit/acd4a92199e03b65a3f099cdc785bae89e379f20 will include the necessary C runtime libraries into the base installation, without any chance for the user to disable it. That way users still have to choice to use a seperate GTK stack but don't need to think about the C runtime.

https://github.com/geany/geany/commit/d92c690e6e24f6c15752818f85782bb7b8d5a72d will keep installing the bundled C runtime only when also the bundled GTK runtime is installed. But the title as well as the description of the option to omit installing those files is reworded to make more clear this affects the C *and* GTK runtime and skipping them might cause problems.


I don't have a strong opinion on which way we want to go, but certainly the current situation need to be improved.

Please do not merge yet. Both commits are mutually exclusive, we should merge only one of them.

Fixes #976.