### PR TITLE
C parser gets confused by backslashes

### DIFF
--- a/ctags/main/lcpp.c
+++ b/ctags/main/lcpp.c
@@ -704,7 +704,10 @@ process:
 				int next = getcFromInputFile ();
 
 				if (next == NEWLINE)
-					continue;
+				{
+					c = getcFromInputFile ();
+					goto process;
+				}
 				else
 					ungetcToInputFile (next);
 				break;

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -20,6 +20,7 @@ test_sources = \
 	array-spec.f90					\
 	attributes.cs					\
 	auto.f							\
+	backslashes.c					\
 	bit_field.c						\
 	block.f90						\
 	bracematch.js					\

--- a/tests/ctags/backslashes.c
+++ b/tests/ctags/backslashes.c
@@ -1,0 +1,29 @@
+typedef int T;
+
+int func1(\
+int var1, int var2, ...);
+
+int func2(int var1, \
+int var2, ...);
+
+int func3(T \
+          var1, T var2, ...);
+int func4(T var1, \
+          T var2, ...);
+
+int func5(int \
+          var1, int var2, ...);
+
+// check continuations in macros are properly handled
+#define MACRO1 \
+  (
+int func6(void);
+#define MACRO2(x) \
+  int x(void);
+#define MACRO3(y) \
+  int \
+  y \
+  ( \
+    void \
+  );
+int func7(int a);

--- a/tests/ctags/backslashes.c.tags
+++ b/tests/ctags/backslashes.c.tags
@@ -1,0 +1,12 @@
+# format=tagmanager
+MACRO1Ì65536Ö0
+MACRO2Ì131072Í(x)Ö0
+MACRO3Ì131072Í(y)Ö0
+TÌ4096Ö0Ïint
+func1Ì1024Í(int var1, int var2, ...)Ö0Ïint
+func2Ì1024Í(int var1, int var2, ...)Ö0Ïint
+func3Ì1024Í(T var1, T var2, ...)Ö0Ïint
+func4Ì1024Í(T var1, T var2, ...)Ö0Ïint
+func5Ì1024Í(int var1, int var2, ...)Ö0Ïint
+func6Ì1024Í(void)Ö0Ïint
+func7Ì1024Í(int a)Ö0Ïint


### PR DESCRIPTION
Original report received via email, here's an enhanced test case:

```C
typedef int T;

int func1( \
int var1, int var2, ...);

int func2(int var1, \
int var2, ...);

int func3(T \
          var1, T var2, ...);
int func4(T var1, \
          T var2, ...);

int func5(int \
          var1, int var2, ...);
```

Only emits tags for `func2()`, `func4()` and `func5()`.  Which is odd.