### PR TITLE
Add option for linewrapping in message window

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1755,52 +1755,76 @@
                             <property name="can_focus">False</property>
                             <property name="left_padding">12</property>
                             <child>
-                              <object class="GtkHBox" id="hbox2">
+                              <object class="GtkVbox" id="vbox57">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="spacing">12</property>
                                 <child>
-                                  <object class="GtkLabel" id="label5">
+                                  <object class="GtkAlignment" id="alignment52">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Position:</property>
+                                    <property name="left_padding">6</property>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_msgwin_linewrap">
+                                        <property name="label" translatable="yes">Line wrapping</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Enable line wrapping in all tabs of the message window. Note: when changing the setting it is only applied to new messages.</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                    </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">0</property>
-                                  </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkRadioButton" id="radio_msgwin_vertical">
-                                    <property name="label" translatable="yes">Bottom</property>
+                                  <object class="GtkHBox" id="hbox2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="active">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label5">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Position:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkRadioButton" id="radio_msgwin_vertical">
+                                        <property name="label" translatable="yes">Bottom</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="active">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkRadioButton" id="radio_msgwin_horizontal">
+                                        <property name="label" translatable="yes">Right</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="active">True</property>
+                                        <property name="draw_indicator">True</property>
+                                        <property name="group">radio_msgwin_vertical</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="radio_msgwin_horizontal">
-                                    <property name="label" translatable="yes">Right</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="active">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">radio_msgwin_vertical</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">2</property>
-                                  </packing>
                                 </child>
                               </object>
                             </child>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -1916,6 +1916,10 @@ Position
 Message window
 ``````````````
 
+Line wrapping
+    Show long lines wrapped around to new display lines in the status-, compiler-
+    and message-tab. Changing this setting only affects newly printed lines.
+
 Position
     Whether to place the message window on the bottom or right of the editor window.
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -551,6 +551,7 @@ static void save_ui_prefs(GKeyFile *config)
 {
 	g_key_file_set_boolean(config, PACKAGE, "sidebar_visible", ui_prefs.sidebar_visible);
 	g_key_file_set_boolean(config, PACKAGE, "statusbar_visible", interface_prefs.statusbar_visible);
+	g_key_file_set_boolean(config, PACKAGE, "msgwin_linewrap", interface_prefs.msgwin_linewrap);
 	g_key_file_set_boolean(config, PACKAGE, "msgwindow_visible", ui_prefs.msgwindow_visible);
 	g_key_file_set_boolean(config, PACKAGE, "fullscreen", ui_prefs.fullscreen);
 
@@ -765,6 +766,7 @@ static void load_dialog_prefs(GKeyFile *config)
 	interface_prefs.sidebar_symbol_visible = utils_get_setting_boolean(config, PACKAGE, "sidebar_symbol_visible", TRUE);
 	interface_prefs.sidebar_openfiles_visible = utils_get_setting_boolean(config, PACKAGE, "sidebar_openfiles_visible", TRUE);
 	interface_prefs.statusbar_visible = utils_get_setting_boolean(config, PACKAGE, "statusbar_visible", TRUE);
+	interface_prefs.msgwin_linewrap = utils_get_setting_boolean(config, PACKAGE, "msgwin_linewrap", TRUE);
 	file_prefs.tab_order_ltr = utils_get_setting_boolean(config, PACKAGE, "tab_order_ltr", TRUE);
 	file_prefs.tab_order_beside = utils_get_setting_boolean(config, PACKAGE, "tab_order_beside", FALSE);
 	interface_prefs.show_notebook_tabs = utils_get_setting_boolean(config, PACKAGE, "show_notebook_tabs", TRUE);

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -112,8 +112,7 @@ void msgwin_set_messages_dir(const gchar *messages_dir)
 }
 
 
-static void
-on_width_change(GtkTreeView *treeview)
+static void on_width_change(GtkTreeView *treeview)
 {
 	/* get width of visible region of treeview */
 	GdkRectangle visible_rect;

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -112,6 +112,55 @@ void msgwin_set_messages_dir(const gchar *messages_dir)
 }
 
 
+static void
+on_width_change(GtkTreeView *treeview)
+{
+	/* get width of visible region of treeview */
+	GdkRectangle visible_rect;
+	visible_rect.width = 0;
+	gtk_tree_view_get_visible_rect (treeview, &visible_rect);
+	gint width = visible_rect.width;
+
+	/* limit maximum column width to visible region and adjust line wrap threshold */
+	GtkTreeViewColumn *column = gtk_tree_view_get_column(treeview, 0);
+	gtk_tree_view_column_set_max_width(column, width);
+	GList *cell_list = gtk_tree_view_column_get_cell_renderers (column);
+	g_object_set (G_OBJECT (cell_list->data), "wrap-width", width, NULL);
+}
+
+
+void treeview_set_linewrap(GtkTreeView *treeview, gboolean has_linewrap)
+{
+	if (has_linewrap) {
+		on_width_change(treeview);
+		g_signal_connect(msgwindow.tree_compiler, "size-allocate", G_CALLBACK(on_width_change), NULL);
+		g_signal_connect(msgwindow.tree_msg, "size-allocate", G_CALLBACK(on_width_change), NULL);
+		g_signal_connect(msgwindow.tree_status, "size-allocate", G_CALLBACK(on_width_change), NULL);
+	}
+	else
+	{
+		g_signal_handlers_disconnect_by_func(msgwindow.tree_compiler, on_width_change, NULL);
+		g_signal_handlers_disconnect_by_func(msgwindow.tree_msg, on_width_change, NULL);
+		g_signal_handlers_disconnect_by_func(msgwindow.tree_status, on_width_change, NULL);
+
+		/* set maximum column width and line wrap threshold to unlimited */
+		GtkTreeViewColumn *column = gtk_tree_view_get_column(treeview, 0);
+		GList *cell_list = gtk_tree_view_column_get_cell_renderers (column);
+		gtk_tree_view_column_set_max_width(column, -1);
+		g_object_set (G_OBJECT (cell_list->data), "wrap-width", -1, NULL);
+	}
+	gtk_widget_queue_draw(GTK_WIDGET(treeview));
+}
+
+
+void msgwin_set_linewrap(gboolean has_linewrap)
+{
+	treeview_set_linewrap(GTK_TREE_VIEW(msgwindow.tree_compiler), has_linewrap);
+	treeview_set_linewrap(GTK_TREE_VIEW(msgwindow.tree_msg), has_linewrap);
+	treeview_set_linewrap(GTK_TREE_VIEW(msgwindow.tree_status), has_linewrap);
+}
+
+
 void msgwin_init(void)
 {
 	msgwindow.notebook = ui_lookup_widget(main_widgets.window, "notebook_info");
@@ -130,6 +179,12 @@ void msgwin_init(void)
 
 	ui_widget_modify_font_from_string(msgwindow.scribble, interface_prefs.msgwin_font);
 	g_signal_connect(msgwindow.scribble, "populate-popup", G_CALLBACK(on_scribble_populate), NULL);
+
+	if (interface_prefs.msgwin_linewrap) {
+		g_signal_connect(msgwindow.tree_compiler, "size-allocate", G_CALLBACK(on_width_change), NULL);
+		g_signal_connect(msgwindow.tree_msg, "size-allocate", G_CALLBACK(on_width_change), NULL);
+		g_signal_connect(msgwindow.tree_status, "size-allocate", G_CALLBACK(on_width_change), NULL);
+	}
 }
 
 
@@ -174,6 +229,7 @@ static void prepare_status_tree_view(void)
 	g_object_unref(msgwindow.store_status);
 
 	renderer = gtk_cell_renderer_text_new();
+	g_object_set (G_OBJECT(renderer), "wrap-mode", GTK_WRAP_WORD, NULL);
 	column = gtk_tree_view_column_new_with_attributes(_("Status messages"), renderer, "text", 0, NULL);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(msgwindow.tree_status), column);
 
@@ -201,6 +257,7 @@ static void prepare_msg_tree_view(void)
 	g_object_unref(msgwindow.store_msg);
 
 	renderer = gtk_cell_renderer_text_new();
+	g_object_set (G_OBJECT(renderer), "wrap-mode", GTK_WRAP_WORD, NULL);
 	column = gtk_tree_view_column_new_with_attributes(NULL, renderer,
 		"foreground-gdk", MSG_COL_COLOR, "text", MSG_COL_STRING, NULL);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(msgwindow.tree_msg), column);
@@ -238,6 +295,7 @@ static void prepare_compiler_tree_view(void)
 	g_object_unref(msgwindow.store_compiler);
 
 	renderer = gtk_cell_renderer_text_new();
+	g_object_set (G_OBJECT(renderer), "wrap-mode", GTK_WRAP_WORD, NULL);
 	column = gtk_tree_view_column_new_with_attributes(NULL, renderer,
 		"foreground-gdk", COMPILER_COL_COLOR, "text", COMPILER_COL_STRING, NULL);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(msgwindow.tree_compiler), column);

--- a/src/msgwindow.h
+++ b/src/msgwindow.h
@@ -63,6 +63,8 @@ void msgwin_clear_tab(gint tabnum);
 
 void msgwin_switch_tab(gint tabnum, gboolean show);
 
+void msgwin_set_linewrap(gboolean b);
+
 void msgwin_set_messages_dir(const gchar *messages_dir);
 
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -504,6 +504,9 @@ static void prefs_init_dialog(void)
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_statusbar_visible");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), interface_prefs.statusbar_visible);
 
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_msgwin_linewrap");
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), interface_prefs.msgwin_linewrap);
+
 
 	/* Toolbar settings */
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_toolbar_show");
@@ -968,6 +971,9 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_statusbar_visible");
 		interface_prefs.statusbar_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_msgwin_linewrap");
+		interface_prefs.msgwin_linewrap = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
 
 		/* Toolbar settings */
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_toolbar_show");
@@ -1272,6 +1278,7 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 		/* apply the changes made */
 		ui_statusbar_showhide(interface_prefs.statusbar_visible);
+		msgwin_set_linewrap(interface_prefs.msgwin_linewrap);
 		sidebar_openfiles_update_all(); /* to update if full path setting has changed */
 		toolbar_apply_settings();
 		toolbar_update_ui();

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -55,6 +55,7 @@ typedef struct GeanyInterfacePrefs
 	gint			tab_pos_msgwin;				/**< positions of message window's tabs */
 	gint			tab_pos_sidebar;			/**< positions of sidebar's tabs */
 	gboolean		statusbar_visible;			/**< whether the status bar is visible */
+	gboolean		msgwin_linewrap;			/**< whether to enable linewrapping in the message window */
 	gboolean		show_symbol_list_expanders;	/**< whether to show expanders in the symbol list */
 	/** whether a double click on notebook tabs hides all other windows */
 	gboolean		notebook_double_click_hides_widgets;


### PR DESCRIPTION
Adds optional linewrapping in the status-, compiler- and message-tab of the message window.
Mainly useful with a vertical layout, but still has some issues:
- on_width_change() is called continuously while resizing the message window, 
  (I did not notice any impact on CPU usage though).
- when changing the setting, messages already present are not wrapped / unwrapped,
  only newly printed ones.
- when resizing the window, messages already present are wrapped only until 
  a new line would be required (but new messages work fine).
- Only very minor, but GTK word wrap treats the minus preceding command line arguments
  as separate words (-> 'gcc -Wall' can become 'gcc -\nWall')

I hope it's not rude to make a pull request directly without first opening a corresponding issue.