### PR TITLE
Add support for generating GIR

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ AUTOMAKE_OPTIONS =	1.7
 
 ACLOCAL_AMFLAGS = -I m4
 AM_DISTCHECK_CONFIGURE_FLAGS = --enable-api-docs --enable-html-docs --enable-pdf-docs \
-                               --enable-gtkdoc-header
+                               --enable-gtkdoc-header --enable-introspection
 
 WIN32_BUILD_FILES = \
 	geany_private.rc \

--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,18 @@ GEANY_CHECK_GTKDOC_HEADER
 # libgeany
 GEANY_LIB_INIT
 
+# *optional* GObject-Introspection support
+m4_ifdef([GOBJECT_INTROSPECTION_CHECK],dnl
+         [GOBJECT_INTROSPECTION_CHECK([1.30.0])],dnl
+         [AC_ARG_ENABLE([introspection],
+                        [AS_HELP_STRING([--enable-introspection=no],
+                                        [Enable introspection for this build (not available)])])
+          AS_IF([test "x$enable_introspection" = xyes],
+                [AC_MSG_ERROR([GObject-Introspection support not built in])],
+                [AC_MSG_NOTICE([GObject-Introspection support not built in])])
+          AM_CONDITIONAL([HAVE_INTROSPECTION], [false])])
+GEANY_STATUS_ADD([Enable GObject-Introspection], [$enable_introspection])
+
 # Output
 AC_CONFIG_FILES([
 		Makefile

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -148,6 +148,75 @@ CLEAN_LOCAL_TARGETS += clean-gtkdoc-header-local
 clean-gtkdoc-header-local:
 	-rm -rf xml/ Doxyfile-gi Doxyfile-gi.stamp geany-gtkdoc.h geany-sciwrappers-gtkdoc.h
 
+if HAVE_INTROSPECTION
+
+INTROSPECTION_GIRS  = Geany-1.0-pre.gir GeanyScintilla-1.0-pre.gir
+SCANNERFLAGS        = --accept-unprefixed --c-include=geanyplugin.h
+
+if GTK3
+GTK_GIR = Gtk-3.0
+else
+GTK_GIR = Gtk-2.0
+endif
+
+Geany_1_0_pre_gir_NAMESPACE     = Geany
+Geany_1_0_pre_gir_VERSION       = 1.0
+Geany_1_0_pre_gir_INCLUDES      = $(GTK_GIR) GLib-2.0 GObject-2.0
+Geany_1_0_pre_gir_CFLAGS        = $(GTK_CFLAGS) -DG_IR_SCANNING \
+                                  -I $(top_srcdir)/src/ \
+                                  -I $(top_srcdir)/scintilla/include/ \
+                                  -DScintillaObject=GeanyScintillaScintillaObject
+Geany_1_0_pre_gir_LIBS          = ../src/libgeany.la
+Geany_1_0_pre_gir_FILES         = geany-gtkdoc.h
+Geany_1_0_pre_gir_SCANNERFLAGS  = $(SCANNERFLAGS) --include-uninstalled=GeanyScintilla-1.0.gir
+
+GeanyScintilla_1_0_pre_gir_NAMESPACE    = GeanyScintilla
+GeanyScintilla_1_0_pre_gir_VERSION      = 1.0
+GeanyScintilla_1_0_pre_gir_INCLUDES     = $(GTK_GIR) GLib-2.0 GObject-2.0
+GeanyScintilla_1_0_pre_gir_CFLAGS       = $(GTK_CFLAGS) -DG_IR_SCANNING \
+                                          -I $(top_srcdir)/src/ \
+                                          -I $(top_srcdir)/scintilla/include/ \
+                                          -include gtk/gtk.h
+GeanyScintilla_1_0_pre_gir_LIBS         = ../src/libgeany.la
+GeanyScintilla_1_0_pre_gir_FILES        = $(top_srcdir)/scintilla/include/ScintillaWidget.h \
+                                          $(top_srcdir)/scintilla/include/Scintilla.h \
+                                          $(top_srcdir)/scintilla/include/SciLexer.h \
+                                          geany-sciwrappers-gtkdoc-tmp.h
+GeanyScintilla_1_0_pre_gir_SCANNERFLAGS = $(SCANNERFLAGS)
+
+girdir          = $(datadir)/gir-1.0
+gir_DATA        = Geany-1.0.gir GeanyScintilla-1.0.gir
+typelibdir      = $(libdir)/girepository-1.0
+typelib_DATA    = Geany-1.0.typelib GeanyScintilla-1.0.typelib
+
+geany-sciwrappers-gtkdoc-tmp.h: geany-sciwrappers-gtkdoc.h
+	$(AM_V_GEN) $(SED) \
+		-e 's,sci_,scintilla_object__GI__MARK_,g' \
+		$< > $@
+
+GeanyScintilla-1.0.gir: GeanyScintilla-1.0-pre.gir
+	$(AM_V_GEN) cat $< \
+		| $(SED) -e 's,scintilla_object__GI__MARK_,sci_,g' \
+		| $(SED) -e 's,_GI__MARK_,,g' > $@
+
+Geany-1.0.gir: Geany-1.0-pre.gir
+	$(AM_V_GEN) $(SED) \
+		-e 's,GeanyScintillaScintillaObject,ScintillaObject,g' \
+		$< > $@
+
+ALL_LOCAL_TARGETS += $(gir_DATA) $(typelib_DATA)
+
+CLEANFILES = \
+	$(gir_DATA) $(typelib_DATA) \
+	Geany-1.0-pre.gir GeanyScintilla-1.0-pre.gir \
+	geany-sciwrappers-gtkdoc-tmp.h
+
+include $(INTROSPECTION_MAKEFILE)
+
+Geany-1.0-pre.gir: GeanyScintilla-1.0.gir
+
+endif HAVE_INTROSPECTION
+
 endif
 
 all-local: $(ALL_LOCAL_TARGETS)


### PR DESCRIPTION
Support here is *optional*, as in it does *not* require even the GIR M4 macros to be available -- but then the generated build system can't generate GIR.  This avoids a hard dependency on GIR for the cost of a configure-time conditional with basic fallback definitions.

As stated in the first commit, it's mostly ripped off Peasy, maybe there are additional change required, but it seems to mostly work.  However, I see a lot of scary warnings like these:
```
…/doc/geany-sciwrappers-gtkdoc-tmp.h:25: syntax error, unexpected '*', expecting ')' or ',' in 'void scintilla_object__GI__MARK_set_text (ScintillaObject *sci, const gchar *text);' at '*'
…/doc/geany-sciwrappers-gtkdoc-tmp.h:25: syntax error, unexpected ')', expecting ',' or ';' in 'void scintilla_object__GI__MARK_set_text (ScintillaObject *sci, const gchar *text);' at ')'
…/doc/geany-sciwrappers-gtkdoc-tmp.h:43: syntax error, unexpected '*', expecting ')' or ',' in 'void scintilla_object__GI__MARK_start_undo_action (ScintillaObject *sci);' at '*'
…/doc/geany-sciwrappers-gtkdoc-tmp.h:64: syntax error, unexpected '*', expecting ')' or ',' in 'void scintilla_object__GI__MARK_end_undo_action (ScintillaObject *sci);' at '*'
…/doc/geany-sciwrappers-gtkdoc-tmp.h:84: syntax error, unexpected '*', expecting ')' or ',' in 'void scintilla_object__GI__MARK_set_marker_at_line (ScintillaObject *sci, gint line_number, gint marker);' at '*'
```

@codebrainz @kugel- 