### PR TITLE
Fix the typo in Kazakh translation

### DIFF
--- a/po/kk.po
+++ b/po/kk.po
@@ -5677,7 +5677,7 @@ msgstr "Буманы ағымдағы ашық жобасының басты б�
 
 #: ../plugins/saveactions.c:43
 msgid "Save Actions"
-msgstr "Әрекеттерді сақтау"
+msgstr "Сақтау әрекеттері"
 
 #: ../plugins/saveactions.c:43
 msgid "This plugin provides different actions related to saving of files."


### PR DESCRIPTION
Dear maintainers,

While using Geany I discovered the typo, pelase review and accept this fix,

Thanks,