### PR TITLE
Better check for a file change on disk by also monitoring the file size.

### DIFF
--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -104,6 +104,8 @@ typedef struct GeanyDocumentPrivate
 	time_t			 last_check;
 	/* Modification time of the document on disk, only used when legacy file monitoring is used. */
 	time_t			 mtime;
+	/* Filesize of the document on disk, only used when legacy file monitoring is used. */
+	guint64			 file_size;
 	/* ID of the idle callback updating the tag list */
 	guint			 tag_list_update_source;
 	/* Whether it's temporarily protected (read-only and saving needs confirmation). Does


### PR DESCRIPTION
Geany only checks if the modification time is newer than the previous fetched.
Having a script generating files and touching those files with an explicit time stamp, geany does not notify the file has changed.
So it's a better check to monitor modification time AND file size.