### PR TITLE
Improve template command error message

### DIFF
--- a/src/templates.c
+++ b/src/templates.c
@@ -615,8 +615,9 @@ static gchar *run_command(const gchar *command, const gchar *file_name,
 	}
 	else
 	{
-		g_warning(_("Cannot execute command \"%s\" from the template: %s. "
-			"Check the path in the template."), command, error->message);
+		g_warning(_("Cannot execute template command \"%s\". "
+			"Hint: incorrect paths in the command are a common cause of errors. "
+			"Error: %s."), command, error->message);
 		g_error_free(error);
 	}
 


### PR DESCRIPTION
The previous string was a bit confusing what the placeholders
could mean. There was an error in the German translation where
the second placeholder was interpreted as template name instead
of the error message.
This change should make it more clear and also put the error message
to the end of the string.