### PR TITLE
Added option to auto reload files changed on disk

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2601,6 +2601,10 @@ gio_unsafe_save_backup            Make a backup when using GIO unsafe file     f
 keep_edit_history_on_reload       Whether to maintain the edit history when    true        immediately
                                   reloading a file, and allow the operation
                                   to be reverted.
+reload_clean_doc_on_file_change   Whether to automatically reload documents    false       immediately
+                                  which have changed on disk.
+                                  If unsaved changes exist then the user is
+                                  prompted to reload manually.
 **Filetype related**
 extract_filetype_regex            Regex to extract filetype name from file     See below.  immediately
                                   via capture group one.

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2602,7 +2602,8 @@ keep_edit_history_on_reload       Whether to maintain the edit history when    t
                                   reloading a file, and allow the operation
                                   to be reverted.
 reload_clean_doc_on_file_change   Whether to automatically reload documents    false       immediately
-                                  which have changed on disk.
+                                  that have no changes but which have changed
+                                  on disk.
                                   If unsaved changes exist then the user is
                                   prompted to reload manually.
 **Filetype related**

--- a/src/document.c
+++ b/src/document.c
@@ -3609,6 +3609,12 @@ static void enable_key_intercept(GeanyDocument *doc, GtkWidget *bar)
 
 static void monitor_reload_file(GeanyDocument *doc)
 {
+	if (! doc->changed && file_prefs.reload_clean_doc_on_file_change)
+	{
+		document_reload_force(doc, doc->encoding);
+		return;
+	}
+
 	gchar *base_name = g_path_get_basename(doc->file_name);
 
 	/* show this message only once */

--- a/src/document.h
+++ b/src/document.h
@@ -66,6 +66,7 @@ typedef struct GeanyFilePrefs
 	gboolean		tab_close_switch_to_mru;
 	gboolean		keep_edit_history_on_reload; /* Keep undo stack upon, and allow undoing of, document reloading. */
 	gboolean		show_keep_edit_history_on_reload_msg; /* whether to show the message introducing the above feature */
+ 	gboolean		reload_clean_doc_on_file_change;
 }
 GeanyFilePrefs;
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -246,6 +246,8 @@ static void init_pref_groups(void)
 		"keep_edit_history_on_reload", TRUE);
 	stash_group_add_boolean(group, &file_prefs.show_keep_edit_history_on_reload_msg,
 		"show_keep_edit_history_on_reload_msg", TRUE);
+	stash_group_add_boolean(group, &file_prefs.reload_clean_doc_on_file_change,
+		"reload_clean_doc_on_file_change", FALSE);
 	/* for backwards-compatibility */
 	stash_group_add_integer(group, &editor_prefs.indentation->hard_tab_width,
 		"indent_hard_tab_width", 8);


### PR DESCRIPTION
When option is enabled geany automatically reloads files which
have changed on disk.
When the option is disabled (default) geany shows the reload
dialog as before.

Created new pull request due to mistakes in:
https://github.com/geany/geany/pull/1245

Fixes issue:
https://github.com/geany/geany/issues/301
