### PR TITLE
Fix Ctrl+X and Ctrl+C in non-Latin keyboard layouts

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -6321,6 +6321,7 @@
               <object class="GtkMenuBar" id="menubar1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <signal name="deactivate" handler="on_menubar1_deactivate" after="yes" swapped="no"/>
                 <child>
                   <object class="GtkMenuItem" id="file1">
                     <property name="visible">True</property>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -200,6 +200,12 @@ static void on_edit1_activate(GtkMenuItem *menuitem, gpointer user_data)
 }
 
 
+static void on_menubar1_deactivate(GtkMenuShell *menushell, gpointer user_data)
+{
+	ui_restore_menu_copy_items();
+}
+
+
 void on_undo1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -512,10 +512,18 @@ void ui_update_popup_goto_items(gboolean enable)
 }
 
 
+static void set_menu_copy_items_sensitive(gboolean enable)
+{
+	guint i, len;
+	len = G_N_ELEMENTS(widgets.menu_copy_items);
+	for (i = 0; i < len; i++)
+		ui_widget_set_sensitive(widgets.menu_copy_items[i], enable);
+}
+
+
 void ui_update_menu_copy_items(GeanyDocument *doc)
 {
 	gboolean enable = FALSE;
-	guint i, len;
 	GtkWidget *focusw = gtk_window_get_focus(GTK_WINDOW(main_widgets.window));
 
 	g_return_if_fail(doc == NULL || doc->is_valid);
@@ -533,9 +541,13 @@ void ui_update_menu_copy_items(GeanyDocument *doc)
 		enable = gtk_text_buffer_get_selection_bounds(buffer, NULL, NULL);
 	}
 
-	len = G_N_ELEMENTS(widgets.menu_copy_items);
-	for (i = 0; i < len; i++)
-		ui_widget_set_sensitive(widgets.menu_copy_items[i], enable);
+	set_menu_copy_items_sensitive(enable);
+}
+
+
+void ui_restore_menu_copy_items()
+{
+	set_menu_copy_items_sensitive(TRUE);
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -299,6 +299,8 @@ void ui_update_popup_goto_items(gboolean enable);
 
 void ui_update_menu_copy_items(GeanyDocument *doc);
 
+void ui_restore_menu_copy_items();
+
 void ui_update_insert_include_item(GeanyDocument *doc, gint item);
 
 void ui_update_fold_items(void);


### PR DESCRIPTION
A partial fix for #1368, #1286, #998. It doesn't add support for the hotkeys that are not bound to menu items, but fixes the most annoying and confusing part of the mentioned reports - about cut and copy that sometimes work, sometimes not.