### PR TITLE
Search: Add help buttons to the dialogs

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -941,11 +941,7 @@ void on_toolbutton_goto_clicked(GtkAction *action, gpointer user_data)
 
 void on_help1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	gchar *uri;
-
-	uri = utils_get_help_url(NULL);
-	utils_open_browser(uri);
-	g_free(uri);
+	utils_open_help(NULL);
 }
 
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1588,7 +1588,6 @@ static void on_prefs_print_page_header_toggled(GtkToggleButton *togglebutton, gp
 
 static void open_preferences_help(void)
 {
-	gchar *uri;
 	const gchar *label, *suffix = NULL;
 	GtkNotebook *notebook = GTK_NOTEBOOK(
 		ui_lookup_widget(ui_widgets.prefs_dialog, "notebook2"));
@@ -1624,9 +1623,7 @@ static void open_preferences_help(void)
 	else if (utils_str_equal(label, _("Terminal")))
 		suffix = "#terminal-vte-preferences";
 
-	uri = utils_get_help_url(suffix);
-	utils_open_browser(uri);
-	g_free(uri);
+	utils_open_help(suffix);
 }
 
 

--- a/src/search.c
+++ b/src/search.c
@@ -867,6 +867,7 @@ static void create_fif_dialog(void)
 
 	fif_dlg.dialog = gtk_dialog_new_with_buttons(
 		_("Find in Files"), GTK_WINDOW(main_widgets.window), GTK_DIALOG_DESTROY_WITH_PARENT,
+		GTK_STOCK_HELP, GTK_RESPONSE_HELP,
 		GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, NULL);
 	vbox = ui_dialog_vbox_new(GTK_DIALOG(fif_dlg.dialog));
 	gtk_box_set_spacing(GTK_BOX(vbox), 9);
@@ -1641,6 +1642,8 @@ on_find_in_files_dialog_response(GtkDialog *dialog, gint response,
 		else
 			ui_set_statusbar(FALSE, _("No text to find."));
 	}
+	else if (response == GTK_RESPONSE_HELP)
+		utils_open_help("#find-in-files");
 	else
 		gtk_widget_hide(fif_dlg.dialog);
 }

--- a/src/search.c
+++ b/src/search.c
@@ -463,6 +463,7 @@ static void create_find_dialog(void)
 
 	find_dlg.dialog = gtk_dialog_new_with_buttons(_("Find"),
 		GTK_WINDOW(main_widgets.window), GTK_DIALOG_DESTROY_WITH_PARENT,
+		GTK_STOCK_HELP, GTK_RESPONSE_HELP,
 		GTK_STOCK_CLOSE, GTK_RESPONSE_CANCEL, NULL);
 	vbox = ui_dialog_vbox_new(GTK_DIALOG(find_dlg.dialog));
 	gtk_widget_set_name(find_dlg.dialog, "GeanyDialogSearch");
@@ -1298,6 +1299,8 @@ on_find_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 	if (response == GTK_RESPONSE_CANCEL || response == GTK_RESPONSE_DELETE_EVENT)
 		gtk_widget_hide(find_dlg.dialog);
+	else if (response == GTK_RESPONSE_HELP)
+		utils_open_help("#find");
 	else
 	{
 		GeanyDocument *doc = document_get_current();

--- a/src/search.c
+++ b/src/search.c
@@ -617,6 +617,7 @@ static void create_replace_dialog(void)
 
 	replace_dlg.dialog = gtk_dialog_new_with_buttons(_("Replace"),
 		GTK_WINDOW(main_widgets.window), GTK_DIALOG_DESTROY_WITH_PARENT,
+		GTK_STOCK_HELP, GTK_RESPONSE_HELP,
 		GTK_STOCK_CLOSE, GTK_RESPONSE_CANCEL, NULL);
 	vbox = ui_dialog_vbox_new(GTK_DIALOG(replace_dlg.dialog));
 	gtk_box_set_spacing(GTK_BOX(vbox), 9);
@@ -1451,6 +1452,11 @@ on_replace_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 	if (response == GTK_RESPONSE_CANCEL || response == GTK_RESPONSE_DELETE_EVENT)
 	{
 		gtk_widget_hide(replace_dlg.dialog);
+		return;
+	}
+	else if (response == GTK_RESPONSE_HELP)
+	{
+		utils_open_help("#replace");
 		return;
 	}
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1886,7 +1886,7 @@ GSList *utils_get_config_files(const gchar *subdir)
 
 /* Suffix can be NULL or a string which should be appended to the Help URL like
  * an anchor link, e.g. "#some_anchor". */
-gchar *utils_get_help_url(const gchar *suffix)
+static gchar *utils_get_help_url(const gchar *suffix)
 {
 	gint skip;
 	gchar *uri;
@@ -1912,6 +1912,16 @@ gchar *utils_get_help_url(const gchar *suffix)
 	}
 
 	return uri;
+}
+
+
+void utils_open_help(const gchar *suffix)
+{
+	gchar *uri;
+
+	uri = utils_get_help_url(suffix);
+	utils_open_browser(uri);
+	g_free(uri);
 }
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -301,7 +301,7 @@ gchar **utils_strv_join(gchar **first, gchar **second) G_GNUC_WARN_UNUSED_RESULT
 
 GSList *utils_get_config_files(const gchar *subdir);
 
-gchar *utils_get_help_url(const gchar *suffix);
+void utils_open_help(const gchar *suffix);
 
 gboolean utils_str_has_upper(const gchar *str);
 


### PR DESCRIPTION
Add a Help button to *Find*, *Replace* and *Find in Files* dialogs.

![find](https://cloud.githubusercontent.com/assets/793526/17500228/f456727e-5dd3-11e6-9288-c139e1caf114.png)
![replace](https://cloud.githubusercontent.com/assets/793526/17500226/f44ef4f4-5dd3-11e6-83b6-bbe1d71d2f3f.png)
![fif](https://cloud.githubusercontent.com/assets/793526/17500227/f453231c-5dd3-11e6-8263-b8f50fe054d7.png)

The *Replace* dialog might be a problem because it has many buttons, so it takes a lot of place.  It's a little better when icons on buttons are not shown (which is the default under GNOME, but not MATE AFAIK), but it's worse in some locales where the *Search & Replace* label takes more space.  Opinions?


---
BTW, one can see that we have a *Close* button for *Find* and *Replace*, but a *Cancel* one for *Find in Files*.  Looks odd.