### PR TITLE
Add an editor option to enable IME's candidate window display inline

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2527,6 +2527,9 @@ show_editor_scrollbars            Whether to display scrollbars. If set to     t
 indent_hard_tab_width             The size of a tab character. Don't change    8           immediately
                                   it unless you really need to; use the
                                   indentation settings instead.
+editor_ime_interaction            Input method editor (IME)'s candidate        0           to new
+                                  window behaviour. May be 0 (windowed) or                 documents
+                                  1 (inline)
 **Interface related**
 show_symbol_list_expanders        Whether to show or hide the small            true        to new
                                   expander icons on the symbol list                        documents

--- a/src/editor.c
+++ b/src/editor.c
@@ -4923,7 +4923,10 @@ static ScintillaObject *create_new_sci(GeanyEditor *editor)
 
 	/* virtual space */
 	SSM(sci, SCI_SETVIRTUALSPACEOPTIONS, editor_prefs.show_virtual_space, 0);
-	
+
+	/* input method editor's candidate window behaviour */
+	SSM(sci, SCI_SETIMEINTERACTION, editor_prefs.ime_interaction, 0);
+
 #ifdef GDK_WINDOWING_QUARTZ
 # if ! GTK_CHECK_VERSION(3,16,0)
 	/* "retina" (HiDPI) display support on OS X - requires disabling buffered draw

--- a/src/editor.h
+++ b/src/editor.h
@@ -137,6 +137,7 @@ typedef struct GeanyEditorPrefs
 	gboolean	long_line_enabled;
 	gint		autocompletion_update_freq;
 	gint		scroll_lines_around_cursor;
+	gint		ime_interaction; /* input method editor's candidate window behaviour */
 }
 GeanyEditorPrefs;
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -255,6 +255,8 @@ static void init_pref_groups(void)
 		"extract_filetype_regex", GEANY_DEFAULT_FILETYPE_REGEX);
 	stash_group_add_boolean(group, &search_prefs.replace_and_find_by_default,
 		"replace_and_find_by_default", TRUE);
+	stash_group_add_integer(group, &editor_prefs.ime_interaction,
+		"editor_ime_interaction", SC_IME_WINDOWED);
 
 	/* Note: Interface-related various prefs are in ui_init_prefs() */
 


### PR DESCRIPTION
This will fix the issue that candidate window can't follow cursor.

See https://github.com/geany/geany/issues/1513 and https://github.com/geany/geany/issues/920