### PR TITLE
Ignore generated file doc/doxygen_sqlite3.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ Makefile.in
 /doc/Doxyfile-gi
 /doc/Doxyfile.stamp
 /doc/Doxyfile-gi.stamp
+/doc/doxygen_*
 /doc/geany.1
 /doc/geany.html
 /doc/hacking.html


### PR DESCRIPTION
This file is created on Windows/MSYS2.

I'm not sure why I don't see this file on a Linux build but it is created on Windows.
Luckily it is already cleaned implicitly by doc/Makefile.am:114: 
`-rm -rf reference/ Doxyfile.stamp doxygen_*`.