### PR TITLE
Test whether the C++ compiler works by compiling a test program

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,11 +30,7 @@ AC_PROG_CC_C99
 AM_PROG_CC_C_O
 
 AC_PROG_CXX
-# check for C++ compiler explicitly and fail if none is found, do this check
-# after AC_PROG_CXX has set the CXX environment variable
-if ! which $CXX >/dev/null 2>&1; then
-	AC_MSG_ERROR([No C++ compiler found. Please install a C++ compiler.])
-fi
+GEANY_PROG_CXX
 
 AC_PROG_INSTALL
 AC_PROG_LN_S

--- a/m4/geany-prog-cxx.m4
+++ b/m4/geany-prog-cxx.m4
@@ -1,0 +1,20 @@
+dnl GEANY_PROG_CXX
+dnl Check for a working C++ compiler.
+dnl like AC_PROG_CXX, but makes sure the compiler actually works instead of
+dnl falling back on a reasonable default only.
+dnl
+dnl You must call AC_PROG_CXX yourself before this macro.
+AC_DEFUN([GEANY_PROG_CXX],
+[
+	AC_REQUIRE([AC_PROG_CXX])
+
+	AC_LANG_PUSH([C++])
+	AC_MSG_CHECKING([whether the C++ compiler works])
+	AC_COMPILE_IFELSE(
+			[AC_LANG_PROGRAM([[class Test {public: static int main() {return 0;}};]],
+			                 [[Test::main();]])],
+			[AC_MSG_RESULT([yes])],
+			[AC_MSG_RESULT([no])
+			 AC_MSG_ERROR([The C++ compiler $CXX does not work. Please install a working C++ compiler or define CXX to the appropriate value.])])
+	AC_LANG_POP([C++])
+])


### PR DESCRIPTION
This is more reliable than using `which`, which doesn't work if the CXX
environment variable is set to something else than an executable (e.g
contains options), and is apparently less portable on some systems.

See:
 * http://lists.geany.org/pipermail/devel/2009-September/001367.html,
   which lead to 5bb28825aadb43ea8ba536c34970d53860b50759.
 * https://sourceforge.net/p/geany/bugs/455/, which lead to a revert
   of the above, 5b9605a9d6d799629b8ed3163596069c8c948b06.

Fixes #829.