### PR TITLE
Inherit C lexer_properties in all filetypes inheriting C styles

### DIFF
--- a/data/filedefs/filetypes.CUDA.conf
+++ b/data/filedefs/filetypes.CUDA.conf
@@ -11,9 +11,7 @@ secondary=__device__ __global__ __shared__ __host__ __constant__ gridDim blockId
 # these are the Doxygen keywords
 docComment=a addindex addtogroup anchor arg attention author authors b brief bug c callergraph callgraph category cite class code cond copybrief copydetails copydoc copyright date def defgroup deprecated details dir dontinclude dot dotfile e else elseif em endcode endcond enddot endhtmlonly endif endinternal endlatexonly endlink endmanonly endmsc endrtfonly endverbatim endxmlonly enum example exception extends file fn headerfile hideinitializer htmlinclude htmlonly if ifnot image implements include includelineno ingroup interface internal invariant latexonly li line link mainpage manonly memberof msc mscfile n name namespace nosubgrouping note overload p package page par paragraph param post pre private privatesection property protected protectedsection protocol public publicsection ref related relatedalso relates relatesalso remark remarks result return returns retval rtfonly sa section see short showinitializer since skip skipline snippet struct subpage subsection subsubsection tableofcontents test throw throws todo tparam typedef union until var verbatim verbinclude version warning weakgroup xmlonly xrefitem
 
-[lexer_properties]
-styling.within.preprocessor=1
-lexer.cpp.track.preprocessor=0
+[lexer_properties=C]
 
 [settings]
 lexer_filetype=C

--- a/data/filedefs/filetypes.Genie.conf
+++ b/data/filedefs/filetypes.Genie.conf
@@ -8,7 +8,7 @@ primary=abstract and array as assert async bool break byte case cast char class 
 # these are the Doxygen and Valadoc keywords
 docComment=a addindex addtogroup anchor arg attention author authors b brief bug c callergraph callgraph category cite class code cond copybrief copydetails copydoc copyright date def defgroup deprecated details dir dontinclude dot dotfile e else elseif em endcode endcond enddot endhtmlonly endif endinternal endlatexonly endlink endmanonly endmsc endrtfonly endverbatim endxmlonly enum example exception extends file fn headerfile hideinitializer htmlinclude htmlonly if ifnot image implements include includelineno ingroup inheritDoc interface internal invariant latexonly li line link mainpage manonly memberof msc mscfile n name namespace nosubgrouping note overload p package page par paragraph param post pre private privatesection property protected protectedsection protocol public publicsection ref related relatedalso relates relatesalso remark remarks result return returns retval rtfonly sa section see short showinitializer since skip skipline snippet struct subpage subsection subsubsection tableofcontents test throw throws todo tparam typedef union until var verbatim verbinclude version warning weakgroup xmlonly xrefitem
 
-[lexer_properties]
+[lexer_properties=C]
 lexer.cpp.triplequoted.strings=1
 
 [settings]

--- a/data/filedefs/filetypes.Graphviz.conf
+++ b/data/filedefs/filetypes.Graphviz.conf
@@ -8,9 +8,9 @@ secondary=Damping K URL area arrowhead arrowsize arrowtail aspect bb bgcolor col
 
 # these are the Doxygen keywords
 docComment=
-[lexer_properties]
+
+[lexer_properties=C]
 styling.within.preprocessor=0
-lexer.cpp.track.preprocessor=0
 
 [settings]
 lexer_filetype=C

--- a/data/filedefs/filetypes.JSON.conf
+++ b/data/filedefs/filetypes.JSON.conf
@@ -1,5 +1,7 @@
 [styling=C]
 
+[lexer_properties=C]
+
 [keywords]
 primary=true false null
 

--- a/data/filedefs/filetypes.Scala.conf
+++ b/data/filedefs/filetypes.Scala.conf
@@ -9,7 +9,7 @@ secondary=null super this AllRef Any AnyRef Array Attribute Elem Iterable List O
 # these are some doxygen keywords (incomplete)
 docComment=attention author brief bug class code date def enum example exception file fn namespace note param remarks return see since struct throw todo typedef var version warning union
 
-[lexer_properties]
+[lexer_properties=C]
 lexer.cpp.triplequoted.strings=1
 
 [settings]

--- a/data/filedefs/filetypes.actionscript
+++ b/data/filedefs/filetypes.actionscript
@@ -7,6 +7,8 @@ primary=arguments break case catch class const continue default do dynamic each 
 secondary=decodeURI decodeURIcomponent encodeURI encodeURIcomponent escape isFinite isNaN isXMLName parseFloat parseInt trace unescape
 classes=ArgumentError Array Boolean Class Date DefinitionError Error EvalError Function int Math NameSpace Null Number Object QName RangeError ReferenceError RegExp SecurityError String SyntaxError TypeError uint URIError Vector VerifyError void XML XMLList
 
+[lexer_properties=C]
+
 [settings]
 # default extension used when saving files
 extension=as

--- a/data/filedefs/filetypes.cpp
+++ b/data/filedefs/filetypes.cpp
@@ -8,9 +8,7 @@ secondary=
 # these are the Doxygen keywords
 docComment=a addindex addtogroup anchor arg attention author authors b brief bug c callergraph callgraph category cite class code cond copybrief copydetails copydoc copyright date def defgroup deprecated details dir dontinclude dot dotfile e else elseif em endcode endcond enddot endhtmlonly endif endinternal endlatexonly endlink endmanonly endmsc endrtfonly endverbatim endxmlonly enum example exception extends file fn headerfile hideinitializer htmlinclude htmlonly if ifnot image implements include includelineno ingroup interface internal invariant latexonly li line link mainpage manonly memberof msc mscfile n name namespace nosubgrouping note overload p package page par paragraph param post pre private privatesection property protected protectedsection protocol public publicsection ref related relatedalso relates relatesalso remark remarks result return returns retval rtfonly sa section see short showinitializer since skip skipline snippet struct subpage subsection subsubsection tableofcontents test throw throws todo tparam typedef union until var verbatim verbinclude version warning weakgroup xmlonly xrefitem
 
-[lexer_properties]
-styling.within.preprocessor=1
-lexer.cpp.track.preprocessor=0
+[lexer_properties=C]
 
 [settings]
 lexer_filetype=C

--- a/data/filedefs/filetypes.cs
+++ b/data/filedefs/filetypes.cs
@@ -8,9 +8,7 @@ secondary=
 # these are some doxygen keywords (incomplete)
 docComment=attention author brief bug class code date def enum example exception file fn namespace note param remarks return see since struct throw todo typedef var version warning union
 
-[lexer_properties]
-styling.within.preprocessor=1
-lexer.cpp.track.preprocessor=0
+[lexer_properties=C]
 
 [settings]
 lexer_filetype=C

--- a/data/filedefs/filetypes.ferite
+++ b/data/filedefs/filetypes.ferite
@@ -7,6 +7,8 @@ primary=false null self super true abstract alias and arguments attribute_missin
 types=boolean string number array object void XML Unix Sys String Stream Serialize RMI Posix Number Network Math FileSystem Console Array Regexp XSLT
 docComment=brief class declaration description end example extends function group implements modifies module namespace param protocol return return static type variable warning
 
+[lexer_properties=C]
+
 [settings]
 # default extension used when saving files
 extension=fe

--- a/data/filedefs/filetypes.glsl
+++ b/data/filedefs/filetypes.glsl
@@ -8,9 +8,7 @@ secondary=
 # these are some doxygen keywords (incomplete)
 docComment=attention author brief bug class code date def enum example exception file fn namespace note param remarks return returns see since struct throw todo typedef var version warning union
 
-[lexer_properties]
-styling.within.preprocessor=1
-lexer.cpp.track.preprocessor=0
+[lexer_properties=C]
 
 [settings]
 lexer_filetype=C

--- a/data/filedefs/filetypes.go
+++ b/data/filedefs/filetypes.go
@@ -10,9 +10,8 @@ secondary=bool byte complex64 complex128 error float32 float64 int int8 int16 in
 # these are the Doxygen keywords
 docComment=a addindex addtogroup anchor arg attention author authors b brief bug c callergraph callgraph category cite class code cond copybrief copydetails copydoc copyright date def defgroup deprecated details dir dontinclude dot dotfile e else elseif em endcode endcond enddot endhtmlonly endif endinternal endlatexonly endlink endmanonly endmsc endrtfonly endverbatim endxmlonly enum example exception extends file fn headerfile hideinitializer htmlinclude htmlonly if ifnot image implements include includelineno ingroup interface internal invariant latexonly li line link mainpage manonly memberof msc mscfile n name namespace nosubgrouping note overload p package page par paragraph param post pre private privatesection property protected protectedsection protocol public publicsection ref related relatedalso relates relatesalso remark remarks result return returns retval rtfonly sa section see short showinitializer since skip skipline snippet struct subpage subsection subsubsection tableofcontents test throw throws todo tparam typedef union until var verbatim verbinclude version warning weakgroup xmlonly xrefitem
 
-[lexer_properties]
+[lexer_properties=C]
 lexer.cpp.backquoted.strings=1
-styling.within.preprocessor=1
 lexer.cpp.allow.dollars=0
 fold.preprocessor=0
 

--- a/data/filedefs/filetypes.haxe
+++ b/data/filedefs/filetypes.haxe
@@ -7,7 +7,7 @@ primary=abstract break case catch class const continue trace do else enum extend
 secondary=Bool Dynamic Float Int null Void Enum String
 classes=Array ArrayAccess Class Date DateTools EReg Hash IntHash IntIter Iterable Iterator Lambda List Math Null Protected Reflect Std StringBuf StringTools Type UInt ValueType Xml XmlType
 
-[lexer_properties]
+[lexer_properties=C]
 # Haxe preprocessor has different directive than C, which the C lexer doesn't understand, so
 # we explicitly need not track the preprocessor at all.
 lexer.cpp.track.preprocessor=0

--- a/data/filedefs/filetypes.java
+++ b/data/filedefs/filetypes.java
@@ -8,6 +8,7 @@ secondary=boolean byte char double float int long short void
 doccomment=author deprecated exception param return see serial serialData serialField since throws todo version
 typedefs=
 
+[lexer_properties=C]
 
 [settings]
 # default extension used when saving files

--- a/data/filedefs/filetypes.javascript
+++ b/data/filedefs/filetypes.javascript
@@ -6,6 +6,8 @@
 primary=break case catch class const continue default delete do each else extends false finally for function get if in Infinity instanceof let NaN new null return set static super switch this throw true try typeof undefined var void while with yield prototype
 secondary=Array Boolean Date Function Math Number Object String RegExp EvalError Error RangeError ReferenceError SyntaxError TypeError URIError constructor prototype decodeURI decodeURIComponent encodeURI encodeURIComponent eval isFinite isNaN parseFloat parseInt
 
+[lexer_properties=C]
+
 [settings]
 # default extension used when saving files
 extension=js

--- a/data/filedefs/filetypes.vala
+++ b/data/filedefs/filetypes.vala
@@ -8,9 +8,7 @@ primary=abstract as async base bool break callback case catch char class const c
 # these are the Doxygen and Valadoc keywords
 docComment=a addindex addtogroup anchor arg attention author authors b brief bug c callergraph callgraph category cite class code cond copybrief copydetails copydoc copyright date def defgroup deprecated details dir dontinclude dot dotfile e else elseif em endcode endcond enddot endhtmlonly endif endinternal endlatexonly endlink endmanonly endmsc endrtfonly endverbatim endxmlonly enum example exception extends file fn headerfile hideinitializer htmlinclude htmlonly if ifnot image implements include includelineno ingroup inheritDoc interface internal invariant latexonly li line link mainpage manonly memberof msc mscfile n name namespace nosubgrouping note overload p package page par paragraph param post pre private privatesection property protected protectedsection protocol public publicsection ref related relatedalso relates relatesalso remark remarks result return returns retval rtfonly sa section see short showinitializer since skip skipline snippet struct subpage subsection subsubsection tableofcontents test throw throws todo tparam typedef union until var verbatim verbinclude version warning weakgroup xmlonly xrefitem
 
-[lexer_properties]
-styling.within.preprocessor=1
-lexer.cpp.track.preprocessor=0
+[lexer_properties=C]
 lexer.cpp.triplequoted.strings=1
 
 [settings]


### PR DESCRIPTION
`lexer.cpp.track.preprocessor` lexer properties affects which styles
are used, and we don't set those, so no filetype inheriting C styles
should set it to 1.

Similarly, some properties like `styling.within.preprocessor` are
mostly general settings rather than selecting syntax details, so they
should probably match in all filetypes for consistency.

So, inherit the C lexer_properties everywhere C styles are used, and
only override specific properties in the inheriting filetype.