### PR TITLE
Allow VTE to be configured to not use bold fonts

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -6115,6 +6115,21 @@
                                 <property name="position">7</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="allow_bold">
+                                <property name="label" translatable="yes">Draw intense colors in bold fonts</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">Whether to use bold fonts when printing characters having the high-intensity attribute</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">8</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2718,6 +2718,10 @@ Don't use run script
     This can be useful if you already have a program running in the VTE
     like a Python console (e.g. ipython). Use this with care.
 
+Draw intense colors in bold fonts
+    Use bold fonts when displaying characters that have the high-intensity
+    attribute.
+
 
 Project management
 ------------------

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -533,6 +533,7 @@ static void save_dialog_prefs(GKeyFile *config)
 		g_key_file_set_boolean(config, "VTE", "run_in_vte", vc->run_in_vte);
 		g_key_file_set_boolean(config, "VTE", "skip_run_script", vc->skip_run_script);
 		g_key_file_set_boolean(config, "VTE", "cursor_blinks", vc->cursor_blinks);
+		g_key_file_set_boolean(config, "VTE", "allow_bold", vc->allow_bold);
 		g_key_file_set_integer(config, "VTE", "scrollback_lines", vc->scrollback_lines);
 		g_key_file_set_string(config, "VTE", "font", vc->font);
 		g_key_file_set_string(config, "VTE", "shell", vc->shell);
@@ -888,6 +889,7 @@ static void load_dialog_prefs(GKeyFile *config)
 		vc->run_in_vte = utils_get_setting_boolean(config, "VTE", "run_in_vte", FALSE);
 		vc->skip_run_script = utils_get_setting_boolean(config, "VTE", "skip_run_script", FALSE);
 		vc->cursor_blinks = utils_get_setting_boolean(config, "VTE", "cursor_blinks", FALSE);
+		vc->allow_bold = utils_get_setting_boolean(config, "VTE", "allow_bold", TRUE);
 		vc->scrollback_lines = utils_get_setting_integer(config, "VTE", "scrollback_lines", 500);
 		get_setting_color(config, "VTE", "colour_fore", &vc->colour_fore, "#ffffff");
 		get_setting_color(config, "VTE", "colour_back", &vc->colour_back, "#000000");

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -799,6 +799,9 @@ static void prefs_init_dialog(void)
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_cursor_blinks");
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), vc->cursor_blinks);
+
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "allow_bold");
+		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), vc->allow_bold);
 	}
 #endif
 }
@@ -1265,6 +1268,9 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 			widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_cursor_blinks");
 			vc->cursor_blinks = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+			widget = ui_lookup_widget(ui_widgets.prefs_dialog, "allow_bold");
+			vc->allow_bold = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
 			vte_apply_user_settings();
 		}

--- a/src/vte.c
+++ b/src/vte.c
@@ -132,6 +132,7 @@ struct VteFunctions
 	void (*vte_terminal_set_cursor_blinks) (VteTerminal *terminal, gboolean blink);
 	void (*vte_terminal_select_all) (VteTerminal *terminal);
 	void (*vte_terminal_set_audible_bell) (VteTerminal *terminal, gboolean is_audible);
+	void (*vte_terminal_set_allow_bold) (VteTerminal *terminal, gboolean allow_bold);
 	GtkAdjustment* (*vte_terminal_get_adjustment) (VteTerminal *terminal);
 #if GTK_CHECK_VERSION(3, 0, 0)
 	/* hack for the VTE 2.91 API using GdkRGBA: we wrap the API to keep using GdkColor on our side */
@@ -630,6 +631,7 @@ static gboolean vte_register_symbols(GModule *mod)
 		BIND_REQUIRED_SYMBOL(vte_terminal_set_cursor_blinks);
 	BIND_REQUIRED_SYMBOL(vte_terminal_select_all);
 	BIND_REQUIRED_SYMBOL(vte_terminal_set_audible_bell);
+	BIND_REQUIRED_SYMBOL(vte_terminal_set_allow_bold);
 	if (! BIND_SYMBOL(vte_terminal_get_adjustment))
 		/* vte_terminal_get_adjustment() is available since 0.9 and removed in 0.38 */
 		vf->vte_terminal_get_adjustment = default_vte_terminal_get_adjustment;
@@ -662,6 +664,7 @@ void vte_apply_user_settings(void)
 	vf->vte_terminal_set_color_background(VTE_TERMINAL(vc->vte), &vc->colour_back);
 	vf->vte_terminal_set_audible_bell(VTE_TERMINAL(vc->vte), prefs.beep_on_errors);
 	vte_set_cursor_blink_mode();
+	vf->vte_terminal_set_allow_bold(VTE_TERMINAL(vc->vte), vc->allow_bold);
 
 	override_menu_key();
 }

--- a/src/vte.h
+++ b/src/vte.h
@@ -55,6 +55,7 @@ typedef struct
 	gboolean enable_bash_keys;
 	gboolean cursor_blinks;
 	gboolean send_selection_unsafe;
+	gboolean allow_bold;
 	gint scrollback_lines;
 	gchar *shell;
 	gchar *font;


### PR DESCRIPTION
I prefer that the terminal doesn't use bold fonts when printing characters with bold or highlight attribute since it's easier to my eyes.

This patch allows VTE to be configured that way through `vte_terminal_set_allow_bold()`.

Preview: http://i.imgur.com/KPZwPyi.png?1
