### PR TITLE
Preventing destroying of symbolic/hard links in Windows OS.

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1957,9 +1957,9 @@ static gchar *write_data_to_disk(const gchar *locale_filename,
 		/* Use POSIX API for unsafe saving (GVFS-unsafe) */
 		/* The error handling is taken from glib-2.26.0 gfileutils.c */
 		errno = 0;
-		fp = fopen(locale_filename, "r+");	// truncate to  data_length + write_data    instead of   new_file + write_data
+		fp = fopen(locale_filename, "r+b");	// truncate to  data_length + write_data    instead of   new_file + write_data
 		if(errno==ENOENT)	// if saved document  not exist,  create document
-			file = fopen(locale_filename,"w");
+			file = fopen(locale_filename,"wb");
 		if (fp == NULL)
 		{
 			save_errno = errno;

--- a/src/document.c
+++ b/src/document.c
@@ -1959,7 +1959,7 @@ static gchar *write_data_to_disk(const gchar *locale_filename,
 		errno = 0;
 		fp = fopen(locale_filename, "r+b");	// truncate to  data_length + write_data    instead of   new_file + write_data
 		if(errno==ENOENT)	// if saved document  not exist,  create document
-			file = fopen(locale_filename,"wb");
+			fp = fopen(locale_filename,"wb");
 		if (fp == NULL)
 		{
 			save_errno = errno;

--- a/src/document.c
+++ b/src/document.c
@@ -1934,8 +1934,7 @@ static gchar *write_data_to_disk(const gchar *locale_filename,
 		if (g_file_set_contents(locale_filename, data, len, &error))
 			geany_debug("Wrote %s with g_file_set_contents().", locale_filename);
 	}
-	#ifndef G_OS_WIN32
-	else if (USE_GIO_FILE_OPERATIONS)	// skip this bad section on windows, because replaces  symlink by file  on document save ?
+	else if (USE_GIO_FILE_OPERATIONS)
 	{
 		GFile *fp;
 
@@ -1947,7 +1946,6 @@ static gchar *write_data_to_disk(const gchar *locale_filename,
 			G_FILE_CREATE_NONE, NULL, NULL, &error);
 		g_object_unref(fp);
 	}
-	#endif
 	else
 	{
 		FILE *fp;
@@ -1973,6 +1971,7 @@ static gchar *write_data_to_disk(const gchar *locale_filename,
 		}
 		else
 		{
+			// half safe writing
 			if(ftruncate(fileno(fp),sizeof(gchar)*len))
 			{
 				save_errno = errno;


### PR DESCRIPTION
Preventing destroying of symbolic/hard links to real documents on "document-save"  in Windows OS.