### PR TITLE
Provide utf-8 command line arguments on Windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,41 @@
 
 #include "main.h"
 
+#ifdef G_OS_WIN32
+# include <windows.h>
+#endif
+
 int main(int argc, char **argv)
 {
-	return main_lib(argc, argv);
+#ifdef G_OS_WIN32
+	if (argc > 1)
+	{
+		int num_arg;
+		LPWSTR *szarglist = CommandLineToArgvW(GetCommandLineW(), &num_arg);
+		char** utf8argv = g_new0(char *, num_arg + 1);
+		int i = num_arg;
+		while(i){
+			i--;
+			utf8argv[i] = g_utf16_to_utf8((gunichar2 *)szarglist[i], -1, NULL, NULL, NULL);
+		}
+
+		gint result = main_lib(num_arg, utf8argv);
+
+		i = num_arg;
+		while(i){
+			i--;
+			g_free(utf8argv[i]);
+		}
+		g_free(utf8argv);
+		LocalFree(szarglist);
+
+		return result;
+	}
+	else
+	{
+#endif
+		return main_lib(argc, argv);
+#ifdef G_OS_WIN32
+	}
+#endif
 }


### PR DESCRIPTION
Windows filenames (NTFS) may contain unicode characters. Passing the filename to `geany.exe` as command line argument does not open the file.

At startup, it can get all arguments in UTF-16, and convert them to UTF-8. So filenames containing unicode characters can be passed to `geany.exe`.