### PR TITLE
Fix loading the default open encoding option

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -826,7 +826,9 @@ static void load_dialog_prefs(GKeyFile *config)
 		"none");
 	if (tmp_string)
 	{
-		const GeanyEncoding *enc = encodings_get_from_charset(tmp_string);
+		const GeanyEncoding *enc = NULL;
+		if (strcmp(tmp_string, "none") != 0)
+			enc = encodings_get_from_charset(tmp_string);
 		if (enc != NULL)
 			file_prefs.default_open_encoding = enc->idx;
 		else


### PR DESCRIPTION
This got broken by 907a79263d907fa354d3b4c6570f33047801dd84 back in 2011 as encoding names started to be compared more permissively, leading to "none" matching the "None" encoding.

This shouldn't be too much of a problem as trying the None encoding first should not cause any issue, but fix loading of the option anyway.

This however won't restore settings from existing configuration files that used the previous code, as there is no way to tell whether the user selected the None encoding voluntarily or not.

---

To reproduce the issue, go to the file preferences, and deactivate the *Use fixed encoding when opening non-Unicode files*.  Save the setting, and restart Geany: you'll see the setting is activated again.
