### PR TITLE
Avoid gdk_display_get_name() on OS X

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -284,8 +284,15 @@ gint socket_init(gint argc, gchar **argv)
 	GdkDisplay *display = gdk_display_get_default();
 	gchar *p;
 
+	/* On OS X with quartz backend gdk_display_get_name() returns hostname
+	 * using [NSHost currentHost] (it could return more or less whatever string
+	 * as display name is a X11 specific thing). This call can lead to network
+	 * query and block for several seconds so better skip it. */
+#ifndef GDK_WINDOWING_QUARTZ
 	if (display != NULL)
 		display_name = g_strdup(gdk_display_get_name(display));
+#endif
+
 	if (display_name == NULL)
 		display_name = g_strdup("NODISPLAY");
 


### PR DESCRIPTION
More in the comment.

Fixes https://github.com/geany/geany/issues/1277

Even if the call gets replaced with something non-blocking in GDK, we can't be sure against which version of GTK Geany gets built (e.g. if someone is using Homebrew) so better to handle it in Geany too.