### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_size = 4
+end_of_line = lf
+
+[*.{c,h,cxx,am,m4}]
+indent_style = tab
+
+[*.{py}]
+indent_style = space


### PR DESCRIPTION
See http://editorconfig.org/. Inspired by similar commit in universal-ctags.

The main reason why this might be interesting is that github understands it and shows correct tab sizes e.g. in pull requests.
