### PR TITLE
Custom theming fixes for Adwaita 3.20/GTK 3.20

### DIFF
--- a/data/geany.css
+++ b/data/geany.css
@@ -20,7 +20,8 @@
 	color: #fff;
 	background: #ff6666;
 }
-#geany-search-entry-no-match:selected {
+#geany-search-entry-no-match:selected /* GTK < 3.20 */,
+#geany-search-entry-no-match selection /* GTK >= 3.20 */ {
 	background-color: #771111;
 }
 

--- a/data/geany.gtkrc
+++ b/data/geany.gtkrc
@@ -20,6 +20,7 @@ widget "GeanyDialogSearch.*.geany-search-entry-no-match" style "geany-monospace"
 style "geany-search-entry-no-match-style" {
 	base[NORMAL] = "#ffff66666666"
 	text[NORMAL] = "#ffffffffffff"
+	base[SELECTED] = "#777711111111"
 	# try and remove the entry background image on pixmap engine so that our
 	# background color is visible, and we don't end up with white text on white
 	# background (workaround for Adwaita 3.20).

--- a/data/geany.gtkrc
+++ b/data/geany.gtkrc
@@ -20,6 +20,15 @@ widget "GeanyDialogSearch.*.geany-search-entry-no-match" style "geany-monospace"
 style "geany-search-entry-no-match-style" {
 	base[NORMAL] = "#ffff66666666"
 	text[NORMAL] = "#ffffffffffff"
+	# try and remove the entry background image on pixmap engine so that our
+	# background color is visible, and we don't end up with white text on white
+	# background (workaround for Adwaita 3.20).
+	engine "pixmap" {
+		image {
+			function = FLAT_BOX
+			detail   = "entry_bg"
+		}
+	}
 }
 widget "*.geany-search-entry-no-match" style "geany-search-entry-no-match-style"
 


### PR DESCRIPTION
Fixes #1135, and ~~may help for~~ #1101 ~~(?)~~

This also restores the custom selection color there too that got lost with GTK 3.20, and adds it to GTK2 too (for some reason it never was there).