### PR TITLE
Fix: Improve documentation on duplication

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3357,6 +3357,10 @@ Delete to line start            Ctrl-Shift-BackSpace      Deletes from the begin
                                                           current caret position.
 
 Duplicate line or selection     Ctrl-D                    Duplicates the current line or selection.
+							  If the selection spans more than one line,
+							  this duplicates the lines containing selections.
+							  If the selection spans only a single line, then only
+							  the selection is duplicated.
 
 Transpose current line                                    Transposes the current line with the previous one.
 


### PR DESCRIPTION
Previously, the documentation on the duplication did not clearly delineate the behavior of the `duplication` keystroke.
Specifically, it was possible to interpret this keystroke as performing selection-only `duplication`.
However, `duplication` only duplicates the selection on the same line, or the multiple lines which are selected.

Accordingly, add additional statements clarifying the behavior of `duplication`.

This is intended to fix [issue #1075](https://github.com/geany/geany/issues/1075)