### PR TITLE
Add utils_get_real_path() and use it

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -41,7 +41,7 @@ typedef struct GeanyApp
 {
 	gboolean			debug_mode;		/**< @c TRUE if debug messages should be printed. */
 	/** User configuration directory, usually @c ~/.config/geany.
-	 * This is a full path read by @ref tm_get_real_path().
+	 * This is a full path read by @ref utils_get_real_path().
 	 * @note Plugin configuration files should be saved as:
 	 * @code g_build_path(G_DIR_SEPARATOR_S, geany->app->configdir, "plugins", "pluginname",
 	 * 	"file.conf", NULL); @endcode */

--- a/src/document.c
+++ b/src/document.c
@@ -126,7 +126,7 @@ static GtkWidget* document_show_message(GeanyDocument *doc, GtkMessageType msgty
  * Finds a document whose @c real_path field matches the given filename.
  *
  * @param realname The filename to search, which should be identical to the
- * string returned by @c tm_get_real_path().
+ * string returned by @c utils_get_real_path().
  *
  * @return @transfer{none} @nullable The matching document, or @c NULL.
  * @note This is only really useful when passing a @c TMSourceFile::file_name.
@@ -163,7 +163,7 @@ GeanyDocument* document_find_by_real_path(const gchar *realname)
 static gchar *get_real_path_from_utf8(const gchar *utf8_filename)
 {
 	gchar *locale_name = utils_get_locale_from_utf8(utf8_filename);
-	gchar *realname = tm_get_real_path(locale_name);
+	gchar *realname = utils_get_real_path(locale_name);
 
 	g_free(locale_name);
 	return realname;
@@ -1348,7 +1348,7 @@ GeanyDocument *document_open_file_full(GeanyDocument *doc, const gchar *filename
 			g_return_val_if_fail(doc != NULL, NULL); /* really should not happen */
 
 			/* file exists on disk, set real_path */
-			SETPTR(doc->real_path, tm_get_real_path(locale_filename));
+			SETPTR(doc->real_path, utils_get_real_path(locale_filename));
 
 			doc->priv->is_remote = utils_is_remote_path(locale_filename);
 			monitor_file_setup(doc);
@@ -2029,7 +2029,7 @@ static gchar *save_doc(GeanyDocument *doc, const gchar *locale_filename,
 	/* now the file is on disk, set real_path */
 	if (doc->real_path == NULL)
 	{
-		doc->real_path = tm_get_real_path(locale_filename);
+		doc->real_path = utils_get_real_path(locale_filename);
 		doc->priv->is_remote = utils_is_remote_path(locale_filename);
 		monitor_file_setup(doc);
 	}

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -760,7 +760,7 @@ static gint setup_config_dir(void)
 	}
 	/* make configdir a real path */
 	if (g_file_test(app->configdir, G_FILE_TEST_EXISTS))
-		SETPTR(app->configdir, tm_get_real_path(app->configdir));
+		SETPTR(app->configdir, utils_get_real_path(app->configdir));
 
 	return mkdir_result;
 }

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -59,7 +59,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 229
+#define GEANY_API_VERSION 230
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */

--- a/src/tagmanager/tm_source_file.c
+++ b/src/tagmanager/tm_source_file.c
@@ -115,6 +115,8 @@ static char *realpath (const char *pathname, char *resolved_path)
  of the file.
  @param file_name The original file_name
  @return A newly allocated string containing the real path to the file. NULL if none is available.
+ @deprecated since 1.29 (ABI 230)
+ @see utils_get_real_path()
 */
 GEANY_API_SYMBOL
 gchar *tm_get_real_path(const gchar *file_name)

--- a/src/tagmanager/tm_source_file.h
+++ b/src/tagmanager/tm_source_file.h
@@ -42,7 +42,11 @@ TMSourceFile *tm_source_file_new(const char *file_name, const char *name);
 
 void tm_source_file_free(TMSourceFile *source_file);
 
-gchar *tm_get_real_path(const gchar *file_name);
+gchar *tm_get_real_path(const gchar *file_name)
+#ifndef GEANY_PRIVATE
+G_DEPRECATED_FOR(utils_get_real_path)
+#endif
+;
 
 #ifdef GEANY_PRIVATE
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -37,6 +37,7 @@
 #include "sciwrappers.h"
 #include "spawn.h"
 #include "support.h"
+#include "tm_source_file.h" // for tm_get_real_path()
 #include "templates.h"
 #include "ui_utils.h"
 #include "win32.h"
@@ -1757,7 +1758,7 @@ gboolean utils_is_remote_path(const gchar *path)
 
 /* Remove all relative and untidy elements from the path of @a filename.
  * @param filename must be a valid absolute path.
- * @see tm_get_real_path() - also resolves links. */
+ * @see utils_get_real_path() - also resolves links. */
 void utils_tidy_path(gchar *filename)
 {
 	GString *str;
@@ -2168,4 +2169,30 @@ void utils_start_new_geany_instance(const gchar *doc_path)
 	}
 	else
 		g_printerr("Unable to find 'geany'");
+}
+
+
+/**
+ * Get a link-dereferenced, absolute version of a file name.
+ *
+ * This is similar to the POSIX `realpath` function when passed a
+ * @c NULL argument.
+ *
+ * @warning This function suffers the same problems as the POSIX
+ * function `realpath()`, namely that it's impossible to determine
+ * a suitable size for the returned buffer, and so it's limited to a
+ * maximum of `PATH_MAX`.
+ *
+ * @param file_name The file name to get the real path of.
+ *
+ * @return A newly-allocated string containing the real path which
+ * should be freed with `g_free()` when no longer needed, or @c NULL
+ * if the real path cannot be obtained.
+ *
+ * @since 1.29 (API 230)
+ */
+GEANY_API_SYMBOL
+gchar *utils_get_real_path(const gchar *file_name)
+{
+	return tm_get_real_path(file_name);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -211,6 +211,7 @@ gchar *utils_find_open_xml_tag(const gchar sel[], gint size);
 
 const gchar *utils_find_open_xml_tag_pos(const gchar sel[], gint size);
 
+gchar *utils_get_real_path(const gchar *file_name);
 
 #ifdef GEANY_PRIVATE
 


### PR DESCRIPTION
This is a wrapper around `tm_get_real_path()` but is in a more suitable namespace/module.

I think it makes more sense like this. I typically dislike adding general-purpose functions to the API, but since Glib doesn't provide any equivalent, it really is useful.
