### PR TITLE
Port more prefs to Stash

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -200,6 +200,17 @@ static void init_pref_groups(void)
 	stash_group_add_toggle_button(group, &interface_prefs.use_native_windows_dialogs,
 		"use_native_windows_dialogs", FALSE, "check_native_windows_dialogs");
 
+	stash_group_add_toggle_button(group, &editor_prefs.long_line_enabled,
+		"long_line_enabled", TRUE, "check_long_line");
+	stash_group_add_radio_buttons(group, &editor_prefs.long_line_type,
+		"long_line_type", 0,
+		"radio_long_line_line", 0,
+		"radio_long_line_background", 1,
+		NULL);
+	stash_group_add_spin_button_integer(group, &editor_prefs.long_line_column,
+		"long_line_column", 72, "spin_long_line");
+	stash_group_add_string(group, &editor_prefs.long_line_color, "long_line_color", "#C2EBC2");
+
 	/* fonts */
 	stash_group_add_string(group, &interface_prefs.tagbar_font,
 		"tagbar_font", GEANY_DEFAULT_FONT_SYMBOL_LIST);
@@ -466,10 +477,6 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "show_line_endings", editor_prefs.show_line_endings);
 	g_key_file_set_boolean(config, PACKAGE, "show_markers_margin", editor_prefs.show_markers_margin);
 	g_key_file_set_boolean(config, PACKAGE, "show_linenumber_margin", editor_prefs.show_linenumber_margin);
-	g_key_file_set_boolean(config, PACKAGE, "long_line_enabled", editor_prefs.long_line_enabled);
-	g_key_file_set_integer(config, PACKAGE, "long_line_type", editor_prefs.long_line_type);
-	g_key_file_set_integer(config, PACKAGE, "long_line_column", editor_prefs.long_line_column);
-	g_key_file_set_string(config, PACKAGE, "long_line_color", editor_prefs.long_line_color);
 
 	/* editor */
 	g_key_file_set_integer(config, PACKAGE, "symbolcompletion_max_height", editor_prefs.symbolcompletion_max_height);
@@ -783,15 +790,6 @@ static void load_dialog_prefs(GKeyFile *config)
 	file_prefs.show_tab_cross = utils_get_setting_boolean(config, PACKAGE, "show_tab_cross", TRUE);
 
 	/* display, editor */
-	editor_prefs.long_line_enabled = utils_get_setting_boolean(config, PACKAGE, "long_line_enabled", TRUE);
-	editor_prefs.long_line_type = utils_get_setting_integer(config, PACKAGE, "long_line_type", 0);
-	if (editor_prefs.long_line_type == 2) /* backward compatibility */
-	{
-		editor_prefs.long_line_type = 0;
-		editor_prefs.long_line_enabled = FALSE;
-	}
-	editor_prefs.long_line_color = utils_get_setting_string(config, PACKAGE, "long_line_color", "#C2EBC2");
-	editor_prefs.long_line_column = utils_get_setting_integer(config, PACKAGE, "long_line_column", 72);
 	editor_prefs.symbolcompletion_min_chars = utils_get_setting_integer(config, PACKAGE, "symbolcompletion_min_chars", GEANY_MIN_SYMBOLLIST_CHARS);
 	editor_prefs.symbolcompletion_max_height = utils_get_setting_integer(config, PACKAGE, "symbolcompletion_max_height", GEANY_MAX_SYMBOLLIST_HEIGHT);
 	editor_prefs.line_wrapping = utils_get_setting_boolean(config, PACKAGE, "line_wrapping", FALSE); /* default is off for better performance */
@@ -982,6 +980,13 @@ static void load_dialog_prefs(GKeyFile *config)
 
 	/* read stash prefs */
 	settings_action(config, SETTING_READ);
+
+	/* display, editor backward compatibility */
+	if (editor_prefs.long_line_type == 2)
+	{
+		editor_prefs.long_line_type = 0;
+		editor_prefs.long_line_enabled = FALSE;
+	}
 
 	/* build menu
 	 * after stash prefs as it uses some of them */

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -200,6 +200,17 @@ static void init_pref_groups(void)
 	stash_group_add_toggle_button(group, &interface_prefs.use_native_windows_dialogs,
 		"use_native_windows_dialogs", FALSE, "check_native_windows_dialogs");
 
+	stash_group_add_toggle_button(group, &ui_prefs.sidebar_visible,
+		"sidebar_visible", TRUE, "check_sidebar_visible");
+	stash_group_add_toggle_button(group, &interface_prefs.sidebar_symbol_visible,
+		"sidebar_symbol_visible", TRUE, "check_list_symbol");
+	stash_group_add_toggle_button(group, &interface_prefs.sidebar_openfiles_visible,
+		"sidebar_openfiles_visible", TRUE, "check_list_openfiles");
+	stash_group_add_toggle_button(group, &interface_prefs.statusbar_visible,
+		"statusbar_visible", TRUE, "check_statusbar_visible");
+	stash_group_add_boolean(group, &ui_prefs.msgwindow_visible,
+		"msgwindow_visible", TRUE);
+
 	stash_group_add_toggle_button(group, &editor_prefs.long_line_enabled,
 		"long_line_enabled", TRUE, "check_long_line");
 	stash_group_add_radio_buttons(group, &editor_prefs.long_line_type,
@@ -462,8 +473,6 @@ static void save_dialog_prefs(GKeyFile *config)
 	/* Some of the key names are not consistent, but this is for backwards compatibility */
 
 	/* interface */
-	g_key_file_set_boolean(config, PACKAGE, "sidebar_symbol_visible", interface_prefs.sidebar_symbol_visible);
-	g_key_file_set_boolean(config, PACKAGE, "sidebar_openfiles_visible", interface_prefs.sidebar_openfiles_visible);
 	g_key_file_set_boolean(config, PACKAGE, "show_notebook_tabs", interface_prefs.show_notebook_tabs);
 	g_key_file_set_boolean(config, PACKAGE, "show_tab_cross", file_prefs.show_tab_cross);
 	g_key_file_set_boolean(config, PACKAGE, "tab_order_ltr", file_prefs.tab_order_ltr);
@@ -579,9 +588,6 @@ static void save_dialog_prefs(GKeyFile *config)
 
 static void save_ui_prefs(GKeyFile *config)
 {
-	g_key_file_set_boolean(config, PACKAGE, "sidebar_visible", ui_prefs.sidebar_visible);
-	g_key_file_set_boolean(config, PACKAGE, "statusbar_visible", interface_prefs.statusbar_visible);
-	g_key_file_set_boolean(config, PACKAGE, "msgwindow_visible", ui_prefs.msgwindow_visible);
 	g_key_file_set_boolean(config, PACKAGE, "fullscreen", ui_prefs.fullscreen);
 
 	/* get the text from the scribble textview */
@@ -781,9 +787,6 @@ static void load_dialog_prefs(GKeyFile *config)
 	/* interface */
 	interface_prefs.tab_pos_editor = utils_get_setting_integer(config, PACKAGE, "tab_pos_editor", GTK_POS_TOP);
 	interface_prefs.tab_pos_msgwin = utils_get_setting_integer(config, PACKAGE, "tab_pos_msgwin",GTK_POS_LEFT);
-	interface_prefs.sidebar_symbol_visible = utils_get_setting_boolean(config, PACKAGE, "sidebar_symbol_visible", TRUE);
-	interface_prefs.sidebar_openfiles_visible = utils_get_setting_boolean(config, PACKAGE, "sidebar_openfiles_visible", TRUE);
-	interface_prefs.statusbar_visible = utils_get_setting_boolean(config, PACKAGE, "statusbar_visible", TRUE);
 	file_prefs.tab_order_ltr = utils_get_setting_boolean(config, PACKAGE, "tab_order_ltr", TRUE);
 	file_prefs.tab_order_beside = utils_get_setting_boolean(config, PACKAGE, "tab_order_beside", FALSE);
 	interface_prefs.show_notebook_tabs = utils_get_setting_boolean(config, PACKAGE, "show_notebook_tabs", TRUE);
@@ -1002,8 +1005,6 @@ static void load_ui_prefs(GKeyFile *config)
 	gint *geo;
 	gsize geo_len;
 
-	ui_prefs.sidebar_visible = utils_get_setting_boolean(config, PACKAGE, "sidebar_visible", TRUE);
-	ui_prefs.msgwindow_visible = utils_get_setting_boolean(config, PACKAGE, "msgwindow_visible", TRUE);
 	ui_prefs.fullscreen = utils_get_setting_boolean(config, PACKAGE, "fullscreen", FALSE);
 	ui_prefs.custom_date_format = utils_get_setting_string(config, PACKAGE, "custom_date_format", "");
 	ui_prefs.custom_commands = g_key_file_get_string_list(config, PACKAGE, "custom_commands", NULL, NULL);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -343,6 +343,17 @@ static void init_pref_groups(void)
 	stash_group_add_spin_button_integer(group, &file_prefs.disk_check_timeout,
 		"disk_check_timeout", GEANY_DISK_CHECK_TIMEOUT, "spin_disk_check");
 
+	stash_group_add_combo_box(group, &file_prefs.default_eol_character,
+		"default_eol_character", GEANY_DEFAULT_EOL_CHARACTER, "combo_eol");
+	stash_group_add_toggle_button(group, &file_prefs.replace_tabs,
+		"pref_editor_replace_tabs", FALSE, "check_replace_tabs");
+	stash_group_add_toggle_button(group, &file_prefs.ensure_convert_new_lines,
+		"pref_editor_ensure_convert_line_endings", FALSE, "check_ensure_convert_new_lines");
+	stash_group_add_toggle_button(group, &file_prefs.final_new_line,
+		"pref_editor_new_line", TRUE, "check_new_line");
+	stash_group_add_toggle_button(group, &file_prefs.strip_trailing_spaces,
+		"pref_editor_trail_space", FALSE, "check_trailing_spaces");
+
 	/* various geany prefs */
 	group = stash_group_new(PACKAGE);
 	configuration_add_various_pref_group(group);
@@ -539,11 +550,6 @@ static void save_dialog_prefs(GKeyFile *config)
 		g_key_file_set_string(config, PACKAGE, "pref_editor_default_open_encoding", "none");
 	else
 		g_key_file_set_string(config, PACKAGE, "pref_editor_default_open_encoding", encodings[file_prefs.default_open_encoding].charset);
-	g_key_file_set_integer(config, PACKAGE, "default_eol_character", file_prefs.default_eol_character);
-	g_key_file_set_boolean(config, PACKAGE, "pref_editor_new_line", file_prefs.final_new_line);
-	g_key_file_set_boolean(config, PACKAGE, "pref_editor_ensure_convert_line_endings", file_prefs.ensure_convert_new_lines);
-	g_key_file_set_boolean(config, PACKAGE, "pref_editor_replace_tabs", file_prefs.replace_tabs);
-	g_key_file_set_boolean(config, PACKAGE, "pref_editor_trail_space", file_prefs.strip_trailing_spaces);
 
 	/* toolbar */
 	g_key_file_set_boolean(config, PACKAGE, "pref_toolbar_show", toolbar_prefs.visible);
@@ -838,11 +844,6 @@ static void load_dialog_prefs(GKeyFile *config)
 
 		g_free(tmp_string);
 	}
-	file_prefs.default_eol_character = utils_get_setting_integer(config, PACKAGE, "default_eol_character", GEANY_DEFAULT_EOL_CHARACTER);
-	file_prefs.replace_tabs = utils_get_setting_boolean(config, PACKAGE, "pref_editor_replace_tabs", FALSE);
-	file_prefs.ensure_convert_new_lines = utils_get_setting_boolean(config, PACKAGE, "pref_editor_ensure_convert_line_endings", FALSE);
-	file_prefs.final_new_line = utils_get_setting_boolean(config, PACKAGE, "pref_editor_new_line", TRUE);
-	file_prefs.strip_trailing_spaces = utils_get_setting_boolean(config, PACKAGE, "pref_editor_trail_space", FALSE);
 
 	/* toolbar */
 	toolbar_prefs.visible = utils_get_setting_boolean(config, PACKAGE, "pref_toolbar_show", TRUE);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -200,6 +200,14 @@ static void init_pref_groups(void)
 	stash_group_add_toggle_button(group, &interface_prefs.use_native_windows_dialogs,
 		"use_native_windows_dialogs", FALSE, "check_native_windows_dialogs");
 
+	/* fonts */
+	stash_group_add_string(group, &interface_prefs.tagbar_font,
+		"tagbar_font", GEANY_DEFAULT_FONT_SYMBOL_LIST);
+	stash_group_add_string(group, &interface_prefs.msgwin_font,
+		"msgwin_font", GEANY_DEFAULT_FONT_MSG_WINDOW);
+	stash_group_add_string(group, &interface_prefs.editor_font,
+		"editor_font", GEANY_DEFAULT_FONT_EDITOR);
+
 	/* tools (in legacy section PACKAGE rather than "tools") */
 	stash_group_add_entry(group, &tool_prefs.context_action_cmd,
 			"context_action_cmd", "", "entry_contextaction");
@@ -445,9 +453,6 @@ static void save_dialog_prefs(GKeyFile *config)
 	/* interface */
 	g_key_file_set_boolean(config, PACKAGE, "sidebar_symbol_visible", interface_prefs.sidebar_symbol_visible);
 	g_key_file_set_boolean(config, PACKAGE, "sidebar_openfiles_visible", interface_prefs.sidebar_openfiles_visible);
-	g_key_file_set_string(config, PACKAGE, "editor_font", interface_prefs.editor_font);
-	g_key_file_set_string(config, PACKAGE, "tagbar_font", interface_prefs.tagbar_font);
-	g_key_file_set_string(config, PACKAGE, "msgwin_font", interface_prefs.msgwin_font);
 	g_key_file_set_boolean(config, PACKAGE, "show_notebook_tabs", interface_prefs.show_notebook_tabs);
 	g_key_file_set_boolean(config, PACKAGE, "show_tab_cross", file_prefs.show_tab_cross);
 	g_key_file_set_boolean(config, PACKAGE, "tab_order_ltr", file_prefs.tab_order_ltr);
@@ -776,9 +781,6 @@ static void load_dialog_prefs(GKeyFile *config)
 	file_prefs.tab_order_beside = utils_get_setting_boolean(config, PACKAGE, "tab_order_beside", FALSE);
 	interface_prefs.show_notebook_tabs = utils_get_setting_boolean(config, PACKAGE, "show_notebook_tabs", TRUE);
 	file_prefs.show_tab_cross = utils_get_setting_boolean(config, PACKAGE, "show_tab_cross", TRUE);
-	interface_prefs.editor_font = utils_get_setting_string(config, PACKAGE, "editor_font", GEANY_DEFAULT_FONT_EDITOR);
-	interface_prefs.tagbar_font = utils_get_setting_string(config, PACKAGE, "tagbar_font", GEANY_DEFAULT_FONT_SYMBOL_LIST);
-	interface_prefs.msgwin_font = utils_get_setting_string(config, PACKAGE, "msgwin_font", GEANY_DEFAULT_FONT_MSG_WINDOW);
 
 	/* display, editor */
 	editor_prefs.long_line_enabled = utils_get_setting_boolean(config, PACKAGE, "long_line_enabled", TRUE);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -174,6 +174,36 @@ static void init_pref_groups(void)
 		"radio_msgwin_horizontal", GTK_ORIENTATION_HORIZONTAL,
 		NULL);
 
+	/* startup */
+	stash_group_add_toggle_button(group, &prefs.load_session,
+		"pref_main_load_session", TRUE, "check_load_session");
+	stash_group_add_toggle_button(group, &project_prefs.project_session,
+		"pref_main_project_session", TRUE, "check_project_session");
+	stash_group_add_toggle_button(group, &project_prefs.project_file_in_basedir,
+		"pref_main_project_file_in_basedir", FALSE, "check_project_file_in_basedir");
+	stash_group_add_toggle_button(group, &prefs.save_winpos,
+		"pref_main_save_winpos", TRUE, "check_save_win_pos");
+
+	/* behaviour */
+	stash_group_add_toggle_button(group, &prefs.confirm_exit,
+		"pref_main_confirm_exit", FALSE, "check_ask_for_quit");
+	stash_group_add_toggle_button(group, &prefs.suppress_status_messages,
+		"pref_main_suppress_status_messages", FALSE, "check_suppress_status_msgs");
+	stash_group_add_toggle_button(group, &prefs.switch_to_status,
+		"switch_msgwin_pages", FALSE, "check_switch_pages");
+	stash_group_add_toggle_button(group, &prefs.beep_on_errors,
+		"beep_on_errors", TRUE, "check_beep");
+	stash_group_add_toggle_button(group, &prefs.auto_focus,
+		"auto_focus", FALSE, "check_auto_focus");
+
+	/* interface */
+	stash_group_add_toggle_button(group, &interface_prefs.use_native_windows_dialogs,
+		"use_native_windows_dialogs", FALSE, "check_native_windows_dialogs");
+
+	/* tools (in legacy section PACKAGE rather than "tools") */
+	stash_group_add_entry(group, &tool_prefs.context_action_cmd,
+			"context_action_cmd", "", "entry_contextaction");
+
 	/* editor display */
 	stash_group_add_toggle_button(group, &interface_prefs.highlighting_invert_all,
 		"highlighting_invert_all", FALSE, "check_highlighting_invert");
@@ -412,17 +442,6 @@ static void save_dialog_prefs(GKeyFile *config)
 
 	/* Some of the key names are not consistent, but this is for backwards compatibility */
 
-	/* general */
-	g_key_file_set_boolean(config, PACKAGE, "pref_main_load_session", prefs.load_session);
-	g_key_file_set_boolean(config, PACKAGE, "pref_main_project_session", project_prefs.project_session);
-	g_key_file_set_boolean(config, PACKAGE, "pref_main_project_file_in_basedir", project_prefs.project_file_in_basedir);
-	g_key_file_set_boolean(config, PACKAGE, "pref_main_save_winpos", prefs.save_winpos);
-	g_key_file_set_boolean(config, PACKAGE, "pref_main_confirm_exit", prefs.confirm_exit);
-	g_key_file_set_boolean(config, PACKAGE, "pref_main_suppress_status_messages", prefs.suppress_status_messages);
-	g_key_file_set_boolean(config, PACKAGE, "switch_msgwin_pages", prefs.switch_to_status);
-	g_key_file_set_boolean(config, PACKAGE, "beep_on_errors", prefs.beep_on_errors);
-	g_key_file_set_boolean(config, PACKAGE, "auto_focus", prefs.auto_focus);
-
 	/* interface */
 	g_key_file_set_boolean(config, PACKAGE, "sidebar_symbol_visible", interface_prefs.sidebar_symbol_visible);
 	g_key_file_set_boolean(config, PACKAGE, "sidebar_openfiles_visible", interface_prefs.sidebar_openfiles_visible);
@@ -435,7 +454,6 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "tab_order_beside", file_prefs.tab_order_beside);
 	g_key_file_set_integer(config, PACKAGE, "tab_pos_editor", interface_prefs.tab_pos_editor);
 	g_key_file_set_integer(config, PACKAGE, "tab_pos_msgwin", interface_prefs.tab_pos_msgwin);
-	g_key_file_set_boolean(config, PACKAGE, "use_native_windows_dialogs", interface_prefs.use_native_windows_dialogs);
 
 	/* display */
 	g_key_file_set_boolean(config, PACKAGE, "show_indent_guide", editor_prefs.show_indent_guide);
@@ -501,7 +519,6 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_string(config, "tools", "terminal_cmd", tool_prefs.term_cmd ? tool_prefs.term_cmd : "");
 	g_key_file_set_string(config, "tools", "browser_cmd", tool_prefs.browser_cmd ? tool_prefs.browser_cmd : "");
 	g_key_file_set_string(config, "tools", "grep_cmd", tool_prefs.grep_cmd ? tool_prefs.grep_cmd : "");
-	g_key_file_set_string(config, PACKAGE, "context_action_cmd", tool_prefs.context_action_cmd);
 
 	/* build menu */
 	build_save_menu(config, NULL, GEANY_BCS_PREF);
@@ -749,17 +766,6 @@ static void load_dialog_prefs(GKeyFile *config)
 			g_key_file_set_boolean(config, "search", "pref_search_hide_find_dialog", suppress_search_dialogs);
 	}
 
-	/* general */
-	prefs.confirm_exit = utils_get_setting_boolean(config, PACKAGE, "pref_main_confirm_exit", FALSE);
-	prefs.suppress_status_messages = utils_get_setting_boolean(config, PACKAGE, "pref_main_suppress_status_messages", FALSE);
-	prefs.load_session = utils_get_setting_boolean(config, PACKAGE, "pref_main_load_session", TRUE);
-	project_prefs.project_session = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_session", TRUE);
-	project_prefs.project_file_in_basedir = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_file_in_basedir", FALSE);
-	prefs.save_winpos = utils_get_setting_boolean(config, PACKAGE, "pref_main_save_winpos", TRUE);
-	prefs.beep_on_errors = utils_get_setting_boolean(config, PACKAGE, "beep_on_errors", TRUE);
-	prefs.switch_to_status = utils_get_setting_boolean(config, PACKAGE, "switch_msgwin_pages", FALSE);
-	prefs.auto_focus = utils_get_setting_boolean(config, PACKAGE, "auto_focus", FALSE);
-
 	/* interface */
 	interface_prefs.tab_pos_editor = utils_get_setting_integer(config, PACKAGE, "tab_pos_editor", GTK_POS_TOP);
 	interface_prefs.tab_pos_msgwin = utils_get_setting_integer(config, PACKAGE, "tab_pos_msgwin",GTK_POS_LEFT);
@@ -773,7 +779,6 @@ static void load_dialog_prefs(GKeyFile *config)
 	interface_prefs.editor_font = utils_get_setting_string(config, PACKAGE, "editor_font", GEANY_DEFAULT_FONT_EDITOR);
 	interface_prefs.tagbar_font = utils_get_setting_string(config, PACKAGE, "tagbar_font", GEANY_DEFAULT_FONT_SYMBOL_LIST);
 	interface_prefs.msgwin_font = utils_get_setting_string(config, PACKAGE, "msgwin_font", GEANY_DEFAULT_FONT_MSG_WINDOW);
-	interface_prefs.use_native_windows_dialogs = utils_get_setting_boolean(config, PACKAGE, "use_native_windows_dialogs", FALSE);
 
 	/* display, editor */
 	editor_prefs.long_line_enabled = utils_get_setting_boolean(config, PACKAGE, "long_line_enabled", TRUE);
@@ -945,8 +950,6 @@ static void load_dialog_prefs(GKeyFile *config)
 	tool_prefs.term_cmd = cmd;
 	tool_prefs.browser_cmd = utils_get_setting_string(config, "tools", "browser_cmd", GEANY_DEFAULT_TOOLS_BROWSER);
 	tool_prefs.grep_cmd = utils_get_setting_string(config, "tools", "grep_cmd", GEANY_DEFAULT_TOOLS_GREP);
-
-	tool_prefs.context_action_cmd = utils_get_setting_string(config, PACKAGE, "context_action_cmd", "");
 
 	/* printing */
 	tmp_string2 = g_find_program_in_path(GEANY_DEFAULT_TOOLS_PRINTCMD);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -282,6 +282,8 @@ static void init_pref_groups(void)
 		"radio_virtualspace_selection", GEANY_VIRTUAL_SPACE_SELECTION,
 		"radio_virtualspace_always", GEANY_VIRTUAL_SPACE_ALWAYS,
 		NULL);
+	stash_group_add_toggle_button(group, &editor_prefs.auto_complete_symbols,
+		"auto_complete_symbols", TRUE, "check_symbol_auto_completion");
 	stash_group_add_toggle_button(group, &editor_prefs.autocomplete_doc_words,
 		"autocomplete_doc_words", FALSE, "check_autocomplete_doc_words");
 	stash_group_add_toggle_button(group, &editor_prefs.completion_drops_rest_of_word,
@@ -291,8 +293,49 @@ static void init_pref_groups(void)
 		"spin_autocompletion_max_entries");
 	stash_group_add_spin_button_integer(group, (gint*)&editor_prefs.autocompletion_update_freq,
 		"autocompletion_update_freq", GEANY_MAX_SYMBOLS_UPDATE_FREQ, "spin_symbol_update_freq");
+	stash_group_add_spin_button_integer(group, &editor_prefs.symbolcompletion_min_chars,
+		"symbolcompletion_min_chars", GEANY_MIN_SYMBOLLIST_CHARS, "spin_symbol_complete_chars");
+	stash_group_add_spin_button_integer(group, &editor_prefs.symbolcompletion_max_height,
+		"symbolcompletion_max_height", GEANY_MAX_SYMBOLLIST_HEIGHT, "spin_symbollistheight");
+	stash_group_add_toggle_button(group, &editor_prefs.auto_close_xml_tags,
+		"auto_close_xml_tags", TRUE, "check_xmltag");
+	stash_group_add_toggle_button(group, &editor_prefs.complete_snippets,
+		"complete_snippets", TRUE, "check_complete_snippets");
+	stash_group_add_toggle_button(group, &editor_prefs.auto_continue_multiline,
+		"auto_continue_multiline", TRUE, "check_auto_multiline");
+	stash_group_add_integer(group, (gint*)&editor_prefs.autoclose_chars, "autoclose_chars", 0);
 	stash_group_add_string(group, &editor_prefs.color_scheme,
 		"color_scheme", NULL);
+	stash_group_add_toggle_button(group, &editor_prefs.line_wrapping,
+		"line_wrapping", FALSE, "check_line_wrapping"); /* default is off for better performance */
+	stash_group_add_toggle_button(group, &editor_prefs.use_indicators,
+		"use_indicators", TRUE, "check_indicators");
+	stash_group_add_toggle_button(group, &editor_prefs.show_indent_guide,
+		"show_indent_guide", FALSE, "check_indent");
+	stash_group_add_toggle_button(group, &editor_prefs.show_white_space,
+		"show_white_space", FALSE, "check_white_space");
+	stash_group_add_toggle_button(group, &editor_prefs.show_line_endings,
+		"show_line_endings", FALSE, "check_line_end");
+	stash_group_add_toggle_button(group, &editor_prefs.show_markers_margin,
+		"show_markers_margin", TRUE, "check_markers_margin");
+	stash_group_add_toggle_button(group, &editor_prefs.show_linenumber_margin,
+		"show_linenumber_margin", TRUE, "check_line_numbers");
+	stash_group_add_toggle_button(group, &editor_prefs.scroll_stop_at_last_line,
+		"scroll_stop_at_last_line", TRUE, "check_scroll_stop_at_last_line");
+	stash_group_add_toggle_button(group, &editor_prefs.folding,
+		"use_folding", TRUE, "check_folding");
+	stash_group_add_toggle_button(group, &editor_prefs.unfold_all_children,
+		"unfold_all_children", FALSE, "check_unfold_children");
+	stash_group_add_toggle_button(group, &editor_prefs.disable_dnd,
+		"pref_editor_disable_dnd", FALSE, "check_disable_dnd");
+	stash_group_add_toggle_button(group, &editor_prefs.smart_home_key,
+		"pref_editor_smart_home_key", TRUE, "check_smart_home");
+	stash_group_add_toggle_button(group, &editor_prefs.newline_strip,
+		"pref_editor_newline_strip", FALSE, "check_newline_strip");
+	stash_group_add_spin_button_integer(group, &editor_prefs.line_break_column,
+		"line_break_column", 72, "spin_line_break");
+	stash_group_add_entry(group, &editor_prefs.comment_toggle_mark,
+		"comment_toggle_mark", GEANY_TOGGLE_MARK, "entry_toggle_mark");
 
 	/* files */
 	stash_group_add_spin_button_integer(group, (gint*)&file_prefs.mru_length,
@@ -489,32 +532,6 @@ static void save_dialog_prefs(GKeyFile *config)
 	settings_action(config, SETTING_WRITE);
 
 	/* Some of the key names are not consistent, but this is for backwards compatibility */
-
-	/* display */
-	g_key_file_set_boolean(config, PACKAGE, "show_indent_guide", editor_prefs.show_indent_guide);
-	g_key_file_set_boolean(config, PACKAGE, "show_white_space", editor_prefs.show_white_space);
-	g_key_file_set_boolean(config, PACKAGE, "show_line_endings", editor_prefs.show_line_endings);
-	g_key_file_set_boolean(config, PACKAGE, "show_markers_margin", editor_prefs.show_markers_margin);
-	g_key_file_set_boolean(config, PACKAGE, "show_linenumber_margin", editor_prefs.show_linenumber_margin);
-
-	/* editor */
-	g_key_file_set_integer(config, PACKAGE, "symbolcompletion_max_height", editor_prefs.symbolcompletion_max_height);
-	g_key_file_set_integer(config, PACKAGE, "symbolcompletion_min_chars", editor_prefs.symbolcompletion_min_chars);
-	g_key_file_set_boolean(config, PACKAGE, "use_folding", editor_prefs.folding);
-	g_key_file_set_boolean(config, PACKAGE, "unfold_all_children", editor_prefs.unfold_all_children);
-	g_key_file_set_boolean(config, PACKAGE, "use_indicators", editor_prefs.use_indicators);
-	g_key_file_set_boolean(config, PACKAGE, "line_wrapping", editor_prefs.line_wrapping);
-	g_key_file_set_boolean(config, PACKAGE, "auto_close_xml_tags", editor_prefs.auto_close_xml_tags);
-	g_key_file_set_boolean(config, PACKAGE, "complete_snippets", editor_prefs.complete_snippets);
-	g_key_file_set_boolean(config, PACKAGE, "auto_complete_symbols", editor_prefs.auto_complete_symbols);
-	g_key_file_set_boolean(config, PACKAGE, "pref_editor_disable_dnd", editor_prefs.disable_dnd);
-	g_key_file_set_boolean(config, PACKAGE, "pref_editor_smart_home_key", editor_prefs.smart_home_key);
-	g_key_file_set_boolean(config, PACKAGE, "pref_editor_newline_strip", editor_prefs.newline_strip);
-	g_key_file_set_integer(config, PACKAGE, "line_break_column", editor_prefs.line_break_column);
-	g_key_file_set_boolean(config, PACKAGE, "auto_continue_multiline", editor_prefs.auto_continue_multiline);
-	g_key_file_set_string(config, PACKAGE, "comment_toggle_mark", editor_prefs.comment_toggle_mark);
-	g_key_file_set_boolean(config, PACKAGE, "scroll_stop_at_last_line", editor_prefs.scroll_stop_at_last_line);
-	g_key_file_set_integer(config, PACKAGE, "autoclose_chars", editor_prefs.autoclose_chars);
 
 	/* files */
 	g_key_file_set_string(config, PACKAGE, "pref_editor_default_new_encoding", encodings[file_prefs.default_new_encoding].charset);
@@ -793,30 +810,6 @@ static void load_dialog_prefs(GKeyFile *config)
 		if (!g_key_file_has_key(config, "search", "pref_search_hide_find_dialog", NULL))
 			g_key_file_set_boolean(config, "search", "pref_search_hide_find_dialog", suppress_search_dialogs);
 	}
-
-	/* display, editor */
-	editor_prefs.symbolcompletion_min_chars = utils_get_setting_integer(config, PACKAGE, "symbolcompletion_min_chars", GEANY_MIN_SYMBOLLIST_CHARS);
-	editor_prefs.symbolcompletion_max_height = utils_get_setting_integer(config, PACKAGE, "symbolcompletion_max_height", GEANY_MAX_SYMBOLLIST_HEIGHT);
-	editor_prefs.line_wrapping = utils_get_setting_boolean(config, PACKAGE, "line_wrapping", FALSE); /* default is off for better performance */
-	editor_prefs.use_indicators = utils_get_setting_boolean(config, PACKAGE, "use_indicators", TRUE);
-	editor_prefs.show_indent_guide = utils_get_setting_boolean(config, PACKAGE, "show_indent_guide", FALSE);
-	editor_prefs.show_white_space = utils_get_setting_boolean(config, PACKAGE, "show_white_space", FALSE);
-	editor_prefs.show_line_endings = utils_get_setting_boolean(config, PACKAGE, "show_line_endings", FALSE);
-	editor_prefs.scroll_stop_at_last_line = utils_get_setting_boolean(config, PACKAGE, "scroll_stop_at_last_line", TRUE);
-	editor_prefs.auto_close_xml_tags = utils_get_setting_boolean(config, PACKAGE, "auto_close_xml_tags", TRUE);
-	editor_prefs.complete_snippets = utils_get_setting_boolean(config, PACKAGE, "complete_snippets", TRUE);
-	editor_prefs.auto_complete_symbols = utils_get_setting_boolean(config, PACKAGE, "auto_complete_symbols", TRUE);
-	editor_prefs.folding = utils_get_setting_boolean(config, PACKAGE, "use_folding", TRUE);
-	editor_prefs.unfold_all_children = utils_get_setting_boolean(config, PACKAGE, "unfold_all_children", FALSE);
-	editor_prefs.show_markers_margin = utils_get_setting_boolean(config, PACKAGE, "show_markers_margin", TRUE);
-	editor_prefs.show_linenumber_margin = utils_get_setting_boolean(config, PACKAGE, "show_linenumber_margin", TRUE);
-	editor_prefs.disable_dnd = utils_get_setting_boolean(config, PACKAGE, "pref_editor_disable_dnd", FALSE);
-	editor_prefs.smart_home_key = utils_get_setting_boolean(config, PACKAGE, "pref_editor_smart_home_key", TRUE);
-	editor_prefs.newline_strip = utils_get_setting_boolean(config, PACKAGE, "pref_editor_newline_strip", FALSE);
-	editor_prefs.line_break_column = utils_get_setting_integer(config, PACKAGE, "line_break_column", 72);
-	editor_prefs.auto_continue_multiline = utils_get_setting_boolean(config, PACKAGE, "auto_continue_multiline", TRUE);
-	editor_prefs.comment_toggle_mark = utils_get_setting_string(config, PACKAGE, "comment_toggle_mark", GEANY_TOGGLE_MARK);
-	editor_prefs.autoclose_chars = utils_get_setting_integer(config, PACKAGE, "autoclose_chars", 0);
 
 	/* Files
 	 * use current locale encoding as default for new files (should be UTF-8 in most cases) */

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -196,6 +196,18 @@ static void init_pref_groups(void)
 		"auto_focus", FALSE, "check_auto_focus");
 
 	/* interface */
+	stash_group_add_radio_buttons(group, &file_prefs.tab_order_ltr,
+		"tab_order_ltr", TRUE,
+		"radio_tab_right", TRUE,
+		"radio_tab_left", FALSE,
+		NULL);
+	stash_group_add_toggle_button(group, &file_prefs.tab_order_beside,
+		"tab_order_beside", FALSE, "check_tab_beside");
+	stash_group_add_toggle_button(group, &interface_prefs.show_notebook_tabs,
+		"show_notebook_tabs", TRUE, "check_show_notebook_tabs");
+	stash_group_add_toggle_button(group, &file_prefs.show_tab_cross,
+		"show_tab_cross", TRUE, "check_show_tab_cross");
+
 	stash_group_add_combo_box(group, &interface_prefs.tab_pos_editor,
 		"tab_pos_editor", GTK_POS_TOP, "combo_tab_editor");
 	stash_group_add_combo_box(group, &interface_prefs.tab_pos_msgwin,
@@ -477,12 +489,6 @@ static void save_dialog_prefs(GKeyFile *config)
 	settings_action(config, SETTING_WRITE);
 
 	/* Some of the key names are not consistent, but this is for backwards compatibility */
-
-	/* interface */
-	g_key_file_set_boolean(config, PACKAGE, "show_notebook_tabs", interface_prefs.show_notebook_tabs);
-	g_key_file_set_boolean(config, PACKAGE, "show_tab_cross", file_prefs.show_tab_cross);
-	g_key_file_set_boolean(config, PACKAGE, "tab_order_ltr", file_prefs.tab_order_ltr);
-	g_key_file_set_boolean(config, PACKAGE, "tab_order_beside", file_prefs.tab_order_beside);
 
 	/* display */
 	g_key_file_set_boolean(config, PACKAGE, "show_indent_guide", editor_prefs.show_indent_guide);
@@ -787,12 +793,6 @@ static void load_dialog_prefs(GKeyFile *config)
 		if (!g_key_file_has_key(config, "search", "pref_search_hide_find_dialog", NULL))
 			g_key_file_set_boolean(config, "search", "pref_search_hide_find_dialog", suppress_search_dialogs);
 	}
-
-	/* interface */
-	file_prefs.tab_order_ltr = utils_get_setting_boolean(config, PACKAGE, "tab_order_ltr", TRUE);
-	file_prefs.tab_order_beside = utils_get_setting_boolean(config, PACKAGE, "tab_order_beside", FALSE);
-	interface_prefs.show_notebook_tabs = utils_get_setting_boolean(config, PACKAGE, "show_notebook_tabs", TRUE);
-	file_prefs.show_tab_cross = utils_get_setting_boolean(config, PACKAGE, "show_tab_cross", TRUE);
 
 	/* display, editor */
 	editor_prefs.symbolcompletion_min_chars = utils_get_setting_integer(config, PACKAGE, "symbolcompletion_min_chars", GEANY_MIN_SYMBOLLIST_CHARS);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -157,7 +157,6 @@ static void init_pref_groups(void)
 		"notebook_double_click_hides_widgets", FALSE, "check_double_click_hides_widgets");
 	stash_group_add_toggle_button(group, &file_prefs.tab_close_switch_to_mru,
 		"tab_close_switch_to_mru", FALSE, "check_tab_close_switch_to_mru");
-	stash_group_add_integer(group, &interface_prefs.tab_pos_sidebar, "tab_pos_sidebar", GTK_POS_TOP);
 	stash_group_add_radio_buttons(group, &interface_prefs.sidebar_pos,
 		"sidebar_pos", GTK_POS_LEFT,
 		"radio_sidebar_left", GTK_POS_LEFT,
@@ -197,6 +196,13 @@ static void init_pref_groups(void)
 		"auto_focus", FALSE, "check_auto_focus");
 
 	/* interface */
+	stash_group_add_combo_box(group, &interface_prefs.tab_pos_editor,
+		"tab_pos_editor", GTK_POS_TOP, "combo_tab_editor");
+	stash_group_add_combo_box(group, &interface_prefs.tab_pos_msgwin,
+		"tab_pos_msgwin", GTK_POS_LEFT, "combo_tab_msgwin");
+	stash_group_add_combo_box(group, &interface_prefs.tab_pos_sidebar,
+		"tab_pos_sidebar", GTK_POS_TOP, "combo_tab_sidebar");
+
 	stash_group_add_toggle_button(group, &interface_prefs.use_native_windows_dialogs,
 		"use_native_windows_dialogs", FALSE, "check_native_windows_dialogs");
 
@@ -477,8 +483,6 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "show_tab_cross", file_prefs.show_tab_cross);
 	g_key_file_set_boolean(config, PACKAGE, "tab_order_ltr", file_prefs.tab_order_ltr);
 	g_key_file_set_boolean(config, PACKAGE, "tab_order_beside", file_prefs.tab_order_beside);
-	g_key_file_set_integer(config, PACKAGE, "tab_pos_editor", interface_prefs.tab_pos_editor);
-	g_key_file_set_integer(config, PACKAGE, "tab_pos_msgwin", interface_prefs.tab_pos_msgwin);
 
 	/* display */
 	g_key_file_set_boolean(config, PACKAGE, "show_indent_guide", editor_prefs.show_indent_guide);
@@ -785,8 +789,6 @@ static void load_dialog_prefs(GKeyFile *config)
 	}
 
 	/* interface */
-	interface_prefs.tab_pos_editor = utils_get_setting_integer(config, PACKAGE, "tab_pos_editor", GTK_POS_TOP);
-	interface_prefs.tab_pos_msgwin = utils_get_setting_integer(config, PACKAGE, "tab_pos_msgwin",GTK_POS_LEFT);
 	file_prefs.tab_order_ltr = utils_get_setting_boolean(config, PACKAGE, "tab_order_ltr", TRUE);
 	file_prefs.tab_order_beside = utils_get_setting_boolean(config, PACKAGE, "tab_order_beside", FALSE);
 	interface_prefs.show_notebook_tabs = utils_get_setting_boolean(config, PACKAGE, "show_notebook_tabs", TRUE);

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -439,15 +439,6 @@ static void prefs_init_dialog(void)
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_show_tab_cross");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.show_tab_cross);
 
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_tab_editor");
-	gtk_combo_box_set_active(GTK_COMBO_BOX(widget), interface_prefs.tab_pos_editor);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_tab_msgwin");
-	gtk_combo_box_set_active(GTK_COMBO_BOX(widget), interface_prefs.tab_pos_msgwin);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_tab_sidebar");
-	gtk_combo_box_set_active(GTK_COMBO_BOX(widget), interface_prefs.tab_pos_sidebar);
-
 
 	/* Toolbar settings */
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_toolbar_show");
@@ -847,16 +838,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_show_tab_cross");
 		file_prefs.show_tab_cross = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_tab_editor");
-		interface_prefs.tab_pos_editor = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_tab_msgwin");
-		interface_prefs.tab_pos_msgwin = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_tab_sidebar");
-		interface_prefs.tab_pos_sidebar = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-
 
 		/* Toolbar settings */
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_toolbar_show");

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -407,41 +407,6 @@ static void prefs_init_dialog(void)
 	ui_widget_show_hide(widget, app->project != NULL);
 
 	/* General settings */
-	/* startup */
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_load_session");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), prefs.load_session);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_project_session");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), project_prefs.project_session);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_project_file_in_basedir");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), project_prefs.project_file_in_basedir);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_save_win_pos");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), prefs.save_winpos);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_ask_for_quit");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), prefs.confirm_exit);
-
-	/* behaviour */
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_beep");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), prefs.beep_on_errors);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_switch_pages");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), prefs.switch_to_status);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_suppress_status_msgs");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), prefs.suppress_status_messages);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_auto_focus");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), prefs.auto_focus);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_native_windows_dialogs");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
-		interface_prefs.use_native_windows_dialogs);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "entry_contextaction");
-	gtk_entry_set_text(GTK_ENTRY(widget), tool_prefs.context_action_cmd);
 
 	project_setup_prefs();	/* project files path */
 
@@ -890,42 +855,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		gtk_orientable_set_orientation(GTK_ORIENTABLE(widget), interface_prefs.msgwin_orientation);
 
 		/* General settings */
-		/* startup */
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_load_session");
-		prefs.load_session = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_project_session");
-		project_prefs.project_session = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_project_file_in_basedir");
-		project_prefs.project_file_in_basedir = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_save_win_pos");
-		prefs.save_winpos = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_ask_for_quit");
-		prefs.confirm_exit = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		/* behaviour */
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_beep");
-		prefs.beep_on_errors = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_switch_pages");
-		prefs.switch_to_status = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_suppress_status_msgs");
-		prefs.suppress_status_messages = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_auto_focus");
-		prefs.auto_focus = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_native_windows_dialogs");
-		interface_prefs.use_native_windows_dialogs =
-			gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "entry_contextaction");
-		g_free(tool_prefs.context_action_cmd);
-		tool_prefs.context_action_cmd = g_strdup(gtk_entry_get_text(GTK_ENTRY(widget)));
 
 		project_apply_prefs();	/* project file path */
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -412,15 +412,10 @@ static void prefs_init_dialog(void)
 
 
 	/* Interface settings */
+
+	/* update the initial state */
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_sidebar_visible");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), ui_prefs.sidebar_visible);
 	on_sidebar_visible_toggled(GTK_TOGGLE_BUTTON(widget), NULL);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_list_symbol");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), interface_prefs.sidebar_symbol_visible);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_list_openfiles");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), interface_prefs.sidebar_openfiles_visible);
 
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "tagbar_font");
 	gtk_font_button_set_font_name(GTK_FONT_BUTTON(widget), interface_prefs.tagbar_font);
@@ -452,9 +447,6 @@ static void prefs_init_dialog(void)
 
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_tab_sidebar");
 	gtk_combo_box_set_active(GTK_COMBO_BOX(widget), interface_prefs.tab_pos_sidebar);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_statusbar_visible");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), interface_prefs.statusbar_visible);
 
 
 	/* Toolbar settings */
@@ -847,15 +839,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 
 		/* Interface settings */
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_sidebar_visible");
-		ui_prefs.sidebar_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_list_symbol");
-		interface_prefs.sidebar_symbol_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_list_openfiles");
-		interface_prefs.sidebar_openfiles_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
 		if (editor_prefs.long_line_column == 0)
 			editor_prefs.long_line_enabled = FALSE;
 
@@ -873,9 +856,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_tab_sidebar");
 		interface_prefs.tab_pos_sidebar = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_statusbar_visible");
-		interface_prefs.statusbar_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
 
 		/* Toolbar settings */

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -430,14 +430,9 @@ static void prefs_init_dialog(void)
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "long_line_color");
 	gtk_color_button_set_color(GTK_COLOR_BUTTON(widget), &color);
 
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_show_notebook_tabs");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), interface_prefs.show_notebook_tabs);
 	/* disable following setting if notebook tabs are hidden */
 	on_show_notebook_tabs_toggled(GTK_TOGGLE_BUTTON(
 					ui_lookup_widget(ui_widgets.prefs_dialog, "check_show_notebook_tabs")), NULL);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_show_tab_cross");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.show_tab_cross);
 
 
 	/* Toolbar settings */
@@ -474,14 +469,6 @@ static void prefs_init_dialog(void)
 
 
 	/* Files settings */
-	if (file_prefs.tab_order_ltr)
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "radio_tab_right");
-	else
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "radio_tab_left");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_tab_beside");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.tab_order_beside);
 
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_new_encoding");
 	ui_encodings_combo_box_set_active_encoding(GTK_COMBO_BOX(widget), file_prefs.default_new_encoding);
@@ -833,12 +820,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		if (editor_prefs.long_line_column == 0)
 			editor_prefs.long_line_enabled = FALSE;
 
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_show_notebook_tabs");
-		interface_prefs.show_notebook_tabs = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_show_tab_cross");
-		file_prefs.show_tab_cross = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
 		/* Toolbar settings */
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_toolbar_show");
 		toolbar_prefs.visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
@@ -881,12 +862,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		}
 
 		/* Files settings */
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "radio_tab_right");
-		file_prefs.tab_order_ltr = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_tab_beside");
-		file_prefs.tab_order_beside = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_new_encoding");
 		file_prefs.default_new_encoding = ui_encodings_combo_box_get_active_encoding(GTK_COMBO_BOX(widget));
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -486,27 +486,7 @@ static void prefs_init_dialog(void)
 	else
 		ui_encodings_combo_box_set_active_encoding(GTK_COMBO_BOX(widget), GEANY_ENCODING_UTF_8);
 
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_eol");
-	if (file_prefs.default_eol_character >= 0 && file_prefs.default_eol_character < 3)
-	{
-		gtk_combo_box_set_active(GTK_COMBO_BOX(widget), file_prefs.default_eol_character);
-	}
-	else
-		gtk_combo_box_set_active(GTK_COMBO_BOX(widget), GEANY_DEFAULT_EOL_CHARACTER);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_trailing_spaces");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.strip_trailing_spaces);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_new_line");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.final_new_line);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_ensure_convert_new_lines");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.ensure_convert_new_lines);
-
 	/* Editor settings */
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_replace_tabs");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.replace_tabs);
-
 	on_use_folding_toggled(GTK_TOGGLE_BUTTON(
 					ui_lookup_widget(ui_widgets.prefs_dialog, "check_folding")), NULL);
 
@@ -811,21 +791,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		}
 		else
 			file_prefs.default_open_encoding = -1;
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_eol");
-		file_prefs.default_eol_character = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_trailing_spaces");
-		file_prefs.strip_trailing_spaces = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_new_line");
-		file_prefs.final_new_line = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_ensure_convert_new_lines");
-		file_prefs.ensure_convert_new_lines = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_replace_tabs");
-		file_prefs.replace_tabs = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
 
 		/* Editor settings */

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -431,19 +431,6 @@ static void prefs_init_dialog(void)
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "editor_font");
 	gtk_font_button_set_font_name(GTK_FONT_BUTTON(widget), interface_prefs.editor_font);
 
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_long_line");
-	gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), editor_prefs.long_line_column);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_long_line");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.long_line_enabled);
-
-	switch (editor_prefs.long_line_type)
-	{
-		case 0: widget = ui_lookup_widget(ui_widgets.prefs_dialog, "radio_long_line_line"); break;
-		case 1: widget = ui_lookup_widget(ui_widgets.prefs_dialog, "radio_long_line_background"); break;
-	}
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
-
 	utils_parse_color(editor_prefs.long_line_color, &color);
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "long_line_color");
 	gtk_color_button_set_color(GTK_COLOR_BUTTON(widget), &color);
@@ -869,16 +856,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_list_openfiles");
 		interface_prefs.sidebar_openfiles_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_long_line");
-		editor_prefs.long_line_enabled = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "radio_long_line_line");
-		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
-			editor_prefs.long_line_type = 0;
-		else
-			/* now only the "background" radio remains */
-			editor_prefs.long_line_type = 1;
-
 		if (editor_prefs.long_line_column == 0)
 			editor_prefs.long_line_enabled = FALSE;
 
@@ -982,11 +959,6 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		SETPTR(editor_prefs.comment_toggle_mark,
 			gtk_editable_get_chars(GTK_EDITABLE(widget), 0, -1));
 
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_long_line");
-		/* note: use stash for new code - it updates spin buttons itself */
-		gtk_spin_button_update(GTK_SPIN_BUTTON(widget));
-		editor_prefs.long_line_column = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
-
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_folding");
 		editor_prefs.folding = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 		ui_update_fold_items();
@@ -1040,6 +1012,7 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		editor_prefs.auto_complete_symbols = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_symbol_complete_chars");
+		/* note: use stash for new code - it updates spin buttons itself */
 		gtk_spin_button_update(GTK_SPIN_BUTTON(widget));
 		editor_prefs.symbolcompletion_min_chars = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -504,73 +504,11 @@ static void prefs_init_dialog(void)
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.ensure_convert_new_lines);
 
 	/* Editor settings */
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "entry_toggle_mark");
-	gtk_entry_set_text(GTK_ENTRY(widget), editor_prefs.comment_toggle_mark);
-
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_replace_tabs");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.replace_tabs);
 
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_indent");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.show_indent_guide);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_white_space");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.show_white_space);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_end");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.show_line_endings);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_numbers");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.show_linenumber_margin);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_markers_margin");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.show_markers_margin);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_scroll_stop_at_last_line");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.scroll_stop_at_last_line);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_wrapping");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.line_wrapping);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_complete_snippets");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.complete_snippets);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_xmltag");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.auto_close_xml_tags);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_folding");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.folding);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_unfold_children");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.unfold_all_children);
 	on_use_folding_toggled(GTK_TOGGLE_BUTTON(
 					ui_lookup_widget(ui_widgets.prefs_dialog, "check_folding")), NULL);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_disable_dnd");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.disable_dnd);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_smart_home");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.smart_home_key);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_newline_strip");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.newline_strip);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_indicators");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.use_indicators);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_auto_multiline");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.auto_continue_multiline);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_symbol_auto_completion");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.auto_complete_symbols);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_symbollistheight");
-	gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), editor_prefs.symbolcompletion_max_height);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_symbol_complete_chars");
-	gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), editor_prefs.symbolcompletion_min_chars);
-
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_line_break");
-	gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), editor_prefs.line_break_column);
 
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_parenthesis");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
@@ -891,74 +829,7 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 
 		/* Editor settings */
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "entry_toggle_mark");
-		SETPTR(editor_prefs.comment_toggle_mark,
-			gtk_editable_get_chars(GTK_EDITABLE(widget), 0, -1));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_folding");
-		editor_prefs.folding = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 		ui_update_fold_items();
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_unfold_children");
-		editor_prefs.unfold_all_children = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_indent");
-		editor_prefs.show_indent_guide = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_white_space");
-		editor_prefs.show_white_space = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_end");
-		editor_prefs.show_line_endings = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_numbers");
-		editor_prefs.show_linenumber_margin = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_markers_margin");
-		editor_prefs.show_markers_margin = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_scroll_stop_at_last_line");
-		editor_prefs.scroll_stop_at_last_line = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_wrapping");
-		editor_prefs.line_wrapping = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_complete_snippets");
-		editor_prefs.complete_snippets = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_xmltag");
-		editor_prefs.auto_close_xml_tags = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_indicators");
-		editor_prefs.use_indicators = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_disable_dnd");
-		editor_prefs.disable_dnd = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_smart_home");
-		editor_prefs.smart_home_key = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_newline_strip");
-		editor_prefs.newline_strip = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_auto_multiline");
-		editor_prefs.auto_continue_multiline = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_symbol_auto_completion");
-		editor_prefs.auto_complete_symbols = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_symbol_complete_chars");
-		/* note: use stash for new code - it updates spin buttons itself */
-		gtk_spin_button_update(GTK_SPIN_BUTTON(widget));
-		editor_prefs.symbolcompletion_min_chars = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_symbollistheight");
-		gtk_spin_button_update(GTK_SPIN_BUTTON(widget));
-		editor_prefs.symbolcompletion_max_height = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
-
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_line_break");
-		gtk_spin_button_update(GTK_SPIN_BUTTON(widget));
-		editor_prefs.line_break_column = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_parenthesis");
 		autoclose_brackets[0] = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
@@ -1076,6 +947,7 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		if (vte_info.have_vte)
 		{
 			widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_scrollback");
+			/* note: use stash for new code - it updates spin buttons itself */
 			gtk_spin_button_update(GTK_SPIN_BUTTON(widget));
 			vc->scrollback_lines = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
 


### PR DESCRIPTION
This both reduces the amount of code (by more than ⅔!), and tries to move towards a state where new contributors don't feel like using manual keyfile read/write is the way to go (experience has shown the `load_dialog_prefs()` has a way of going unnoticed -- but @elextr will come up with a nice way of documenting this :wink:).

In theory it also reduce the possibility for typos leading to settings not being saved/loaded properly (i.e. if the setting name/group doesn't match), but as it's currently working it mostly allows for mistakes in the diff of this PR :smile:
Though, I should have done that carefully enough to not risk too much.  But review is of course a good idea (hint hint).