### PR TITLE
Escape format arguments passed to ui_label_set_markup()

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1462,6 +1462,8 @@ void ui_update_view_editor_menu_items(void)
  *
  * @return @transfer{floating} The frame widget, setting the alignment container for
  * packing child widgets.
+ * 
+ * @deprecated 1.29: Use GTK API directly
  **/
 GEANY_API_SYMBOL
 GtkWidget *ui_frame_new_with_alignment(const gchar *label_text, GtkWidget **alignment)

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2835,7 +2835,7 @@ void ui_label_set_markup(GtkLabel *label, const gchar *format, ...)
 	gchar *text;
 
 	va_start(a, format);
-	text = g_strdup_vprintf(format, a);
+	text = g_markup_vprintf_escaped(format, a);
 	va_end(a);
 
 	gtk_label_set_text(label, text);
@@ -2896,7 +2896,7 @@ void ui_menu_add_document_items_sorted(GtkMenu *menu, GeanyDocument *active,
 	GtkWidget *menu_item, *menu_item_label, *image;
 	GeanyDocument *doc;
 	guint i, len;
-	gchar *base_name, *label;
+	gchar *base_name;
 	GPtrArray *sorted_documents;
 
 	len = (guint) gtk_notebook_get_n_pages(GTK_NOTEBOOK(main_widgets.notebook));
@@ -2930,11 +2930,7 @@ void ui_menu_add_document_items_sorted(GtkMenu *menu, GeanyDocument *active,
 		gtk_widget_set_name(menu_item_label, document_get_status_widget_class(doc));
 
 		if (doc == active)
-		{
-			label = g_markup_escape_text(base_name, -1);
-			ui_label_set_markup(GTK_LABEL(menu_item_label), "<b>%s</b>", label);
-			g_free(label);
-		}
+			ui_label_set_markup(GTK_LABEL(menu_item_label), "<b>%s</b>", base_name);
 
 		g_free(base_name);
 	}

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -101,8 +101,6 @@ GeanyMainWidgets;
 
 GtkWidget *ui_dialog_vbox_new(GtkDialog *dialog);
 
-GtkWidget *ui_frame_new_with_alignment(const gchar *label_text, GtkWidget **alignment);
-
 void ui_set_statusbar(gboolean log, const gchar *format, ...) G_GNUC_PRINTF (2, 3);
 
 void ui_table_add_row(GtkTable *table, gint row, ...) G_GNUC_NULL_TERMINATED;
@@ -143,6 +141,8 @@ void ui_tree_view_set_tooltip_text_column(GtkTreeView *tree_view, gint column);
 
 
 #ifndef GEANY_DISABLE_DEPRECATED
+GtkWidget *ui_frame_new_with_alignment(const gchar *label_text, GtkWidget **alignment) GEANY_DEPRECATED;
+
 void ui_widget_set_tooltip_text(GtkWidget *widget, const gchar *text) GEANY_DEPRECATED_FOR(gtk_widget_set_tooltip_text);
 #endif	/* GEANY_DISABLE_DEPRECATED */
 


### PR DESCRIPTION
A good example of why is the changes to `ui_menu_add_document_items_sorted()`: the *format* should contain markup, but the placeholders should not (they will generally be mostly unknown text).

This however has one side effect on the API: [`ui_frame_new_with_alignment()`](https://www.geany.org/manual/reference/ui__utils_8h.html#a740aa567ff6b9e3829565193e8317706)'s first argument is passed as-is to `ui_label_new_bold()`, which itself is implemented using `ui_label_set_markup()`.  The documentation of `ui_frame_new_with_alignment()` never suggested it supported markup (and none of the users I could fine did expect that), but it's a change in how the API works.
IMO it's a bug fix (markup control character no longer break frame labels), but someone could see it as a feature removal (although it'd be somewhat dishonest as it never was advertized).