### PR TITLE
Rework Save-As; Abort saving if rename fails

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -678,7 +678,10 @@ gboolean dialogs_show_save_as(void)
 		gchar *utf8_name = win32_show_document_save_as_dialog(GTK_WINDOW(main_widgets.window),
 						_("Save File"), doc);
 		if (utf8_name != NULL)
+		{
 			result = handle_save_as(utf8_name, FALSE);
+			g_free(utf8_name);
+		}
 	}
 	else
 #endif

--- a/src/document.c
+++ b/src/document.c
@@ -1764,16 +1764,6 @@ void document_rename_file(GeanyDocument *doc, const gchar *new_filename)
 }
 
 
-/**
- *  Renames the file in @a doc to @a new_filename then saves data to it.
- *
- *  @param doc The current document which should be renamed.
- *  @param new_filename The new filename in UTF-8 encoding.
- *
- *  @return @c TRUE if file was renamed or @c FALSE otherwise.
- *  @since ?
- **/
-GEANY_API_SYMBOL
 gboolean document_rename_file_and_save(GeanyDocument *doc, const gchar *new_filename)
 {
 	g_return_val_if_fail(DOC_VALID(doc), FALSE);

--- a/src/document.c
+++ b/src/document.c
@@ -1782,21 +1782,7 @@ gboolean document_rename_file_and_save(GeanyDocument *doc, const gchar *new_file
 	if (success)
 	{
 		doc->priv->file_disk_status = FILE_CHANGED;
-
-		/* Perhaps this is better placed in document_save_file_as(). */
-		if (doc->tm_file)
-		{
-			/* Create a new tm_source_file object otherwise tagmanager won't work correctly. */
-			tm_workspace_remove_source_file(doc->tm_file);
-			tm_source_file_free(doc->tm_file);
-			doc->tm_file = NULL;
-		}
-
 		success = document_save_file_as(doc, new_filename);
-
-		/* Not sure if we should call this by default whether document_save_file_as() succeeds
-		 * or not.  Also, this might be better placed in document_save_file_as(). */
-		build_menu_update(doc);
 	}
 	else
 	{
@@ -1839,22 +1825,7 @@ gboolean document_rename_and_save(GeanyDocument *doc, const gchar *new_filename,
 	if (doc->file_name && doc->real_path)
 		ret = document_rename_file_and_save(doc, new_filename);
 	else
-	{
-		/* Perhaps this is better placed in document_save_file_as(). */
-		if (doc->tm_file)
-		{
-			/* Create a new tm_source_file object otherwise tagmanager won't work correctly. */
-			tm_workspace_remove_source_file(doc->tm_file);
-			tm_source_file_free(doc->tm_file);
-			doc->tm_file = NULL;
-		}
-
 		ret = document_save_file_as(doc, new_filename);
-
-		/* Not sure if we should call this by default whether document_save_file_as() succeeds
-		 * or not.  Also, this might be better placed in document_save_file_as(). */
-		build_menu_update(doc);
-	}
 
 cleanup:
 	g_free(new_locale_filename);
@@ -1943,6 +1914,14 @@ gboolean document_save_file_as(GeanyDocument *doc, const gchar *utf8_fname)
 		doc->readonly = FALSE;
 		if (doc->priv->protected > 0)
 			unprotect_document(doc);
+
+		if (doc->tm_file)
+		{
+			/* create a new tm_source_file object otherwise tagmanager won't work correctly. */
+			tm_workspace_remove_source_file(doc->tm_file);
+			tm_source_file_free(doc->tm_file);
+			doc->tm_file = NULL;
+		}
 	}
 
 	replace_header_filename(doc);
@@ -1956,6 +1935,9 @@ gboolean document_save_file_as(GeanyDocument *doc, const gchar *utf8_fname)
 
 	if (ret)
 		ui_add_recent_document(doc);
+
+	build_menu_update(doc);
+
 	return ret;
 }
 

--- a/src/document.h
+++ b/src/document.h
@@ -208,8 +208,6 @@ gboolean document_save_file_as(GeanyDocument *doc, const gchar *utf8_fname);
 
 void document_rename_file(GeanyDocument *doc, const gchar *new_filename);
 
-gboolean document_rename_file_and_save(GeanyDocument *doc, const gchar *new_filename);
-
 const GdkColor *document_get_status_color(GeanyDocument *doc);
 
 gchar *document_get_basename_for_display(GeanyDocument *doc, gint length);
@@ -324,6 +322,8 @@ void document_set_data(GeanyDocument *doc, const gchar *key, gpointer data);
 
 void document_set_data_full(GeanyDocument *doc, const gchar *key,
 	gpointer data, GDestroyNotify free_func);
+
+gboolean document_rename_file_and_save(GeanyDocument *doc, const gchar *new_filename);
 
 #endif /* GEANY_PRIVATE */
 

--- a/src/document.h
+++ b/src/document.h
@@ -208,6 +208,8 @@ gboolean document_save_file_as(GeanyDocument *doc, const gchar *utf8_fname);
 
 void document_rename_file(GeanyDocument *doc, const gchar *new_filename);
 
+gboolean document_rename_file_and_save(GeanyDocument *doc, const gchar *new_filename);
+
 const GdkColor *document_get_status_color(GeanyDocument *doc);
 
 gchar *document_get_basename_for_display(GeanyDocument *doc, gint length);

--- a/src/document.h
+++ b/src/document.h
@@ -325,6 +325,8 @@ void document_set_data_full(GeanyDocument *doc, const gchar *key,
 
 gboolean document_rename_file_and_save(GeanyDocument *doc, const gchar *new_filename);
 
+gboolean document_rename_and_save(GeanyDocument *doc, const gchar *new_filename, gboolean ask_overwrite);
+
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS


### PR DESCRIPTION
As discussed in https://github.com/geany/geany/pull/1180.

This change adds two new functions: `document_rename_file_and_save()`, and `document_rename_and_save()`.  `document_rename_file_and_save()` is kind of like the combination of `document_rename_file()` and `document_save_file_as()`, and is strictly about renaming the associated file, and doing the stuff necessary before and after the file has been renamed, like disabling file monitoring, and putting it back if a rename fails, saving/restoring file disk status, etc.

`document_rename_and_save()` OTOH is more of a wrapper, and is about renaming the document itself.  It doesn't require the document to have an associated file to it (i.e. `doc->real_path != NULL`).  But if there is an associated file, the file is also renamed, i.e., `document_rename_file_and_save()` is called.  The algorithm to check if the file has to be overwritten is also contained in it.  This function should be adaptable to other implementations like [in-place renaming](https://github.com/konsolebox/geany/tree/docs_rename).

In `dialogs.c`, stuff about resetting `doc->tm_file` and calling `build_menu_update()` has been moved to `document_save_file_as()`, since both are essentially needed to be done by anyone that calls the function. It helps significantly simplify the two new functions and the functions in `dialogs.c`.

The function `save_as_dialog_handle_response()` has been refactored, and is now simpler since the "overwrite file?" prompt has been moved to `document_rename_and_save()`, and since it can now directly call `document_rename_and_save()` and `document_save_file_as()`.  `dialogs_show_save_as()` now also directly calls `document_save_file_as()` if `interface_prefs.use_native_windows_dialogs == TRUE`.  `handle_save_as()` is no longer needed, so it's been removed.
