### PR TITLE
Add windows default for execute command

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -2655,7 +2655,11 @@ static struct
 	{ N_("_Make"), "make", NULL, &non_ft_def, GBO_TO_CMD(GEANY_GBO_MAKE_ALL)},
 	{ N_("Make Custom _Target..."), "make ", NULL, &non_ft_def, GBO_TO_CMD(GEANY_GBO_CUSTOM)},
 	{ N_("Make _Object"), "make %e.o", NULL, &non_ft_def, GBO_TO_CMD(GEANY_GBO_MAKE_OBJECT)},
+#ifdef G_OS_WIN32
+	{ N_("_Execute"), "./%e.exe", NULL, &exec_def, GBO_TO_CMD(GEANY_GBO_EXEC)},
+#else
 	{ N_("_Execute"), "./%e", NULL, &exec_def, GBO_TO_CMD(GEANY_GBO_EXEC)},
+#endif
 	{ NULL, NULL, NULL, NULL, 0 }
 };
 


### PR DESCRIPTION
Came up on IRC, for windows the execute command should have a .exe extension.

Note due to my lack of windows access the win branch of the `#ifdef` has not even been compiled, a winspurt should test and/or comment. 