### PR TITLE
Export keybindings_load_keyfile() for plugins

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -824,6 +824,15 @@ static void apply_kb_accel(GeanyKeyGroup *group, GeanyKeyBinding *kb, gpointer u
 }
 
 
+/** Reloads keybinding settings from configuration file. Normally plugins do
+ * not need to call this function as it is called automatically when a the
+ * plugin is activated. However, plugins which need to create keybindings
+ * dynamically and reload them when needed should call this function after
+ * all keybindings have been updated with plugin_set_key_group() and
+ * keybindings_set_item() calls - this makes sure that the corresponding user
+ * keybinding shortcuts are applied.
+ * @since 1.31. */
+GEANY_API_SYMBOL
 void keybindings_load_keyfile(void)
 {
 	load_user_kb();

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -293,14 +293,14 @@ GeanyKeyBinding *keybindings_get_item(GeanyKeyGroup *group, gsize key_id);
 
 GdkModifierType keybindings_get_modifiers(GdkModifierType mods);
 
+void keybindings_load_keyfile(void);
+
 #ifdef GEANY_PRIVATE
 
 extern GPtrArray *keybinding_groups;	/* array of GeanyKeyGroup pointers */
 
 
 void keybindings_init(void);
-
-void keybindings_load_keyfile(void);
 
 void keybindings_free(void);
 

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -59,7 +59,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 230
+#define GEANY_API_VERSION 231
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */


### PR DESCRIPTION
This allows plugins to reload keybindings later during their execution.
For more info see the comment in the commit.

---

I'm working on a plugin which is a more universal version of the current GeanyMiniscript plugins - users will be able to write custom scripts which will be executed and depending on the configuration the output will replace current document or selection or be inserted at current position or shown in new window etc. Users will be able to create new scripts (and remove existing). Each script will be keybindingable and since scripts can be removed or added, keybindings have to reload which isn't currently possible because keybindings_load_keyfile() isn't public and because of #1426.

(The plugin is in a VERY early stage of development and will likely not come out soon.)