### PR TITLE
Added keybinding for Delete from line start to current position

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3347,6 +3347,9 @@ Delete current line(s)          Ctrl-K                    Deletes the current li
 Delete to line end              Ctrl-Shift-Delete         Deletes from the current caret position to the
                                                           end of the current line.
 
+Delete to line start            Ctrl-Shift-BackSpace      Deletes from the beginning of the line to the 
+                                                          current caret position.
+
 Duplicate line or selection     Ctrl-D                    Duplicates the current line or selection.
 
 Transpose current line                                    Transposes the current line with the previous one.

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3347,7 +3347,7 @@ Delete current line(s)          Ctrl-K                    Deletes the current li
 Delete to line end              Ctrl-Shift-Delete         Deletes from the current caret position to the
                                                           end of the current line.
 
-Delete to line start            Ctrl-Shift-BackSpace      Deletes from the beginning of the line to the 
+Delete to line start            Ctrl-Shift-BackSpace      Deletes from the beginning of the line to the
                                                           current caret position.
 
 Duplicate line or selection     Ctrl-D                    Duplicates the current line or selection.

--- a/src/editor.c
+++ b/src/editor.c
@@ -4815,6 +4815,7 @@ static void setup_sci_keys(ScintillaObject *sci)
 	sci_clear_cmdkey(sci, 'L' | (SCMOD_CTRL << 16)); /* line cut */
 	sci_clear_cmdkey(sci, 'L' | (SCMOD_CTRL << 16) | (SCMOD_SHIFT << 16)); /* line delete */
 	sci_clear_cmdkey(sci, SCK_DELETE | (SCMOD_CTRL << 16) | (SCMOD_SHIFT << 16)); /* line to end delete */
+	sci_clear_cmdkey(sci, SCK_BACK | (SCMOD_CTRL << 16) | (SCMOD_SHIFT << 16)); /* line to beginning delete */
 	sci_clear_cmdkey(sci, '/' | (SCMOD_CTRL << 16)); /* Previous word part */
 	sci_clear_cmdkey(sci, '\\' | (SCMOD_CTRL << 16)); /* Next word part */
 	sci_clear_cmdkey(sci, SCK_UP | (SCMOD_CTRL << 16)); /* scroll line up */

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -386,6 +386,9 @@ static void init_default_kb(void)
 	add_kb(group, GEANY_KEYS_EDITOR_DELETELINETOEND, NULL,
 		GDK_Delete, GDK_SHIFT_MASK | GEANY_PRIMARY_MOD_MASK, "edit_deletelinetoend",
 		_("Delete to line end"), NULL);
+	add_kb(group, GEANY_KEYS_EDITOR_DELETELINETOBEGINNING, NULL,
+		GDK_BackSpace, GDK_SHIFT_MASK | GEANY_PRIMARY_MOD_MASK, "edit_deletelinetobegin",
+		_("Delete to beginning of line"), NULL);
 	/* Note: transpose may fit better in format group, but that would break the API */
 	add_kb(group, GEANY_KEYS_EDITOR_TRANSPOSELINE, NULL,
 		0, 0, "edit_transposeline", _("_Transpose Current Line"), NULL);
@@ -2133,6 +2136,9 @@ static gboolean cb_func_editor_action(guint key_id)
 			break;
 		case GEANY_KEYS_EDITOR_DELETELINETOEND:
 			sci_send_command(doc->editor->sci, SCI_DELLINERIGHT);
+			break;
+		case GEANY_KEYS_EDITOR_DELETELINETOBEGINNING:
+			sci_send_command(doc->editor->sci, SCI_DELLINELEFT);
 			break;
 		case GEANY_KEYS_EDITOR_TRANSPOSELINE:
 			sci_send_command(doc->editor->sci, SCI_LINETRANSPOSE);

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -185,6 +185,7 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_GOTO_TAGDEFINITION,				/**< Keybinding. */
 	GEANY_KEYS_SEARCH_NEXTMESSAGE,				/**< Keybinding. */
 	GEANY_KEYS_EDITOR_DELETELINETOEND,			/**< Keybinding. */
+	GEANY_KEYS_EDITOR_DELETELINETOBEGINNING,			/**< Keybinding. */
 	GEANY_KEYS_FORMAT_AUTOINDENT,				/**< Keybinding. */
 	GEANY_KEYS_FILE_OPENSELECTED,				/**< Keybinding. */
 	GEANY_KEYS_GOTO_BACK,						/**< Keybinding. */

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -185,7 +185,7 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_GOTO_TAGDEFINITION,				/**< Keybinding. */
 	GEANY_KEYS_SEARCH_NEXTMESSAGE,				/**< Keybinding. */
 	GEANY_KEYS_EDITOR_DELETELINETOEND,			/**< Keybinding. */
-	GEANY_KEYS_EDITOR_DELETELINETOBEGINNING,			/**< Keybinding. */
+	GEANY_KEYS_EDITOR_DELETELINETOBEGINNING,	/**< Keybinding. */
 	GEANY_KEYS_FORMAT_AUTOINDENT,				/**< Keybinding. */
 	GEANY_KEYS_FILE_OPENSELECTED,				/**< Keybinding. */
 	GEANY_KEYS_GOTO_BACK,						/**< Keybinding. */


### PR DESCRIPTION
Some time ago I posted an e-mail into the Geany-users mailing list asking for a keybinding for deleting from the begining of the line to the current position. I got some good answers and suggestions, and, some months later, here I come with the implementation ready to be used.
I've tested it and it looks fine.

Anything else, just let me know. I didn't touch any of the translation files, should I?