### PR TITLE
Fix crash when plugin_set_key_group() is called several times by plugins

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -2697,10 +2697,12 @@ GeanyKeyGroup *keybindings_set_group(GeanyKeyGroup *group, const gchar *section_
 		group = g_new0(GeanyKeyGroup, 1);
 		add_kb_group(group, section_name, label, callback, TRUE);
 	}
+	/* Calls free_key_binding() for individual entries for plugins - has to be
+	 * called before g_free(group->plugin_keys) */
+	g_ptr_array_set_size(group->key_items, 0);
 	g_free(group->plugin_keys);
 	group->plugin_keys = g_new0(GeanyKeyBinding, count);
 	group->plugin_key_count = count;
-	g_ptr_array_set_size(group->key_items, 0);
 	return group;
 }
 


### PR DESCRIPTION
When plugin calls plugin_set_key_group() several times for the same
group (when creating keybindings dynamically and needs to reset them),
it crashes with the current code the second time it gets called.

The reason is that group->plugin_keys is an array into which entries of
group->key_items point and when calling

g_ptr_array_set_size(group->key_items, 0);

it calls free_key_binding() for every item - when these items are
deallocated by g_free(group->plugin_keys) previously, calls of
free_key_binding() reference an invalid memory.

Just first resizing group->key_items (and calling free_key_binding() for
its items) and freeing group->plugin_keys afterwards fixes the problem.