### PR TITLE
Improve goto-symbols popup

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -262,6 +262,8 @@ ALIASES               += "optional=\noop \xmlonly <simplesect kind=\"geany:optio
 ALIASES               += "cb=\noop \xmlonly <simplesect kind=\"geany:scope\">notified</simplesect>\endxmlonly"
 ALIASES               += "cbdata=\noop \xmlonly <simplesect kind=\"geany:closure\"></simplesect>\endxmlonly"
 ALIASES               += "cbfree=\noop \xmlonly <simplesect kind=\"geany:destroy\"></simplesect>\endxmlonly"
+ALIASES               += "array=\noop \xmlonly <simplesect kind=\"geany:array\"></simplesect>\endxmlonly"
+ALIASES               += "arraylen{1}=\noop \xmlonly <simplesect kind=\"geany:array\">length=\1</simplesect>\endxmlonly"
 
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -263,7 +263,7 @@ ALIASES               += "cb=\noop \xmlonly <simplesect kind=\"geany:scope\">not
 ALIASES               += "cbdata=\noop \xmlonly <simplesect kind=\"geany:closure\"></simplesect>\endxmlonly"
 ALIASES               += "cbfree=\noop \xmlonly <simplesect kind=\"geany:destroy\"></simplesect>\endxmlonly"
 ALIASES               += "array=\noop \xmlonly <simplesect kind=\"geany:array\"></simplesect>\endxmlonly"
-ALIASES               += "arraylen{1}=\noop \xmlonly <simplesect kind=\"geany:array\">length=\1</simplesect>\endxmlonly"
+ALIASES               += "array{1}=\noop \xmlonly <simplesect kind=\"geany:array\">\1</simplesect>\endxmlonly"
 
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).

--- a/scripts/gen-api-gtkdoc.py
+++ b/scripts/gen-api-gtkdoc.py
@@ -75,11 +75,14 @@ class AtDoc(object):
                       "geany:closure",
                       "geany:destroy"):
             self.annot.append(type.split(":")[1])
-        elif type in ("geany:transfer",
+        elif type in ("geany:array",
+                      "geany:transfer",
                       "geany:element-type",
                       "geany:scope"):
             type = type.split(":")[1]
-            self.annot.append("%s %s" % (type, str))
+            if len(str):
+                str = " " + str
+            self.annot.append("%s%s" % (type, str))
         elif (type == "see"):
             return "See " + str
         elif type in ("a", "c") and str in ("NULL", "TRUE", "FALSE"):

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1933,15 +1933,23 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 	GdkEventButton *button_event = NULL;
 	TMTag *tmtag;
 	guint i;
-
+	gchar **short_names, **file_names, **p;
 	menu = gtk_menu_new();
+
+	/* If popup would show multiple files presend a smart file list that allows
+	 * to easily distinguish the files while avoiding the file paths in their entirety */
+	file_names = g_new(gchar *, tags->len);
+	foreach_ptr_array(tmtag, i, tags)
+		file_names[i] = tmtag->file->file_name;
+	short_names = utils_strv_shorten_file_list(file_names, tags->len);
+	g_free(file_names);
 
 	foreach_ptr_array(tmtag, i, tags)
 	{
 		GtkWidget *item;
 		GtkWidget *label;
 		GtkWidget *image;
-		gchar *fname = g_path_get_basename(tmtag->file->file_name);
+		gchar *fname = short_names[i];
 		gchar *text;
 
 		if (! first && have_best)
@@ -1964,6 +1972,7 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 		g_free(text);
 		g_free(fname);
 	}
+	g_free(short_names);
 
 	gtk_widget_show_all(menu);
 

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1933,10 +1933,10 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 	GdkEventButton *button_event = NULL;
 	TMTag *tmtag;
 	guint i;
-	gchar **short_names, **file_names, **p;
+	gchar **short_names, **file_names;
 	menu = gtk_menu_new();
 
-	/* If popup would show multiple files presend a smart file list that allows
+	/* If popup would show multiple files present a smart file list that allows
 	 * to easily distinguish the files while avoiding the file paths in their entirety */
 	file_names = g_new(gchar *, tags->len);
 	foreach_ptr_array(tmtag, i, tags)

--- a/src/utils.c
+++ b/src/utils.c
@@ -2049,18 +2049,19 @@ gchar **utils_strv_join(gchar **first, gchar **second)
  * The size of the list may be given explicitely, but defaults to @c g_strv_length(strv).
  *
  * @param strv The list of strings to process.
- * @param num The number of strings contained in @a strv. Can be -1 if it's terminated by @c NULL.
+ * @param strv_len The number of strings contained in @a strv. Can be -1 if it's terminated by @c NULL.
  *
  * @return The common prefix that is part of all strings (maybe empty), or NULL if an empty list
  *         was passed in.
  */
-static gchar *utils_strv_find_common_prefix(gchar **strv, gssize num)
+static gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len)
 {
+	gsize num;
+
 	if (!NZV(strv))
 		return NULL;
 
-	if (num == -1)
-		num = g_strv_length(strv);
+	num = (strv_len == -1) ? g_strv_length(strv) : (gsize) strv_len;
 
 	for (gsize i = 0; strv[0][i]; i++)
 	{
@@ -2083,22 +2084,21 @@ static gchar *utils_strv_find_common_prefix(gchar **strv, gssize num)
  * The size of the list may be given explicitely, but defaults to @c g_strv_length(strv).
  *
  * @param strv The list of strings to process.
- * @param num The number of strings contained in @a strv. Can be -1 if it's terminated by @c NULL.
+ * @param strv_len The number of strings contained in @a strv. Can be -1 if it's terminated by @c NULL.
  *
  * @return The common prefix that is part of all strings.
  */
-static gchar *utils_strv_find_lcs(gchar **strv, gssize num)
+static gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len)
 {
 	gchar *first, *_sub, *sub;
+	gsize num;
 	gsize n_chars;
 	gsize len;
 	gsize max = 0;
 	char *lcs;
 	gsize found;
 
-	if (num == -1)
-		num = g_strv_length(strv);
-
+	num = (strv_len == -1) ? g_strv_length(strv) : (gsize) strv_len;
 	if (num < 1)
 		return NULL;
 
@@ -2147,29 +2147,30 @@ static gchar *utils_strv_find_lcs(gchar **strv, gssize num)
  * The algorthm strips the common prefix (e-g. the user's home directory) and
  * replaces the longest common substring with an ellipsis ("...").
  *
- * @param file_names @array{length=num} The list of strings to process.
- * @param num The number of strings contained in @a file_names. Can be -1 if it's terminated by @c NULL.
+ * @param file_names @array{length=file_names_len} The list of strings to process.
+ * @param file_names_len The number of strings contained in @a file_names. Can be -1 if it's
+ *        terminated by @c NULL.
  * @return @transfer{full} A newly-allocated array of transformed paths strings, terminated by
             @c NULL. Use @c g_strfreev() to free it.
  *
  * @since 1.34 (API 239)
  */
 GEANY_API_SYMBOL
-gchar **utils_strv_shorten_file_list(gchar **file_names, gssize num)
+gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len)
 {
+	gsize num;
 	gsize i;
 	gchar *prefix, *substring, *lcs;
 	gchar *start, *end;
 	gchar **names;
 	gsize prefix_len, lcs_len;
 
-	/* We don't dereference file_names if num == 0. */
-	g_return_val_if_fail(num == 0 || file_names != NULL, NULL);
+	/* We don't dereference file_names if file_names_len == 0. */
+	g_return_val_if_fail(file_names_len == 0 || file_names != NULL, NULL);
 
 	/* The return value shall have exactly the same size as the input. If the input is a
 	 * GStrv (last element is NULL), the output will follow suit. */
-	if (num == -1)
-		num = g_strv_length(file_names);
+	num = (file_names_len == -1) ? g_strv_length(file_names) : (gsize) file_names_len;
 	/* Always include a terminating NULL, enables easy freeing with g_strfreev() */
 	names = g_new0(gchar *, num + 1);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -2146,7 +2146,7 @@ gchar *utils_strv_find_lcs(gchar **strv, size_t num)
 }
 
 
-/** Transform file names in a list to be shorter.
+/* * Transform file names in a list to be shorter.
  *
  * This function takes a list of file names (porbably with absolute paths), and
  * transforms the paths such that they are short but still unique. This is intended
@@ -2156,13 +2156,10 @@ gchar *utils_strv_find_lcs(gchar **strv, size_t num)
  * The algorthm strips the common prefix (e-g. the user's home directory) and
  * replaces the longest common substring with "...".
  *
- * @param file_names @arraylen{num} The list of strings to process.
+ * @param file_names The list of strings to process.
  * @param num The number of strings contained in @a strv. Can be 0 if @a strv is a @c GStrv
- * @return @transfer{full} A newly-allocated NULL-terminated array of transformed paths strings. Use @c g_strfreev() to free it.
- *
- * @since 1.31 (API 232
+ * @return A newly-allocated NULL-terminated array of transformed paths strings. Use @c g_strfreev() to free it.
  */
-GEANY_API_SYMBOL
 gchar **utils_strv_shorten_file_list(gchar **file_names, size_t num)
 {
 	gint i, j;

--- a/src/utils.c
+++ b/src/utils.c
@@ -2146,7 +2146,7 @@ gchar *utils_strv_find_lcs(gchar **strv, size_t num)
 }
 
 
-/* * Transform file names in a list to be shorter.
+/** Transform file names in a list to be shorter.
  *
  * This function takes a list of file names (porbably with absolute paths), and
  * transforms the paths such that they are short but still unique. This is intended
@@ -2156,10 +2156,13 @@ gchar *utils_strv_find_lcs(gchar **strv, size_t num)
  * The algorthm strips the common prefix (e-g. the user's home directory) and
  * replaces the longest common substring with "...".
  *
- * @param file_names The list of strings to process.
+ * @param file_names @arraylen{num} The list of strings to process.
  * @param num The number of strings contained in @a strv. Can be 0 if @a strv is a @c GStrv
- * @return A newly-allocated NULL-terminated array of transformed paths strings. Use @c g_strfreev() to free it.
+ * @return @transfer{full} A newly-allocated NULL-terminated array of transformed paths strings. Use @c g_strfreev() to free it.
+ *
+ * @since 1.34 (API 239)
  */
+GEANY_API_SYMBOL
 gchar **utils_strv_shorten_file_list(gchar **file_names, size_t num)
 {
 	gint i, j;

--- a/src/utils.c
+++ b/src/utils.c
@@ -2044,6 +2044,198 @@ gchar **utils_strv_join(gchar **first, gchar **second)
 	return strv;
 }
 
+/* * Returns the common prefix in a list of strings.
+ *
+ * The size of the list may be given explicitely automatically determined if passed a GStrv.
+ *
+ * @param strv The list of strings to process.
+ * @param num The number of strings contained in @a strv. Can be 0 if @a strv is a @c GStrv
+ *
+ * @return The common prefix that is part of all strings (maybe empty), or NULL if an empty list
+ *         was passed in.
+ */
+static gchar *utils_strv_find_common_prefix(gchar **strv, size_t num)
+{
+	gchar *prefix, **ptr;
+
+	if (!NZV(strv))
+		return NULL;
+
+	if (num == 0)
+		num = g_strv_length(strv);
+
+	prefix = g_strdup(strv[0]);
+
+	for (gint i = 0; prefix[i]; i++)
+	{
+		foreach_strv(ptr, &strv[1])
+		for (gint j = 1; j < num; j++)
+		{
+			gchar *s = strv[j];
+			if (s[i] != prefix[i])
+			{
+				/* terminate prefix on first mismatch and return */
+				prefix[i] = '\0';
+				break;
+			}
+		}
+		if (prefix[i] == '\0')
+			break;
+	}
+	return prefix;
+}
+
+/* * Returns the common prefix in a list of strings.
+ *
+ * The size of the list may be given explicitely automatically determined if passed a GStrv.
+ *
+ * @param strv The list of strings to process.
+ * @param num The number of strings contained in @a strv. Can be 0 if @a strv is a @c GStrv
+ *
+ * @return The common prefix that is part of all strings.
+ */
+gchar *utils_strv_find_lcs(gchar **strv, size_t num)
+{
+	gchar *first, *other, *_sub, *sub;
+	gsize n_chars;
+	gsize len;
+	gsize max = 0;
+	char *lcs;
+	gint found;
+
+	if (strv == NULL)
+		return NULL;
+
+	first = strv[0];
+	len = strlen(first);
+
+	if (num == 0)
+		num = g_strv_length(strv);
+
+	/* sub is the working area where substrings from first are copied to */
+	sub = g_malloc(len+1);
+	lcs = g_strdup("");
+	foreach_str(_sub, first)
+	{
+		gsize chars_left = len - (_sub - first);
+		/* No point in continuing if the remainder is too short */
+		if (max > chars_left)
+			break;
+		for (n_chars = 1; n_chars <= chars_left; n_chars++)
+		{
+			/* strlcpy() ftw! */
+			memcpy(sub, _sub, n_chars);
+			sub[n_chars] = '\0';
+			found = 1;
+			for (gint i = 1; i < num; i++)
+			{
+				if (strstr(strv[i], sub) == NULL)
+					break;
+				found++;
+			}
+			if (found == num && n_chars > max)
+			{
+				max = n_chars;
+				SETPTR(lcs, g_strdup(sub));
+			}
+		}
+	}
+	g_free(sub);
+
+	return lcs;
+}
+
+
+/** Transform file names in a list to be shorter.
+ *
+ * This function takes a list of file names (porbably with absolute paths), and
+ * transforms the paths such that they are short but still unique. This is intended
+ * for dialogs which present the file list to the user, where the base name may result
+ * in duplicates (showing the full path might be inappropriate).
+ *
+ * The algorthm strips the common prefix (e-g. the user's home directory) and
+ * replaces the longest common substring with "...".
+ *
+ * @param file_names @arraylen{num} The list of strings to process.
+ * @param num The number of strings contained in @a strv. Can be 0 if @a strv is a @c GStrv
+ * @return @transfer{full} A newly-allocated NULL-terminated array of transformed paths strings. Use @c g_strfreev() to free it.
+ *
+ * @since 1.31 (API 232
+ */
+GEANY_API_SYMBOL
+gchar **utils_strv_shorten_file_list(gchar **file_names, size_t num)
+{
+	gint i, j;
+	gchar *prefix, *substring, *name, *sep, **s;
+	TMTag *tmtag;
+	gchar **names;
+	gsize len;
+
+	/* The return value shall have exactly the same size as the input. If the input is a
+	 * GStrv (last element is NULL), the output will follow suit. */
+	if (!num)
+		num = g_strv_length(file_names);
+	/* Always include a terminating NULL, enables easy freeing with g_strfreev() */
+	names = g_new(gchar *, num + 1);
+	names[num] = 0;
+
+	prefix = utils_strv_find_common_prefix(file_names, num);
+	/* First: determine the common prefix, that will be stripped.
+	 * Don't strip single-letter prefixes, such as '/' */
+	len = 0;
+	if (NZV(prefix) && prefix[1])
+	{
+		/* Only strip directory components, include trailing '/' */
+		sep = strrchr(prefix, G_DIR_SEPARATOR);
+		if (sep)
+			len = sep - prefix + 1;
+	}
+
+	for (i = 0; i < num; i++)
+		names[i] = g_strdup(file_names[i] + len);
+
+	/* Second: determine the longest common substring, that will be ellipsized */
+	substring = utils_strv_find_lcs(names, num);
+	if (NZV(substring))
+	{
+		/* Only ellipsize directory components. Directory delimiters ought
+		 * to be part of the substring. If it doesn't contain at least two
+		 * separators, then there isn't even a single directory to ellipsize
+		 * (also take care to not ellipsize the base file name). */
+		gchar *start;
+		sep = strchr(substring, G_DIR_SEPARATOR);
+
+		if (sep)
+		{
+			len = 0;
+			start = sep + 1;
+			sep = strrchr(start, G_DIR_SEPARATOR);
+			if (sep)
+			{
+				*sep = '\0';
+				len = strlen(start);
+			}
+			/* Don't bother for tiny substrings. */
+			if (len >= 5)
+			{
+				for (i = 0; i < num; i++)
+				{
+					gchar *s = strstr(names[i], start);
+					gchar *rem = s + len; /* +1 skips over the leading '/' */
+					gsize copy_n = strlen(rem) + 1; /* include NUL */
+					memcpy(s, "...", 3); /* Maybe replace with unicode's "…" ? */
+					memmove(s+3, rem, copy_n);
+				}
+			}
+		}
+	}
+
+	g_free(substring);
+	g_free(prefix);
+
+	return names;
+}
+
 
 /* Try to parse a date using g_date_set_parse(). It doesn't take any format hint,
  * obviously g_date_set_parse() uses some magic.

--- a/src/utils.c
+++ b/src/utils.c
@@ -2155,7 +2155,7 @@ gchar *utils_strv_find_lcs(gchar **strv, size_t num)
  * The algorthm strips the common prefix (e-g. the user's home directory) and
  * replaces the longest common substring with an ellipsis ("...").
  *
- * @param file_names @arraylen{num} The list of strings to process.
+ * @param file_names @array{length=num} The list of strings to process.
  * @param num The number of strings contained in @a file_names. Can be 0 if it's terminated by @c NULL.
  * @return @transfer{full} A newly-allocated array of transformed paths strings, terminated by
             @c NULL. Use @c g_strfreev() to free it.

--- a/src/utils.c
+++ b/src/utils.c
@@ -2046,10 +2046,10 @@ gchar **utils_strv_join(gchar **first, gchar **second)
 
 /* * Returns the common prefix in a list of strings.
  *
- * The size of the list may be given explicitely automatically determined if passed a GStrv.
+ * The size of the list may be given explicitely, but defaults to @c g_strv_length(strv).
  *
  * @param strv The list of strings to process.
- * @param num The number of strings contained in @a strv. Can be 0 if @a strv is a @c GStrv
+ * @param num The number of strings contained in @a strv. Can be 0 if it's terminated by @c NULL.
  *
  * @return The common prefix that is part of all strings (maybe empty), or NULL if an empty list
  *         was passed in.
@@ -2068,7 +2068,6 @@ static gchar *utils_strv_find_common_prefix(gchar **strv, size_t num)
 
 	for (gint i = 0; prefix[i]; i++)
 	{
-		foreach_strv(ptr, &strv[1])
 		for (gint j = 1; j < num; j++)
 		{
 			gchar *s = strv[j];
@@ -2085,12 +2084,12 @@ static gchar *utils_strv_find_common_prefix(gchar **strv, size_t num)
 	return prefix;
 }
 
-/* * Returns the common prefix in a list of strings.
+/* * Returns the longest common substring in a list of strings.
  *
- * The size of the list may be given explicitely automatically determined if passed a GStrv.
+ * The size of the list may be given explicitely, but defaults to @c g_strv_length(strv).
  *
  * @param strv The list of strings to process.
- * @param num The number of strings contained in @a strv. Can be 0 if @a strv is a @c GStrv
+ * @param num The number of strings contained in @a strv. Can be 0 if it's terminated by @c NULL.
  *
  * @return The common prefix that is part of all strings.
  */
@@ -2154,11 +2153,12 @@ gchar *utils_strv_find_lcs(gchar **strv, size_t num)
  * in duplicates (showing the full path might be inappropriate).
  *
  * The algorthm strips the common prefix (e-g. the user's home directory) and
- * replaces the longest common substring with "...".
+ * replaces the longest common substring with an ellipsis ("...").
  *
  * @param file_names @arraylen{num} The list of strings to process.
- * @param num The number of strings contained in @a strv. Can be 0 if @a strv is a @c GStrv
- * @return @transfer{full} A newly-allocated NULL-terminated array of transformed paths strings. Use @c g_strfreev() to free it.
+ * @param num The number of strings contained in @a file_names. Can be 0 if it's terminated by @c NULL.
+ * @return @transfer{full} A newly-allocated array of transformed paths strings, terminated by
+            @c NULL. Use @c g_strfreev() to free it.
  *
  * @since 1.34 (API 239)
  */

--- a/src/utils.h
+++ b/src/utils.h
@@ -301,7 +301,7 @@ gchar **utils_strv_new(const gchar *first, ...) G_GNUC_NULL_TERMINATED;
 
 gchar **utils_strv_join(gchar **first, gchar **second) G_GNUC_WARN_UNUSED_RESULT;
 
-gchar **utils_strv_shorten_file_list(gchar **file_names, size_t num);
+gchar **utils_strv_shorten_file_list(gchar **file_names, gssize num);
 
 GSList *utils_get_config_files(const gchar *subdir);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -301,7 +301,7 @@ gchar **utils_strv_new(const gchar *first, ...) G_GNUC_NULL_TERMINATED;
 
 gchar **utils_strv_join(gchar **first, gchar **second) G_GNUC_WARN_UNUSED_RESULT;
 
-gchar **utils_strv_shorten_file_list(gchar **file_names, gssize num);
+gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len);
 
 GSList *utils_get_config_files(const gchar *subdir);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -301,6 +301,8 @@ gchar **utils_strv_new(const gchar *first, ...) G_GNUC_NULL_TERMINATED;
 
 gchar **utils_strv_join(gchar **first, gchar **second) G_GNUC_WARN_UNUSED_RESULT;
 
+gchar **utils_strv_shorten_file_list(gchar **file_names, size_t num);
+
 GSList *utils_get_config_files(const gchar *subdir);
 
 gchar *utils_get_help_url(const gchar *suffix);


### PR DESCRIPTION
Fixes #1069 by  implementing the suggestions there.

See commit messages for details. tl;dr: the goto-symbols popup will show more of the paths, but as little as possible. The common prefix is stripped and the longest common sub-path is ellipsized.

Example: Assume the popup would show utils.h twice (/home/kugel/geany.git/src/utils.h and /home/kugel/geany.git/build/dest/include/geany/utils.h.

The popup would show:
src/utils.h
build/dest/include/geany/utils.h

Additionally, as per @elextr suggestion and for a frequent use-case of mine, the ellipsis is introduced for long common substrings, which I often have due to having the same code base checked out multiple times (my workflow at work requires this).

So, /home/kugel/checkout_a/path/to/project/src/main.c and /home/kugel/checkout_b/path/to/project/src/main.c shows as:
checkout_a/.../main.c
checkout_b/.../main.c

Preview (/home/kugel is stripped of the front):
![grafik](https://cloud.githubusercontent.com/assets/564520/25218702/0db743d8-25ac-11e7-9d62-00657a767631.png)
