### PR TITLE
Add default filenames (.copy-xx) to cloned documents

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -511,11 +511,17 @@ shortcuts including for Most-Recently-Used document switching.
 
 Cloning documents
 ^^^^^^^^^^^^^^^^^
+
 The `Document->Clone` menu item copies the current document's text,
 cursor position and properties into a new untitled document. If
 there is a selection, only the selected text is copied. This can be
 useful when making temporary copies of text or for creating
 documents with similar or identical contents.
+
+The new document gets a filename based on the original document, and is 
+in the form of '<original_name>.copy-xx' where 'xx' is a number ranging 
+from 00 to 99.  The name that doesn't point to an existing file and is 
+not used by any document gets used.
 
 
 Character sets and Unicode Byte-Order-Mark (BOM)

--- a/src/document.c
+++ b/src/document.c
@@ -3366,6 +3366,7 @@ GeanyDocument *document_clone(GeanyDocument *old_doc)
 	}
 
 	doc = document_new_file(new_filename, old_doc->file_type, text);
+	g_free(new_filename);
 	g_free(text);
 	document_set_text_changed(doc, TRUE);
 

--- a/src/document.c
+++ b/src/document.c
@@ -3377,13 +3377,11 @@ GeanyDocument *document_clone(GeanyDocument *old_doc)
 	doc->editor->auto_indent = old_doc->editor->auto_indent;
 	editor_set_indent(doc->editor, old_doc->editor->indent_type,
 		old_doc->editor->indent_width);
+	doc->readonly = FALSE;
 	doc->has_bom = old_doc->has_bom;
 	doc->priv->protected = 0;
 	document_set_encoding(doc, old_doc->encoding);
 	sci_set_lines_wrapped(doc->editor->sci, doc->editor->line_wrapping);
-
-	/* do not set cloned documents as readonly */
-	doc->readonly = FALSE;
 	sci_set_readonly(doc->editor->sci, doc->readonly);
 
 	/* update ui */

--- a/src/document.c
+++ b/src/document.c
@@ -3377,7 +3377,7 @@ GeanyDocument *document_clone(GeanyDocument *old_doc)
 	doc->editor->auto_indent = old_doc->editor->auto_indent;
 	editor_set_indent(doc->editor, old_doc->editor->indent_type,
 		old_doc->editor->indent_width);
-	doc->readonly = FALSE;
+	doc->readonly = old_doc->readonly;
 	doc->has_bom = old_doc->has_bom;
 	doc->priv->protected = 0;
 	document_set_encoding(doc, old_doc->encoding);

--- a/src/document.c
+++ b/src/document.c
@@ -3375,11 +3375,13 @@ GeanyDocument *document_clone(GeanyDocument *old_doc)
 	doc->editor->auto_indent = old_doc->editor->auto_indent;
 	editor_set_indent(doc->editor, old_doc->editor->indent_type,
 		old_doc->editor->indent_width);
-	doc->readonly = FALSE;
 	doc->has_bom = old_doc->has_bom;
 	doc->priv->protected = 0;
 	document_set_encoding(doc, old_doc->encoding);
 	sci_set_lines_wrapped(doc->editor->sci, doc->editor->line_wrapping);
+
+	/* do not set cloned documents as readonly */
+	doc->readonly = FALSE;
 	sci_set_readonly(doc->editor->sci, doc->readonly);
 
 	/* update ui */

--- a/src/document.c
+++ b/src/document.c
@@ -3356,10 +3356,17 @@ GeanyDocument *document_clone(GeanyDocument *old_doc)
 				}
 			}
 
-			if (unused && !g_file_test(candidate, G_FILE_TEST_EXISTS))
+			if (unused)
 			{
-				new_filename = candidate;
-				break;
+				gchar *locale_candidate = utils_get_locale_from_utf8(candidate);
+				gboolean file_exists = g_file_test(locale_candidate, G_FILE_TEST_EXISTS);
+				g_free(locale_candidate);
+
+				if (!file_exists)
+				{
+					new_filename = candidate;
+					break;
+				}
 			}
 
 			g_free(candidate);

--- a/src/document.c
+++ b/src/document.c
@@ -3341,27 +3341,28 @@ GeanyDocument *document_clone(GeanyDocument *old_doc)
 	if (old_doc->file_name)
 	{
 		guint i, j;
-		gboolean unused;
 
 		for (i = 0; i <= 99; ++i)
 		{
-			new_filename = g_strdup_printf("%s.copy-%02u", old_doc->file_name, i);
-			unused = TRUE;
+			gchar *candidate = g_strdup_printf("%s.copy-%02u", old_doc->file_name, i);
+			gboolean unused = TRUE;
 
 			foreach_document(j)
 			{
-				if (documents[j]->file_name && strcmp(documents[j]->file_name, new_filename) == 0)
+				if (documents[j]->file_name && strcmp(documents[j]->file_name, candidate) == 0)
 				{
 					unused = FALSE;
 					break;
 				}
 			}
 
-			if (unused && !g_file_test(new_filename, G_FILE_TEST_EXISTS))
+			if (unused && !g_file_test(candidate, G_FILE_TEST_EXISTS))
+			{
+				new_filename = candidate;
 				break;
+			}
 
-			g_free(new_filename);
-			new_filename = NULL;
+			g_free(candidate);
 		}
 	}
 


### PR DESCRIPTION
I find this helpful when replicating documents since you wouldn't have to browse through the original directory when renaming the document when it's untitled.  You also get to have a pattern from the original filename.  It becomes very convenient along with in-place renaming.

I'm happy with how it is but perhaps people would want it to be configurable so that it can be disabled, or given with a different naming format.   The latter wouldn't sound easy though.

Reasons for choosing `.copy-xx:`

- Lowercase because it's less noisy.
- A dash to make it more distinguishable with the numbers.
- 2 digits because it's good enough.  1-digit is a little conservative.  3-digits is overkill.
- Prefixed with '.copy' because `.xx` files could exist and could confuse the user; and '.copy' over '.clone' because it's shorter, and it's also common among some file managers, I think.
