### PR TITLE
Track changes to line numbers for messages and compiler errors

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -745,7 +745,7 @@ static void build_spawn_cmd(GeanyDocument *doc, const gchar *cmd, const gchar *d
 	utf8_working_dir = !EMPTY(dir) ? g_strdup(dir) : g_path_get_dirname(doc->file_name);
 	working_dir = utils_get_locale_from_utf8(utf8_working_dir);
 
-	gtk_list_store_clear(msgwindow.store_compiler);
+	msgwin_clear_tab(MSG_COMPILER);
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_COMPILER);
 	msgwin_compiler_add(COLOR_BLUE, _("%s (in directory: %s)"), cmd, utf8_working_dir);
 	g_free(utf8_working_dir);

--- a/src/document.c
+++ b/src/document.c
@@ -1474,6 +1474,7 @@ GeanyDocument *document_open_file_full(GeanyDocument *doc, const gchar *filename
 		else
 			document_apply_indent_settings(doc);
 
+		msgwin_forget_line_shifts(doc);
 		document_set_text_changed(doc, FALSE);	/* also updates tab state */
 		ui_document_show_hide(doc);	/* update the document menu */
 

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -1380,3 +1380,15 @@ void msgwin_shift_line_numbers(GeanyDocument *doc, gint line, gint added)
 			record_line_shift(msgwindow.line_shifts_compiler, doc, line, added);
 	}
 }
+
+
+void msgwin_forget_line_shifts(GeanyDocument *doc)
+{
+	if (doc->file_name)
+	{
+		if (msgwindow.line_shifts_msg)
+			g_hash_table_remove(msgwindow.line_shifts_msg, doc->file_name);
+		if (msgwindow.line_shifts_compiler)
+			g_hash_table_remove(msgwindow.line_shifts_compiler, doc->file_name);
+	}
+}

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -64,6 +64,14 @@ typedef struct
 }
 ParseData;
 
+/* used for tracking changes to line numbers as documents are edited */
+typedef struct
+{
+	gint line;
+	gint added;
+}
+LineShift;
+
 MessageWindow msgwindow;
 
 enum
@@ -135,6 +143,10 @@ void msgwin_init(void)
 
 void msgwin_finalize(void)
 {
+	if (msgwindow.line_shifts_msg)
+		g_hash_table_destroy(msgwindow.line_shifts_msg);
+	if (msgwindow.line_shifts_compiler)
+		g_hash_table_destroy(msgwindow.line_shifts_compiler);
 	g_free(msgwindow.messages_dir);
 }
 
@@ -160,6 +172,72 @@ static gboolean on_msgwin_key_press_event(GtkWidget *widget, GdkEventKey *event,
 		}
 	}
 	return FALSE;
+}
+
+
+/* Remember the fact that lines have been added (deleted if negative) to doc after line
+ * (0 if at the beginning of document), so we can update the line number on the fly
+ * when we need to go to a message/error. */
+static void record_line_shift(GHashTable *shifts, GeanyDocument *doc, gint line, gint added)
+{
+	GArray *shifts_seq = g_hash_table_lookup(shifts, doc->file_name);
+	LineShift shift = { line, added };
+
+	if (!shifts_seq)
+	{
+		shifts_seq = g_array_new(FALSE, FALSE, sizeof(LineShift));
+		g_hash_table_insert(shifts, g_strdup(doc->file_name), shifts_seq);
+	}
+
+	if (shifts_seq->len > 0)
+	{
+		/* See if we can amend the last shift instead of adding a new one. */
+		LineShift *last = &g_array_index(shifts_seq, LineShift, shifts_seq->len - 1);
+
+		if ((added > 0 && last->added > 0 && line >= last->line && line <= last->line + last->added)
+			|| (added < 0 && last->added < 0 && line == last->line))
+		{
+			last->added += added;
+			return;
+		}
+	}
+
+	g_array_append_val(shifts_seq, shift);
+}
+
+
+/* Update a message/error line number with shifts that have happened
+ * since the message/error was generated. */
+static gint adjust_line_number(GeanyDocument *doc, gint line, GHashTable *shifts)
+{
+	GArray *shifts_seq = g_hash_table_lookup(shifts, doc->file_name);
+	LineShift *shift;
+
+	if (shifts_seq)
+	{
+		foreach_array(LineShift, shift, shifts_seq)
+		{
+			if (line > shift->line)
+			{
+				line += shift->added;
+				if (line < shift->line)
+					/* Line has been deleted. But we can't just "lose" messages/errors, so stay
+					 * at the same line. (Doing this instead of line + 1 is consistent with the
+					 * Git Change Bar plugin, which marks deleted lines on the preceding line. */
+					line = shift->line;
+				if (line < 1)
+					/* It was the first line and it was deleted. */
+					line = 1;
+			}
+		}
+	}
+	return line;
+}
+
+
+static void free_line_shifts_seq(gpointer data)
+{
+	g_array_free(data, TRUE);
 }
 
 
@@ -200,6 +278,8 @@ static void prepare_msg_tree_view(void)
 	gtk_tree_view_set_model(GTK_TREE_VIEW(msgwindow.tree_msg), GTK_TREE_MODEL(msgwindow.store_msg));
 	g_object_unref(msgwindow.store_msg);
 
+	msgwindow.line_shifts_msg = NULL;
+
 	renderer = gtk_cell_renderer_text_new();
 	column = gtk_tree_view_column_new_with_attributes(NULL, renderer,
 		"foreground-gdk", MSG_COL_COLOR, "text", MSG_COL_STRING, NULL);
@@ -236,6 +316,8 @@ static void prepare_compiler_tree_view(void)
 	msgwindow.store_compiler = gtk_list_store_new(COMPILER_COL_COUNT, GDK_TYPE_COLOR, G_TYPE_STRING);
 	gtk_tree_view_set_model(GTK_TREE_VIEW(msgwindow.tree_compiler), GTK_TREE_MODEL(msgwindow.store_compiler));
 	g_object_unref(msgwindow.store_compiler);
+
+	msgwindow.line_shifts_compiler = NULL;
 
 	renderer = gtk_cell_renderer_text_new();
 	column = gtk_tree_view_column_new_with_attributes(NULL, renderer,
@@ -315,6 +397,11 @@ void msgwin_compiler_add_string(gint msg_color, const gchar *msg)
 	gtk_list_store_append(msgwindow.store_compiler, &iter);
 	gtk_list_store_set(msgwindow.store_compiler, &iter,
 		COMPILER_COL_COLOR, color, COMPILER_COL_STRING, utf8_msg, -1);
+
+	/* Lazily initialize the line shifts hash table once we get a non-status compiler message */
+	if (msg_color != COLOR_BLUE && msgwindow.line_shifts_compiler == NULL)
+		msgwindow.line_shifts_compiler = g_hash_table_new_full(g_str_hash, g_str_equal,
+			g_free, free_line_shifts_seq);
 
 	if (ui_prefs.msgwindow_visible && interface_prefs.compiler_tab_autoscroll)
 	{
@@ -406,6 +493,11 @@ void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const 
 	gtk_list_store_set(msgwindow.store_msg, &iter,
 		MSG_COL_LINE, line, MSG_COL_DOC_ID, doc ? doc->id : 0, MSG_COL_COLOR,
 		color, MSG_COL_STRING, utf8_msg, -1);
+
+	/* Lazily initialize the line shifts hash table once we get a non-status message */
+	if (msg_color != COLOR_BLUE && msgwindow.line_shifts_msg == NULL)
+		msgwindow.line_shifts_msg = g_hash_table_new_full(g_str_hash, g_str_equal,
+			g_free, free_line_shifts_seq);
 
 	g_free(tmp);
 	if (utf8_msg != tmp)
@@ -700,7 +792,9 @@ static gboolean goto_compiler_file_line(const gchar *fname, gint line, gboolean 
 
 		if (doc != NULL)
 		{
-			if (! doc->changed && editor_prefs.use_indicators)	/* if modified, line may be wrong */
+			line = adjust_line_number(doc, line, msgwindow.line_shifts_compiler);
+
+			if (editor_prefs.use_indicators)
 				editor_indicator_set_on_line(doc->editor, GEANY_INDICATOR_ERROR, line - 1);
 
 			ret = navqueue_goto_line(old_doc, doc, line);
@@ -1120,6 +1214,7 @@ gboolean msgwin_goto_messages_file_line(gboolean focus_editor)
 			}
 			else
 			{
+				line = adjust_line_number(doc, line, msgwindow.line_shifts_msg);
 				ret = navqueue_goto_line(old_doc, doc, line);
 				if (ret && focus_editor)
 					gtk_widget_grab_focus(GTK_WIDGET(doc->editor->sci));
@@ -1137,6 +1232,7 @@ gboolean msgwin_goto_messages_file_line(gboolean focus_editor)
 				doc = document_open_file(filename, FALSE, NULL, NULL);
 				if (doc != NULL)
 				{
+					line = adjust_line_number(doc, line, msgwindow.line_shifts_msg);
 					ret = (line < 0) ? TRUE : navqueue_goto_line(old_doc, doc, line);
 					if (ret && focus_editor)
 						gtk_widget_grab_focus(GTK_WIDGET(doc->editor->sci));
@@ -1250,23 +1346,37 @@ void msgwin_switch_tab(gint tabnum, gboolean show)
 GEANY_API_SYMBOL
 void msgwin_clear_tab(gint tabnum)
 {
-	GtkListStore *store = NULL;
-
 	switch (tabnum)
 	{
 		case MSG_MESSAGE:
-			store = msgwindow.store_msg;
+			gtk_list_store_clear(msgwindow.store_msg);
+			if (msgwindow.line_shifts_msg)
+				g_hash_table_destroy(msgwindow.line_shifts_msg);
+			msgwindow.line_shifts_msg = NULL;
 			break;
 
 		case MSG_COMPILER:
 			gtk_list_store_clear(msgwindow.store_compiler);
+			if (msgwindow.line_shifts_compiler)
+				g_hash_table_destroy(msgwindow.line_shifts_compiler);
+			msgwindow.line_shifts_compiler = NULL;
 			build_menu_update(NULL);	/* update next error items */
-			return;
+			break;
 
-		case MSG_STATUS: store = msgwindow.store_status; break;
-		default: return;
+		case MSG_STATUS:
+			gtk_list_store_clear(msgwindow.store_status);
+			break;
 	}
-	if (store == NULL)
-		return;
-	gtk_list_store_clear(store);
+}
+
+
+void msgwin_shift_line_numbers(GeanyDocument *doc, gint line, gint added)
+{
+	if (doc->file_name)
+	{
+		if (msgwindow.line_shifts_msg)
+			record_line_shift(msgwindow.line_shifts_msg, doc, line, added);
+		if (msgwindow.line_shifts_compiler)
+			record_line_shift(msgwindow.line_shifts_compiler, doc, line, added);
+	}
 }

--- a/src/msgwindow.h
+++ b/src/msgwindow.h
@@ -73,6 +73,8 @@ typedef struct
 	GtkListStore	*store_status;
 	GtkListStore	*store_msg;
 	GtkListStore	*store_compiler;
+	GHashTable		*line_shifts_msg;
+	GHashTable		*line_shifts_compiler;
 	GtkWidget		*tree_compiler;
 	GtkWidget		*tree_status;
 	GtkWidget		*tree_msg;
@@ -98,6 +100,8 @@ void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const 
 void msgwin_compiler_add_string(gint msg_color, const gchar *msg);
 
 void msgwin_show_hide_tabs(void);
+
+void msgwin_shift_line_numbers(GeanyDocument *doc, gint line, gint added);
 
 
 void msgwin_menu_add_common_items(GtkMenu *menu);

--- a/src/msgwindow.h
+++ b/src/msgwindow.h
@@ -103,6 +103,8 @@ void msgwin_show_hide_tabs(void);
 
 void msgwin_shift_line_numbers(GeanyDocument *doc, gint line, gint added);
 
+void msgwin_forget_line_shifts(GeanyDocument *doc);
+
 
 void msgwin_menu_add_common_items(GtkMenu *menu);
 

--- a/src/search.c
+++ b/src/search.c
@@ -1695,7 +1695,7 @@ search_find_in_files(const gchar *utf8_search_text, const gchar *utf8_dir, const
 		}
 	}
 
-	gtk_list_store_clear(msgwindow.store_msg);
+	msgwin_clear_tab(MSG_MESSAGE);
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_MESSAGE);
 
 	/* we can pass 'enc' without strdup'ing it here because it's a global const string and
@@ -2199,7 +2199,7 @@ void search_find_usage(const gchar *search_text, const gchar *original_search_te
 	}
 
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_MESSAGE);
-	gtk_list_store_clear(msgwindow.store_msg);
+	msgwin_clear_tab(MSG_MESSAGE);
 
 	if (! in_session)
 	{	/* use current document */


### PR DESCRIPTION
This is my naive attempt at solving #1136. It works for me (not heavily tested yet), but I’m not sure if it’s a good idea. I would appreciate any feedback.

Geany’s message window is sort of detached from the editor. In general, it’s just lines of text that are not parsed or associated with the files in question until the user wants to navigate to one of them (although there are some exceptions).

Constrained by this design, I bolted on a cache of line number shifts. Actually two caches: one for the messages tab (`line_shifts_msg`) and one for the compiler tab (`line_shifts_compiler`). A cache is cleared when the user initiates a search/build (`msgwindow_clear_tab`), and then updated whenever the user adds/deletes lines in *any* open file (`SCN_MODIFIED` with a non-zero `linesAdded`), as long as *any* messages/errors are present. A cache is a hash table where keys are filenames and values are sequences of “at line, lines added” pairs (`LineShift`).

This of course means some overhead on mundane editing operations. Line numbers are requested from Scintilla, filename hashes are computed, arrays may need to be resized. Some of this overhead could be optimized out, but I’m not sure it’s worth it.

Also, this approach doesn’t handle undo very well. If there’s a compiler error on line 3, and I delete that entire line, and then undo the deletion, navigating to that error will now bring me to line 2 instead of 3, because the undo is understood as inserting an unrelated new line.

A possibly cleaner and/or more efficient approach might be to rely on Scintilla’s features such as line markers or indicators. That would probably require some revamp of the message window: lines would have to be parsed eagerly and associated with those Scintilla features as long as the corresponding file is open. I haven’t tried that approach.
