### PR TITLE
Fix comment/uncomment keyboard shortcut for Arduino filetype

### DIFF
--- a/data/filedefs/filetypes.Arduino.conf
+++ b/data/filedefs/filetypes.Arduino.conf
@@ -14,6 +14,19 @@ lexer_filetype=C
 tag_parser=C
 extension=ino
 
+# single comments, like # in this file
+comment_single=//
+# multiline comments
+comment_open=/*
+comment_close=*/
+
+# set to false if a comment character/string should start at column 0 of a line, true uses any
+# indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
+	#command_example();
+# setting to false would generate this
+#	command_example();
+# This setting works only for single line comments
+comment_use_indent=true
 # context action command (please see Geany's main documentation for details)
 context_action_cmd=xdg-open "https://www.arduino.cc/en/Reference/%s"
 


### PR DESCRIPTION
This fixes the line comment/uncomment keyboard shortcut for the Arduino filetype.