### PR TITLE
Fixes spelling mistake in German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -2010,7 +2010,7 @@ msgstr "Zeilenen_den festlegen"
 
 #: ../data/geany.glade.h:425
 msgid "Convert and Set to _CR/LF (Windows)"
-msgstr "Auf _CR/LF setzen und umwandeln (Winows)"
+msgstr "Auf _CR/LF setzen und umwandeln (Windows)"
 
 #: ../data/geany.glade.h:426
 msgid "Convert and Set to _LF (Unix)"


### PR DESCRIPTION
This PR fixes a spelling mistake in the German translation (`geany.glade.h:425`), where *Windows* was spelled incorrectly.