### PR TITLE
api: export tm_tag_get_type()

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -798,6 +798,7 @@ INPUT                  = @top_srcdir@/src/ \
                          @top_srcdir@/src/tagmanager/tm_source_file.h \
                          @top_srcdir@/src/tagmanager/tm_workspace.c \
                          @top_srcdir@/src/tagmanager/tm_workspace.h \
+                         @top_srcdir@/src/tagmanager/tm_tag.c \
                          @top_srcdir@/src/tagmanager/tm_tag.h \
                          @top_srcdir@/src/tagmanager/tm_parser.h
 

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -59,7 +59,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 231
+#define GEANY_API_VERSION 232
 
 /* hack to have a different ABI when built with GTK3 because loading GTK2-linked plugins
  * with GTK3-linked Geany leads to crash */

--- a/src/tagmanager/tm_tag.c
+++ b/src/tagmanager/tm_tag.c
@@ -82,7 +82,11 @@ typedef struct
 	gboolean first;
 } TMSortOptions;
 
-/* Gets the GType for a TMTag */
+/** Gets the GBoxed-derived GType for a TMTag.
+ *
+ * @return TMTag type
+ * @since 1.31 (API 232) */
+GEANY_API_SYMBOL
 GType tm_tag_get_type(void)
 {
 	static GType gtype = 0;

--- a/src/tagmanager/tm_tag.h
+++ b/src/tagmanager/tm_tag.h
@@ -103,13 +103,12 @@ typedef struct TMTag
 	TMParserType lang; /* Programming language of the file */
 } TMTag;
 
-
-#ifdef GEANY_PRIVATE
-
 /* The GType for a TMTag */
 #define TM_TYPE_TAG (tm_tag_get_type())
 
 GType tm_tag_get_type(void) G_GNUC_CONST;
+
+#ifdef GEANY_PRIVATE
 
 TMTag *tm_tag_new(void);
 


### PR DESCRIPTION
This indicates that TMTag is GBoxed-derived, and can be copied/ref'd.

This helps plugins that must store a tag pointer for later usage while the
tagmanager might let it go in the meantime (can happen quickly if the user
comments a function out when starting a doxygen-comment).