### PR TITLE
api: new function geany_api_version

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -59,7 +59,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 230
+#define GEANY_API_VERSION 231
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -52,6 +52,22 @@ typedef struct
 PluginDocDataProxy;
 
 
+/** Returns the runtime API version Geany was compiled with.
+ *
+ * Unlike @ref GEANY_API_VERSION this version is the value of that
+ * define at the time when Geany itself was compiled. This allows to
+ * establish soft dependencies which are resolved at runtime depending
+ * on Geany's API version.
+ *
+ * @return Geany's API version
+ * @since 1.30 (API 231)
+ **/
+GEANY_API_SYMBOL
+gint geany_api_version(void)
+{
+	return GEANY_API_VERSION;
+}
+
 /** Inserts a toolbar item before the Quit button, or after the previous plugin toolbar item.
  * A separator is added on the first call to this function, and will be shown when @a item is
  * shown; hidden when @a item is hidden.

--- a/src/pluginutils.h
+++ b/src/pluginutils.h
@@ -35,6 +35,7 @@ G_BEGIN_DECLS
 struct GeanyPlugin;
 struct GeanyDocument;
 
+gint geany_api_version(void);
 
 void plugin_add_toolbar_item(struct GeanyPlugin *plugin, GtkToolItem *item);
 


### PR DESCRIPTION
This allows plugins to detect the API version of Geany at runtime. This enables
switching behavior based on the API version (perhaps using a new feature
with a fallback for older API versions). Previously the only alternatives
were to hard-depend on a more recent Geany version or ignoring new features.