### PR TITLE
Fix search marker translucency (currently ignoring scheme)

### DIFF
--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -658,7 +658,7 @@ static void styleset_common(ScintillaObject *sci, guint ft_id)
 	SSM(sci, SCI_INDICSETSTYLE, GEANY_INDICATOR_SEARCH, INDIC_ROUNDBOX);
 	SSM(sci, SCI_INDICSETFORE, GEANY_INDICATOR_SEARCH,
 		invert(common_style_set.styling[GCS_MARKER_SEARCH].background));
-	SSM(sci, SCI_INDICSETALPHA, GEANY_INDICATOR_SEARCH, 60);
+	SSM(sci, SCI_INDICSETALPHA, GEANY_INDICATOR_SEARCH, common_style_set.styling[GCS_MARKER_TRANSLUCENCY].background);
 
 	/* define marker symbols
 	 * 0 -> line marker */


### PR DESCRIPTION
On filetypes common it says: "# translucency for the line marker(first argument) and the search marker (second argument)
marker_translucency=255;255"
However changing the 2nd argument does NOT affect search marker translucency.
The proposed change addresses this.

On the downside: current hard-coded value of 60 (very transparent) would become filetypes.common's default of 255 (no transparency).

On the upside:
1) we would be consistent with what is indicated in filetypes.common about translucency for the search marker
2) this change may help all DARK themes, since marked words are barely visible no matter the GCS_MARKER_SEARCH background color used. By changing the translucency we can make them standout, just like in white themes.