### PR TITLE
Updated filetypes.javascript keywords

### DIFF
--- a/data/filedefs/filetypes.javascript
+++ b/data/filedefs/filetypes.javascript
@@ -3,7 +3,7 @@
 
 [keywords]
 # all items must be in one line
-primary=break case catch class const continue debugger default delete do each else enum export extends false finally for function get if import in Infinity instanceof let NaN new null return set static super switch this throw true try typeof undefined var void while with yield prototype async await
+primary=break case catch class const continue debugger default delete do else enum export extends false finally for function get if import in Infinity instanceof let NaN new null return set static super switch this throw true try typeof undefined var void while with yield prototype async await
 secondary=Array Boolean Date Function Math Number Object String RegExp EvalError Error RangeError ReferenceError SyntaxError TypeError URIError constructor prototype decodeURI decodeURIComponent encodeURI encodeURIComponent eval isFinite isNaN parseFloat parseInt alert
 
 [settings]

--- a/data/filedefs/filetypes.javascript
+++ b/data/filedefs/filetypes.javascript
@@ -3,8 +3,8 @@
 
 [keywords]
 # all items must be in one line
-primary=break case catch class const continue default delete do each else extends false finally for function get if in Infinity instanceof let NaN new null return set static super switch this throw true try typeof undefined var void while with yield prototype
-secondary=Array Boolean Date Function Math Number Object String RegExp EvalError Error RangeError ReferenceError SyntaxError TypeError URIError constructor prototype decodeURI decodeURIComponent encodeURI encodeURIComponent eval isFinite isNaN parseFloat parseInt
+primary=break case catch class const continue debugger default delete do each else enum export extends false finally for function get if import in Infinity instanceof let NaN new null return set static super switch this throw true try typeof undefined var void while with yield prototype async await
+secondary=Array Boolean Date Function Math Number Object String RegExp EvalError Error RangeError ReferenceError SyntaxError TypeError URIError constructor prototype decodeURI decodeURIComponent encodeURI encodeURIComponent eval isFinite isNaN parseFloat parseInt alert
 
 [settings]
 # default extension used when saving files

--- a/data/filedefs/filetypes.javascript
+++ b/data/filedefs/filetypes.javascript
@@ -4,7 +4,7 @@
 [keywords]
 # all items must be in one line
 primary=break case catch class const continue debugger default delete do else enum export extends false finally for function get if import in Infinity instanceof let NaN new null return set static super switch this throw true try typeof undefined var void while with yield prototype async await
-secondary=Array Boolean Date Function Math Number Object String RegExp EvalError Error RangeError ReferenceError SyntaxError TypeError URIError constructor prototype decodeURI decodeURIComponent encodeURI encodeURIComponent eval isFinite isNaN parseFloat parseInt alert
+secondary=Array Boolean Date Function Math Number Object String RegExp EvalError Error RangeError ReferenceError SyntaxError TypeError URIError constructor prototype decodeURI decodeURIComponent encodeURI encodeURIComponent eval isFinite isNaN parseFloat parseInt
 
 [settings]
 # default extension used when saving files


### PR DESCRIPTION
Based on ES6 keywords: [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords) and [ES6 specification](http://www.ecma-international.org/ecma-262/6.0/#sec-keywords).

I did a second 'amend' commit to remove `each` from primary since I didn't find anywhere it's keyworded.