### PR TITLE
Make document_rename_file() return a gboolean; Abort save if rename fails

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -497,9 +497,9 @@ static gboolean handle_save_as(const gchar *utf8_filename, gboolean rename_file)
 	if (doc->file_name != NULL)
 	{
 		if (rename_file)
-		{
-			document_rename_file(doc, utf8_filename);
-		}
+			if (! document_rename_file(doc, utf8_filename))
+				return FALSE;
+
 		if (doc->tm_file)
 		{
 			/* create a new tm_source_file object otherwise tagmanager won't work correctly */

--- a/src/document.c
+++ b/src/document.c
@@ -1736,10 +1736,11 @@ static void replace_header_filename(GeanyDocument *doc)
  *  @param doc The current document which should be renamed.
  *  @param new_filename The new filename in UTF-8 encoding.
  *
+ *  @return @c TRUE if file was renamed or @c FALSE otherwise.
  *  @since 0.16
  **/
 GEANY_API_SYMBOL
-void document_rename_file(GeanyDocument *doc, const gchar *new_filename)
+gboolean document_rename_file(GeanyDocument *doc, const gchar *new_filename)
 {
 	gchar *old_locale_filename = utils_get_locale_from_utf8(doc->file_name);
 	gchar *new_locale_filename = utils_get_locale_from_utf8(new_filename);
@@ -1757,6 +1758,7 @@ void document_rename_file(GeanyDocument *doc, const gchar *new_filename)
 	}
 	g_free(old_locale_filename);
 	g_free(new_locale_filename);
+	return (result == 0);
 }
 
 

--- a/src/document.h
+++ b/src/document.h
@@ -206,7 +206,7 @@ GeanyDocument *document_index(gint idx);
 
 gboolean document_save_file_as(GeanyDocument *doc, const gchar *utf8_fname);
 
-void document_rename_file(GeanyDocument *doc, const gchar *new_filename);
+gboolean document_rename_file(GeanyDocument *doc, const gchar *new_filename);
 
 const GdkColor *document_get_status_color(GeanyDocument *doc);
 


### PR DESCRIPTION
Virtually it's more correct that if `document_rename_file()` fails, `handle_save_as()` would no longer proceed to call `document_save_file_as()`.   I'm not sure if unexpected things in runtime would not happen if `document_save_file_as()` somehow succeeds even if `document_rename_file()` fails, but it's certainly not what the user would be expecting.   I.e., being able to save to the target file but the originally file remains to exist.  This might be a rare case, but it still stands to be programmatically incorrect.

I decided to include changing `document_rename_file()` itself in this update rather than creating another non-API function, because I believe it's the only correct way to do it.  Sooner or later, it would have to be changed anyway.  And I don't think it's likeable that an old non-gboolean function which no code would use would exist just for the sake of not breaking the API.  This should also be helpful to future code that might rely on it.
