### PR TITLE
Always emit the project-save signal when writing project file

### DIFF
--- a/doc/pluginsignals.c
+++ b/doc/pluginsignals.c
@@ -142,8 +142,9 @@ signal void (*document_close)(GObject *obj, GeanyDocument *doc, gpointer user_da
 signal void (*project_open)(GObject *obj, GKeyFile *config, gpointer user_data);
 
 /** Sent when a project is saved (happens when the project is created, the properties
- *  dialog is closed or Geany is exited). This signal is emitted shortly before Geany
- *  will write the contents of the GKeyFile to the disc.
+ *  dialog is closed, before the project is closed, or when Geany is exited).
+ *  This signal is emitted shortly before Geany will write the contents of the
+ *  GKeyFile to the disc.
  *
  * @param obj a GeanyObject instance, should be ignored.
  * @param config an existing GKeyFile object which can be used to read and write data.

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -59,7 +59,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 230
+#define GEANY_API_VERSION 231
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */


### PR DESCRIPTION
For some reason "project-save" isn't emitted when closing project - see
write_config(FALSE) in project_close(). This means that in this case
plugins cannot save their configuration into the config file. This doesn't
even correspond to the documentation of the signal

"Sent when a project is saved (happens when the project is created, the
 properties dialog is closed or Geany is exited)"

as the signal isnt emitted when exiting Geany because at this point Geany
closes the project.

The comment seems to indicate that the reason is that "project-save"
shouldn't be emitted when "project-close" is emitted but I don't see any
reason why.

Bump API so plugins can rely on the changed behavior.