### PR TITLE
Fix converting color to hex for insertion

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -451,10 +451,14 @@ const gchar *utils_path_skip_root(const gchar *path)
 }
 
 
+/* Convert a fractional @a val in the range [0, 1] to a whole value in the range [0, @a factor].
+ * In particular, this is used for converting a @c GdkColor to the "#RRGGBB" format in a way that
+ * agrees with GTK+, so the "#RRGGBB" in the color picker is the same "#RRGGBB" that is inserted
+ * into the document. See https://github.com/geany/geany/issues/1527
+ */
 gdouble utils_scale_round(gdouble val, gdouble factor)
 {
-	/*val = floor(val * factor + 0.5);*/
-	val = floor(val);
+	val = floor(val * factor + 0.5);
 	val = MAX(val, 0);
 	val = MIN(val, factor);
 
@@ -881,9 +885,9 @@ gchar *utils_get_hex_from_color(GdkColor *color)
 	g_return_val_if_fail(color != NULL, NULL);
 
 	return g_strdup_printf("#%02X%02X%02X",
-		(guint) (utils_scale_round(color->red / 256, 255)),
-		(guint) (utils_scale_round(color->green / 256, 255)),
-		(guint) (utils_scale_round(color->blue / 256, 255)));
+		(guint) (utils_scale_round(color->red / 65535.0, 255)),
+		(guint) (utils_scale_round(color->green / 65535.0, 255)),
+		(guint) (utils_scale_round(color->blue / 65535.0, 255)));
 }
 
 

--- a/src/win32.c
+++ b/src/win32.c
@@ -626,10 +626,7 @@ void win32_show_color_dialog(const gchar *colour)
 	{
 		rgb_current = cc.rgbResult;
 		g_snprintf(hex, 11, "#%02X%02X%02X",
-	      (guint) (utils_scale_round(GetRValue(rgb_current), 255)),
-	      (guint) (utils_scale_round(GetGValue(rgb_current), 255)),
-	      (guint) (utils_scale_round(GetBValue(rgb_current), 255)));
-
+			GetRValue(rgb_current), GetGValue(rgb_current), GetBValue(rgb_current));
 		editor_insert_color(doc->editor, hex);
 	}
 	g_free(hex);


### PR DESCRIPTION
Fixes #1527 as discussed there.

In `win32_show_color_dialog`, `utils_scale_round` is not necessary at all because [`Get{R,G,B}Value`](https://msdn.microsoft.com/en-us/library/windows/desktop/dd144923.aspx) already return 0..255, which we can immediately render as hex.

The resulting code behaves correctly for me under all configurations: Linux and Windows, GTK+2 and GTK+3, with or without native Windows dialogs. (The native [Windows color dialog](https://i-msdn.sec.s-msft.com/dynimg/IC534143.png) does not show `#RRGGBB`, but it does show the individual R, G, B bytes, and I checked against those.)

However, I still have no idea why @elextr was unable to reproduce #1527 while I can easily reproduce it in all configurations (with GTK+ color picker).

I’m also not sure why I remember not having this issue in the past, but it’s likely that I only used the color chooser a few times back then, so I may have missed it.