### PR TITLE
api: rework GeanyProxyProbeResults compat symbols as defines

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -345,29 +345,17 @@ void geany_plugin_set_data(GeanyPlugin *plugin, gpointer data, GDestroyNotify fr
  */
 typedef enum
 {
-	/** @deprecated Use GEANY_PROXY_IGNORE instead.
-	 * @since 1.26 (API 226)
-	 */
-	PROXY_IGNORED,
-	/** @deprecated Use GEANY_PROXY_MATCH instead.
-	 * @since 1.26 (API 226)
-	 */
-	PROXY_MATCHED,
-	/** @deprecated Use GEANY_PROXY_RELATED instead.
-	 * @since 1.26 (API 226)
-	 */
-	PROXY_NOLOAD = 0x100,
 	/** The proxy is not responsible at all, and Geany or other plugins are free
 	 * to probe it.
 	 *
 	 * @since 1.29 (API 229)
 	 **/
-	GEANY_PROXY_IGNORE = PROXY_IGNORED,
+	GEANY_PROXY_IGNORE,
 	/** The proxy is responsible for this file, and creates a plugin for it.
 	 *
 	 * @since 1.29 (API 229)
 	 */
-	GEANY_PROXY_MATCH = PROXY_MATCHED,
+	GEANY_PROXY_MATCH,
 	/** The proxy is does not directly load it, but it's still tied to the proxy.
 	 *
 	 * This is for plugins that come in multiple files where only one of these
@@ -378,10 +366,22 @@ typedef enum
 	 *
 	 * @since 1.29 (API 229)
 	 */
-	GEANY_PROXY_RELATED = PROXY_MATCHED | PROXY_NOLOAD
+	GEANY_PROXY_RELATED = GEANY_PROXY_MATCH | 0x100
 }
 GeanyProxyProbeResults;
 
+/** @deprecated Use GEANY_PROXY_IGNORE instead.
+ * @since 1.26 (API 226)
+ */
+#define PROXY_IGNORED GEANY_PROXY_IGNORE
+/** @deprecated Use GEANY_PROXY_MATCH instead.
+ * @since 1.26 (API 226)
+ */
+#define PROXY_MATCHED GEANY_PROXY_MATCH
+/** @deprecated Use GEANY_PROXY_RELATED instead.
+ * @since 1.26 (API 226)
+ */
+#define PROXY_NOLOAD 0x100
 
 /** Hooks that need to be implemented by every proxy
  *


### PR DESCRIPTION
Constants with different namespace in the same enum confuse g-ir-scanner.er