### PR TITLE
Themable compiler output in message window

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -4597,6 +4597,33 @@ indicator_error
 
     *Example:* ``indicator_error=0xff0000``
 
+msg_default
+	The default foreground color in the compiler tab of the message window.
+
+	Only the first argument (foreground color) is used.
+
+	*Example:* ``msg_default=0x000000``
+
+msg_error
+	The foreground color of compiler errors in the message window.
+
+	Only the first argument (foreground color) is used.
+
+	*Example:* ``msg_error=0xff0000``
+
+msg_context
+	The foreground color of the surrounding lines of compiler errors.
+
+	Only the first argument (foreground color) is used.
+
+	*Example:* ``msg_context=0x880000``
+
+msg_message
+	The foreground color of messages and commands in the message window.
+
+	Only the first argument (foreground color) is used.
+
+	*Example:* ``msg_message=0x0000cc``
 
 [settings] section
 ``````````````````

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -60,6 +60,10 @@
 
 static gchar *whitespace_chars = NULL;
 
+gint msg_context = 0x880000;
+gint msg_default = 0x000000;
+gint msg_error = 0xff0000;
+gint msg_message = 0x0000cc;
 
 typedef struct
 {
@@ -456,7 +460,29 @@ static void add_named_style(GKeyFile *config, const gchar *key)
 		GeanyLexerStyle *style = g_new0(GeanyLexerStyle, 1);
 
 		parse_keyfile_style(config, list, &gsd_default, style);
-		g_hash_table_insert(named_style_hash, g_strdup(key), style);
+
+		if (!strcmp(key, "msg_context"))
+		{
+			msg_context = style->foreground;
+			g_free(style);
+		}
+		else if (!strcmp(key, "msg_default"))
+		{
+			msg_default = style->foreground;
+			g_free(style);
+		}
+		else if (!strcmp(key, "msg_error"))
+		{
+			msg_error = style->foreground;
+			g_free(style);
+		}
+		else if (!strcmp(key, "msg_message"))
+		{
+			msg_message = style->foreground;
+			g_free(style);
+		}
+		else
+			g_hash_table_insert(named_style_hash, g_strdup(key), style);
 	}
 	g_strfreev(list);
 }

--- a/src/highlighting.h
+++ b/src/highlighting.h
@@ -45,6 +45,10 @@ typedef struct GeanyLexerStyle
 }
 GeanyLexerStyle;
 
+extern gint msg_context;
+extern gint msg_default;
+extern gint msg_error;
+extern gint msg_message;
 
 const GeanyLexerStyle *highlighting_get_style(gint ft_id, gint style_id);
 


### PR DESCRIPTION
Adds four new styling options to customize the colors in the compiler tab to address issue #1376. When the values are not set by a colorscheme the previously hardcoded colors will be used.

A minor drawback is that the few lines in the compiler tab that were using the GTK default foreground color don't do that anymore and are by default black now (but also themable).