### PR TITLE
Sync highlighted symbol with cursor position

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -525,7 +525,14 @@ static void on_update_ui(GeanyEditor *editor, G_GNUC_UNUSED SCNotification *nt)
 	/* brace highlighting */
 	editor_highlight_braces(editor, pos);
 
-	ui_update_statusbar(editor->document, pos);
+	/* update status bar */
+	const gchar *scope = NULL;
+	const gint tag_line = symbols_get_current_scope(editor->document, &scope);
+	ui_update_statusbar_with_scope(editor->document, pos, scope);
+
+	/* update selection in symbols window */
+    gint cursor_line = sci_get_current_line(sci);
+	ui_update_symbols_window_selection(tag_line, scope, cursor_line);
 
 #if 0
 	/** experimental code for inverting selections */

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -64,6 +64,13 @@ gint symbols_get_current_function(GeanyDocument *doc, const gchar **tagname);
 
 gint symbols_get_current_scope(GeanyDocument *doc, const gchar **tagname);
 
+TMTag* symbols_get_current_selection_tag();
+
+gboolean symbols_select_tag(gint tag_line, const gchar *tagname);
+
+gboolean symbols_select_symbol_at_cursor(gint cursor_line);
+
+void symbols_clear_selection();
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -281,6 +281,7 @@ void ui_add_config_file_menu_item(const gchar *real_path, const gchar *label,
 
 void ui_update_statusbar(GeanyDocument *doc, gint pos);
 
+void ui_update_statusbar_with_scope(GeanyDocument *doc, gint pos, const gchar *scope);
 
 /* This sets the window title according to the current filename. */
 void ui_set_window_title(GeanyDocument *doc);
@@ -303,6 +304,7 @@ void ui_update_insert_include_item(GeanyDocument *doc, gint item);
 
 void ui_update_fold_items(void);
 
+void ui_update_symbols_window_selection(gint tag_line, const gchar *tag_name, gint cursor_line);
 
 void ui_create_insert_menu_items(void);
 


### PR DESCRIPTION
The symbols tree view is allowing to navigate through all symbols parsed by CTags. However, when editing a symbol in the editor panel, the highlighted symbol won't synchronize in the tree view. As discussed in issue #1325, an option is to resolve the symbol from the current cursor position.

My implementation of the feature is doing this in two steps:
1. Check if a direct match can be made between the cursor line and one of the TMTag inside the tree
2. If no direct match but in a scope, resolve by selecting this scope

If both steps fail, the selection is cleared.

One thing that I am not sure yet how to implement is the auto-adjustment of the scrollbar to reach the symbol if it's out of visible range. Maybe someone has an idea how to do that in a clean fashion? Should the automatic scroll be an option or default behavior?