### PR TITLE
Do not strip dots from proxy plugin extensions

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -2005,18 +2005,6 @@ static void pm_show_dialog(GtkMenuItem *menuitem, gpointer user_data)
 }
 
 
-static const gchar *fix_extension(const gchar *ext)
-{
-	if (*ext == '.')
-	{
-		g_warning(_("Proxy plugin extension '%s' starts with a dot, "
-			"stripping. Please fix your proxy plugin."), ext);
-		ext++;
-	}
-	return ext;
-}
-
-
 /** Register the plugin as a proxy for other plugins
  *
  * Proxy plugins register a list of file extensions and a set of callbacks that are called
@@ -2067,8 +2055,14 @@ gboolean geany_plugin_register_proxy(GeanyPlugin *plugin, const gchar **extensio
 
 	foreach_strv(ext, extensions)
 	{
+		if (**ext == '.')
+		{
+			g_warning(_("Proxy plugin '%s' extension '%s' starts with a dot. "
+				"Please fix your proxy plugin."), p->info.name, *ext);
+		}
+
 		proxy = g_new(PluginProxy, 1);
-		g_strlcpy(proxy->extension, fix_extension(*ext), sizeof(proxy->extension));
+		g_strlcpy(proxy->extension, *ext, sizeof(proxy->extension));
 		proxy->plugin = p;
 		/* prepend, so that plugins automatically override core providers for a given extension */
 		g_queue_push_head(&active_proxies, proxy);


### PR DESCRIPTION
Only warn when an extension starts with a dot, because it's unlikely to
be what the author wanted, but leave the dot there.  This both forces
the author to fix the extension, and allows future use of the dot if
wanted.

Also, include the proxy plugin name in the warning message.

Follow-up to #1212.