### PR TITLE
Document data

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -657,6 +657,8 @@ static GeanyDocument *document_create(const gchar *utf8_filename)
 	doc->priv->last_check = time(NULL);
 #endif
 
+	g_datalist_init(&doc->priv->data);
+
 	sidebar_openfiles_add(doc);	/* sets doc->iter */
 
 	notebook_new_tab(doc);
@@ -711,6 +713,8 @@ static gboolean remove_page(guint page_num)
 	/* Checking real_path makes it likely the file exists on disk */
 	if (! main_status.closing_all && doc->real_path != NULL)
 		ui_add_recent_document(doc);
+
+	g_datalist_clear(&doc->priv->data);
 
 	doc->is_valid = FALSE;
 	doc->id = 0;
@@ -3839,3 +3843,22 @@ GEANY_API_SYMBOL
 GType document_get_type (void);
 
 G_DEFINE_BOXED_TYPE(GeanyDocument, document, copy_, free_);
+
+
+gpointer document_get_data(const GeanyDocument *doc, const gchar *key)
+{
+	return g_datalist_get_data(&doc->priv->data, key);
+}
+
+
+void document_set_data(GeanyDocument *doc, const gchar *key, gpointer data)
+{
+	g_datalist_set_data(&doc->priv->data, key, data);
+}
+
+
+void document_set_data_full(GeanyDocument *doc, const gchar *key,
+	gpointer data, GDestroyNotify free_func)
+{
+	g_datalist_set_data_full(&doc->priv->data, key, data, free_func);
+}

--- a/src/document.h
+++ b/src/document.h
@@ -316,6 +316,13 @@ void document_grab_focus(GeanyDocument *doc);
 
 GeanyDocument *document_clone(GeanyDocument *old_doc);
 
+gpointer document_get_data(const GeanyDocument *doc, const gchar *key);
+
+void document_set_data(GeanyDocument *doc, const gchar *key, gpointer data);
+
+void document_set_data_full(GeanyDocument *doc, const gchar *key,
+	gpointer data, GDestroyNotify free_func);
+
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS

--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -111,6 +111,8 @@ typedef struct GeanyDocumentPrivate
 	gint			 protected;
 	/* Save pointer to info bars allowing to cancel them programatically (to avoid multiple ones) */
 	GtkWidget		*info_bars[NUM_MSG_TYPES];
+	/* Keyed Data List to attach arbitrary data to the document */
+	GData			*data;
 }
 GeanyDocumentPrivate;
 

--- a/src/pluginutils.h
+++ b/src/pluginutils.h
@@ -33,6 +33,7 @@ G_BEGIN_DECLS
 
 /* avoid including plugindata.h otherwise this redefines the GEANY() macro */
 struct GeanyPlugin;
+struct GeanyDocument;
 
 
 void plugin_add_toolbar_item(struct GeanyPlugin *plugin, GtkToolItem *item);
@@ -61,6 +62,16 @@ void plugin_show_configure(struct GeanyPlugin *plugin);
 
 void plugin_builder_connect_signals(struct GeanyPlugin *plugin,
 	GtkBuilder *builder, gpointer user_data);
+
+gpointer plugin_get_document_data(struct GeanyPlugin *plugin,
+	struct GeanyDocument *doc, const gchar *key);
+
+void plugin_set_document_data(struct GeanyPlugin *plugin, struct GeanyDocument *doc,
+	const gchar *key, gpointer data);
+
+void plugin_set_document_data_full(struct GeanyPlugin *plugin,
+	struct GeanyDocument *doc, const gchar *key, gpointer data,
+	GDestroyNotify free_func);
 
 G_END_DECLS
 


### PR DESCRIPTION
It's useful to be able to attach arbitrary data to documents, especially for plugins. This PR adds GObject-like keyed data lists to documents so plugins can add stuff similar to `g_object_get|set_data()`. The first commit adds a simple wrapper to the document module, the second exposes a safe API for plugins.

In the future if GeanyDocument is ever converted to a GObject, the new `document_get|set_data()` functions could become simple wrappers around `g_object_get|set_data()` rather than using keyed data lists directly.

Aside from conventional plugins, this will also be useful for planned "filetype plugins" from #1195 and possibly for certain proxy plugin implementations, and could even prove useful in the core.

I made a very simple test plugin to tinker with this in https://github.com/codebrainz/geany/commit/b662ba3ca15969429ee2f9cf4c00e84024e499bd.