### PR TITLE
Add 'File->Open Files Recursively'

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -6369,6 +6369,15 @@
                           </object>
                         </child>
                         <child>
+                          <object class="GtkImageMenuItem" id="menu_open_files_recursively1">
+                            <property name="label" translatable="yes">Open Files Recursivel_y</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="use_underline">True</property>
+                            <signal name="activate" handler="on_open_files_recursively1_activate" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
                           <object class="GtkMenuItem" id="menu_open_selected_file1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -104,6 +104,12 @@
     <property name="stock">gtk-open</property>
     <property name="icon-size">1</property>
   </object>
+  <object class="GtkImage" id="image_open_files_recursively1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-open</property>
+    <property name="icon-size">1</property>
+  </object>
   <object class="GtkImage" id="image3192">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -6374,6 +6380,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="use_underline">True</property>
+                            <property name="image">image_open_files_recursively1</property>
                             <signal name="activate" handler="on_open_files_recursively1_activate" swapped="no"/>
                           </object>
                         </child>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3313,6 +3313,8 @@ New                             Ctrl-N  (C)               Creates a new file.
 
 Open                            Ctrl-O  (C)               Opens a file.
 
+Open files recursively                                    Opens files recursively.
+
 Open selected file              Ctrl-Shift-O              Opens the selected filename.
 
 Re-open last closed tab                                   Re-opens the last closed document tab.

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -313,7 +313,14 @@ static void on_info1_activate(GtkMenuItem *menuitem, gpointer user_data)
 /* open file */
 void on_open1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	dialogs_show_open_file();
+	dialogs_show_open_file(FALSE);
+}
+
+
+/* open files recursively */
+void on_open_files_recursively1_activate(GtkMenuItem *menuitem, gpointer user_data)
+{
+	dialogs_show_open_file(TRUE);
 }
 
 

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -41,6 +41,8 @@ void on_quit1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_open1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
+void on_open_files_recursively1_activate(GtkMenuItem *menuitem, gpointer user_data);
+
 void on_save_all1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_close1_activate(GtkMenuItem *menuitem, gpointer user_data);

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -152,6 +152,15 @@ static gboolean open_file_dialog_handle_response(GtkWidget *dialog, gint respons
 			charset = encodings[filesel_state.open.encoding_idx].charset;
 
 		filelist = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(dialog));
+		
+		if (filelist == NULL && recursive)
+		{
+			gchar *path = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog));
+
+			if (path)
+				filelist = g_slist_append(filelist, path);
+		}
+
 		if (filelist != NULL)
 		{
 			const gchar *first = filelist->data;
@@ -395,8 +404,6 @@ static GtkWidget *create_open_file_dialog(gboolean recursive)
 	{
 		title = _("Open Files Recursively");
 		open_button_text = _("_Open Recursively");
-		g_assert(GEANY_RESPONSE_OPEN_RECURSIVELY != GTK_RESPONSE_ACCEPT);
-		g_assert(GEANY_RESPONSE_OPEN_RECURSIVELY != GTK_RESPONSE_CANCEL);
 		open_response_id = GEANY_RESPONSE_OPEN_RECURSIVELY;
 		view_button_text = _("_View Recursively");
 	}

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -129,7 +129,7 @@ static gboolean open_file_dialog_handle_response(GtkWidget *dialog, gint respons
 {
 	gboolean ret = TRUE;
 
-	if (response == GTK_RESPONSE_ACCEPT || response == GEANY_RESPONSE_VIEW || GEANY_RESPONSE_OPEN_RECURSIVELY)
+	if (response == GTK_RESPONSE_ACCEPT || response == GEANY_RESPONSE_VIEW || response == GEANY_RESPONSE_OPEN_RECURSIVELY)
 	{
 		GSList *filelist;
 		GeanyFiletype *ft = NULL;
@@ -395,6 +395,8 @@ static GtkWidget *create_open_file_dialog(gboolean recursive)
 	{
 		title = _("Open Files Recursively");
 		open_button_text = _("_Open Recursively");
+		g_assert(GEANY_RESPONSE_OPEN_RECURSIVELY != GTK_RESPONSE_ACCEPT);
+		g_assert(GEANY_RESPONSE_OPEN_RECURSIVELY != GTK_RESPONSE_CANCEL);
 		open_response_id = GEANY_RESPONSE_OPEN_RECURSIVELY;
 		view_button_text = _("_View Recursively");
 	}

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -520,8 +520,9 @@ void dialogs_show_open_file(gboolean recursive)
 			gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(dialog),
 					app->project->base_path, NULL);
 
-		while (!open_file_dialog_handle_response(dialog,
-			gtk_dialog_run(GTK_DIALOG(dialog)), recursive));
+		while (!open_file_dialog_handle_response(dialog, gtk_dialog_run(GTK_DIALOG(dialog)),
+				recursive))
+			;
 		gtk_widget_destroy(dialog);
 	}
 	g_free(initdir);

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -491,7 +491,7 @@ static void open_file_dialog_apply_settings(GtkWidget *dialog)
 /* This shows the file selection dialog to open a file. */
 void dialogs_show_open_file(gboolean recursive)
 {
-	gchar *initdir, *title;
+	gchar *initdir;
 
 	/* set dialog directory to the current file's directory, if present */
 	initdir = utils_get_current_file_dir_utf8();
@@ -505,7 +505,7 @@ void dialogs_show_open_file(gboolean recursive)
 
 #ifdef G_OS_WIN32
 	if (interface_prefs.use_native_windows_dialogs && !recursive)
-		win32_show_document_open_dialog(GTK_WINDOW(main_widgets.window), title, initdir);
+		win32_show_document_open_dialog(GTK_WINDOW(main_widgets.window), _("Open File"), initdir);
 	else
 #endif
 	{

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -62,7 +62,8 @@
 enum
 {
 	GEANY_RESPONSE_RENAME,
-	GEANY_RESPONSE_VIEW
+	GEANY_RESPONSE_VIEW,
+	GEANY_RESPONSE_OPEN_RECURSIVELY
 };
 
 
@@ -124,11 +125,11 @@ static void file_chooser_set_filter_idx(GtkFileChooser *chooser, guint idx)
 }
 
 
-static gboolean open_file_dialog_handle_response(GtkWidget *dialog, gint response)
+static gboolean open_file_dialog_handle_response(GtkWidget *dialog, gint response, gboolean recursive)
 {
 	gboolean ret = TRUE;
 
-	if (response == GTK_RESPONSE_ACCEPT || response == GEANY_RESPONSE_VIEW)
+	if (response == GTK_RESPONSE_ACCEPT || response == GEANY_RESPONSE_VIEW || GEANY_RESPONSE_OPEN_RECURSIVELY)
 	{
 		GSList *filelist;
 		GeanyFiletype *ft = NULL;
@@ -163,7 +164,21 @@ static gboolean open_file_dialog_handle_response(GtkWidget *dialog, gint respons
 			}
 			else
 			{
-				document_open_files(filelist, ro, ft, charset);
+				if (recursive)
+				{
+					GtkFileFilter *filter = gtk_file_chooser_get_filter(GTK_FILE_CHOOSER(dialog));
+					GError *error;
+
+					document_open_files_recursively(filelist, ro, ft, charset, filter, &error);
+
+					if (error)
+					{
+						dialogs_show_msgbox(GTK_MESSAGE_ERROR, "%s", error->message);
+						g_error_free(error);
+					}
+				}
+				else
+					document_open_files(filelist, ro, ft, charset);
 			}
 			g_slist_foreach(filelist, (GFunc) g_free, NULL);	/* free filenames */
 		}
@@ -368,23 +383,40 @@ static GtkWidget *add_file_open_extra_widget(GtkWidget *dialog)
 }
 
 
-static GtkWidget *create_open_file_dialog(void)
+static GtkWidget *create_open_file_dialog(gboolean recursive)
 {
 	GtkWidget *dialog;
 	GtkWidget *viewbtn;
 	GSList *node;
+	const gchar *title, *open_button_text, *view_button_text;
+	gint open_response_id;
 
-	dialog = gtk_file_chooser_dialog_new(_("Open File"), GTK_WINDOW(main_widgets.window),
+	if (recursive)
+	{
+		title = _("Open Files Recursively");
+		open_button_text = _("_Open Recursively");
+		open_response_id = GEANY_RESPONSE_OPEN_RECURSIVELY;
+		view_button_text = _("_View Recursively");
+	}
+	else
+	{
+		title = _("Open File");
+		open_button_text = GTK_STOCK_OPEN;
+		open_response_id = GTK_RESPONSE_ACCEPT;
+		view_button_text = C_("Open dialog action", "_View");
+	}
+
+	dialog = gtk_file_chooser_dialog_new(title, GTK_WINDOW(main_widgets.window),
 			GTK_FILE_CHOOSER_ACTION_OPEN, NULL, NULL);
 	gtk_widget_set_name(dialog, "GeanyDialog");
 
-	viewbtn = gtk_dialog_add_button(GTK_DIALOG(dialog), C_("Open dialog action", "_View"), GEANY_RESPONSE_VIEW);
+	viewbtn = gtk_dialog_add_button(GTK_DIALOG(dialog), view_button_text, GEANY_RESPONSE_VIEW);
 	gtk_widget_set_tooltip_text(viewbtn,
 		_("Opens the file in read-only mode. If you choose more than one file to open, all files will be opened read-only."));
 
 	gtk_dialog_add_buttons(GTK_DIALOG(dialog),
 		GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-		GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT, NULL);
+		open_button_text, open_response_id, NULL);
 	gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_ACCEPT);
 
 	gtk_widget_set_size_request(dialog, -1, 460);
@@ -448,9 +480,9 @@ static void open_file_dialog_apply_settings(GtkWidget *dialog)
 
 
 /* This shows the file selection dialog to open a file. */
-void dialogs_show_open_file(void)
+void dialogs_show_open_file(gboolean recursive)
 {
-	gchar *initdir;
+	gchar *initdir, *title;
 
 	/* set dialog directory to the current file's directory, if present */
 	initdir = utils_get_current_file_dir_utf8();
@@ -463,12 +495,12 @@ void dialogs_show_open_file(void)
 	SETPTR(initdir, utils_get_locale_from_utf8(initdir));
 
 #ifdef G_OS_WIN32
-	if (interface_prefs.use_native_windows_dialogs)
-		win32_show_document_open_dialog(GTK_WINDOW(main_widgets.window), _("Open File"), initdir);
+	if (interface_prefs.use_native_windows_dialogs && !recursive)
+		win32_show_document_open_dialog(GTK_WINDOW(main_widgets.window), title, initdir);
 	else
 #endif
 	{
-		GtkWidget *dialog = create_open_file_dialog();
+		GtkWidget *dialog = create_open_file_dialog(recursive);
 
 		open_file_dialog_apply_settings(dialog);
 
@@ -480,7 +512,7 @@ void dialogs_show_open_file(void)
 					app->project->base_path, NULL);
 
 		while (!open_file_dialog_handle_response(dialog,
-			gtk_dialog_run(GTK_DIALOG(dialog))));
+			gtk_dialog_run(GTK_DIALOG(dialog)), recursive));
 		gtk_widget_destroy(dialog);
 	}
 	g_free(initdir);

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -52,7 +52,7 @@ gchar *dialogs_show_input(const gchar *title, GtkWindow *parent,
 typedef void (*GeanyInputCallback)(const gchar *text, gpointer data);
 
 
-void dialogs_show_open_file(void);
+void dialogs_show_open_file(gboolean recursive);
 
 gboolean dialogs_show_unsaved_file(GeanyDocument *doc);
 

--- a/src/document.c
+++ b/src/document.c
@@ -1631,12 +1631,9 @@ void document_open_files_recursively(const GSList *filenames, gboolean readonly,
 
 						if (filename)
 						{
-							filter_info.filename = g_file_info_get_attribute_byte_string(file_info,
-									G_FILE_ATTRIBUTE_STANDARD_NAME);
-							filter_info.display_name = g_file_info_get_attribute_string(file_info,
-									G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME);
-							filter_info.mime_type = g_file_info_get_attribute_string(file_info,
-									G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE);
+							filter_info.filename = g_file_info_get_name(file_info);
+							filter_info.display_name = g_file_info_get_display_name(file_info);
+							filter_info.mime_type = g_file_info_get_content_type(file_info);
 
 							if (gtk_file_filter_filter(filter, &filter_info))
 								document_open_file(filename, readonly, ft, forced_enc);

--- a/src/document.c
+++ b/src/document.c
@@ -1593,9 +1593,6 @@ void document_open_files_recursively(const GSList *filenames, gboolean readonly,
 	{
 		filename = item->data;
 
-		if (g_file_test(filename, G_FILE_TEST_IS_SYMLINK))
-			continue;
-
 		if (g_file_test(filename, G_FILE_TEST_IS_DIR))
 		{
 			file = g_file_new_for_path(filename);

--- a/src/document.c
+++ b/src/document.c
@@ -1582,13 +1582,11 @@ void document_open_files_recursively(const GSList *filenames, gboolean readonly,
 	guint enum_stack_index = 0;
 
 	const gchar* attributes = G_FILE_ATTRIBUTE_STANDARD_TYPE "," G_FILE_ATTRIBUTE_STANDARD_NAME ","
-			G_FILE_ATTRIBUTE_STANDARD_TARGET_URI "," G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME ","
-			G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE;
+			G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME "," G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE;
 
 	GtkFileFilterInfo filter_info;
-
-	filter_info.contains = GTK_FILE_FILTER_FILENAME|GTK_FILE_FILTER_URI
-			|GTK_FILE_FILTER_DISPLAY_NAME|GTK_FILE_FILTER_MIME_TYPE;
+	filter_info.contains = GTK_FILE_FILTER_FILENAME|GTK_FILE_FILTER_DISPLAY_NAME|GTK_FILE_FILTER_MIME_TYPE;
+	filter_info.uri = NULL;
 
 	for (item = filenames; item != NULL; item = g_slist_next(item))
 	{
@@ -1635,8 +1633,6 @@ void document_open_files_recursively(const GSList *filenames, gboolean readonly,
 						{
 							filter_info.filename = g_file_info_get_attribute_byte_string(file_info,
 									G_FILE_ATTRIBUTE_STANDARD_NAME);
-							filter_info.uri = g_file_info_get_attribute_string(file_info,
-									G_FILE_ATTRIBUTE_STANDARD_TARGET_URI);
 							filter_info.display_name = g_file_info_get_attribute_string(file_info,
 									G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME);
 							filter_info.mime_type = g_file_info_get_attribute_string(file_info,

--- a/src/document.c
+++ b/src/document.c
@@ -1576,8 +1576,9 @@ void document_open_files_recursively(const GSList *filenames, gboolean readonly,
 	GFileType file_type;
 	GError *my_error = NULL;
 
-	enum { ENUM_STACK_LIMIT = 100 };
-	GFileEnumerator *enum_stack[ENUM_STACK_LIMIT];
+	const guint RECURSION_LIMIT = 100;
+	const guint ENUM_STACK_SIZE = RECURSION_LIMIT - 1;
+	GFileEnumerator *enum_stack[ENUM_STACK_SIZE];
 	guint enum_stack_index = 0;
 
 	const gchar* attributes = G_FILE_ATTRIBUTE_STANDARD_TYPE "," G_FILE_ATTRIBUTE_STANDARD_NAME ","
@@ -1615,7 +1616,7 @@ void document_open_files_recursively(const GSList *filenames, gboolean readonly,
 
 					if (file_type == G_FILE_TYPE_DIRECTORY)
 					{
-						if (enum_stack_index == ENUM_STACK_LIMIT)
+						if (enum_stack_index == ENUM_STACK_SIZE)
 						{
 							my_error = g_error_new(0, 0, "Recursion depth limit reached");
 							break;

--- a/src/document.h
+++ b/src/document.h
@@ -323,6 +323,9 @@ void document_set_data(GeanyDocument *doc, const gchar *key, gpointer data);
 void document_set_data_full(GeanyDocument *doc, const gchar *key,
 	gpointer data, GDestroyNotify free_func);
 
+void document_open_files_recursively(const GSList *filenames, gboolean readonly, GeanyFiletype *ft,
+		const gchar *forced_enc, GtkFileFilter *filter, GError **error);
+
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -333,6 +333,8 @@ static void init_default_kb(void)
 		GDK_n, GEANY_PRIMARY_MOD_MASK, "menu_new", _("New"), "menu_new1");
 	add_kb(group, GEANY_KEYS_FILE_OPEN, NULL,
 		GDK_o, GEANY_PRIMARY_MOD_MASK, "menu_open", _("Open"), "menu_open1");
+	add_kb(group, GEANY_KEYS_FILE_OPENRECURSIVE, NULL,
+		0, 0, "menu_open_files_recursively", _("Open files recursively"), "menu_open_files_recursively1");
 	add_kb(group, GEANY_KEYS_FILE_OPENSELECTED, NULL,
 		GDK_o, GDK_SHIFT_MASK | GEANY_PRIMARY_MOD_MASK, "menu_open_selected",
 		_("Open selected file"), "menu_open_selected_file1");
@@ -1428,6 +1430,9 @@ static gboolean cb_func_file_action(guint key_id)
 			break;
 		case GEANY_KEYS_FILE_OPEN:
 			on_open1_activate(NULL, NULL);
+			break;
+		case GEANY_KEYS_FILE_OPENRECURSIVE:
+			on_open_files_recursively1_activate(NULL, NULL);
 			break;
 		case GEANY_KEYS_FILE_OPENSELECTED:
 			on_menu_open_selected_file1_activate(NULL, NULL);

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -274,6 +274,7 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_FORMAT_SENDTOCMD8,				/**< Keybinding. */
 	GEANY_KEYS_FORMAT_SENDTOCMD9,				/**< Keybinding. */
 	GEANY_KEYS_EDITOR_DELETELINETOBEGINNING,	/**< Keybinding. */
+	GEANY_KEYS_FILE_OPENRECURSIVE,				/**< Keybinding. */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 


### PR DESCRIPTION
This feature is most helpful when recursively opening multiple files in the second instance of Geany where opening from the command-line doesn't help, since it just makes the first instance open them.  Having another instance is necessary if you want to open another project.

This feature recognizes the specified filter in the dialog box, and uses it to select enumerated files to be opened.

Snapshot: http://imgur.com/a/DtiRI
