### PR TITLE
Add default filenames (.clone[X]) to cloned documents

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -511,11 +511,17 @@ shortcuts including for Most-Recently-Used document switching.
 
 Cloning documents
 ^^^^^^^^^^^^^^^^^
+
 The `Document->Clone` menu item copies the current document's text,
 cursor position and properties into a new untitled document. If
 there is a selection, only the selected text is copied. This can be
 useful when making temporary copies of text or for creating
 documents with similar or identical contents.
+
+The new document gets a filename based on the original document, and is 
+in the form of '<original_name>.cloneX' where X is a number ranging 
+from 0 to 99, but is not set if it is 0.  The name that doesn't point to
+an existing file and is not used by any document gets used.
 
 
 Character sets and Unicode Byte-Order-Mark (BOM)

--- a/src/document.c
+++ b/src/document.c
@@ -3365,10 +3365,17 @@ GeanyDocument *document_clone(GeanyDocument *old_doc)
 				}
 			}
 
-			if (unused && !g_file_test(candidate, G_FILE_TEST_EXISTS))
+			if (unused)
 			{
-				new_filename = candidate;
-				break;
+				gchar *locale_candidate = utils_get_locale_from_utf8(candidate);
+				gboolean file_exists = g_file_test(locale_candidate, G_FILE_TEST_EXISTS);
+				g_free(locale_candidate);
+
+				if (!file_exists)
+				{
+					new_filename = candidate;
+					break;
+				}
 			}
 
 			g_free(candidate);


### PR DESCRIPTION
This is an alternative (which I find better) to https://github.com/geany/geany/pull/1191.

When cloning documents, a filename that's similar to the original - with a `.clone` extension appended to it, is given to the clone.  The new filename is unique.  It starts first with `filename.clone`.  If the filename exists or is used by another document, a number is appended to it (e.g. `.clone1`), which increments until a unique filename is found.
