### PR TITLE
Push current position to navqueue before navigating back

### DIFF
--- a/src/navqueue.c
+++ b/src/navqueue.c
@@ -192,6 +192,20 @@ static gboolean goto_file_pos(const gchar *file, gint pos)
 void navqueue_go_back(void)
 {
 	filepos *fprev;
+	GeanyDocument *doc = document_get_current();
+
+	/* If the navqueue is currently at some position A, but the actual cursor is at some other
+	 * place B, we should add B to the navqueue, so that (1) we go back to A, not to the next
+	 * item in the queue; and (2) we can later restore B by going forward.
+	 * (If A = B, add_new_position will ignore it.) */
+	if (doc)
+	{
+		if (doc->file_name)
+			add_new_position(doc->file_name, sci_get_current_position(doc->editor->sci));
+	}
+	else
+		/* see also https://github.com/geany/geany/pull/1537 */
+		g_warning("Attempted navigation when nothing is open");
 
 	/* return if theres no place to go back to */
 	if (g_queue_is_empty(navigation_queue) ||


### PR DESCRIPTION
Consider the following C document:

```
int foo(void)
{
    return bar(123);
}

int bar(int n)
{
    return n + 1;
}
```

**Scenario 1.** Place the cursor on line 3, column 12, and invoke *Go to Symbol Definition*. The cursor jumps to line 6, column 0. Now invoke *Navigate back a location*. The cursor jumps to 3,12 — just what you’d expect.

**Scenario 2.** Place the cursor on line 3, column 12, and invoke *Go to Symbol Definition*. The cursor jumps to line 6, column 0. Now move the cursor manually to line 8, column 15, and then invoke *Navigate back a location*. Again, the cursor jumps to 3,12. Is this what you’d expect? Depends; but clearly there are cases where you’d prefer to jump to 6,0 first. In addition, you can’t *Navigate forward a location* to 8,15.

This PR changes *Navigate back a location* so that it first pushes the current position onto the navqueue. This does not affect scenario 1, because the navqueue’s `add_new_position` deduplicates positions at the head. But in scenario 2, this has the effect that *Navigate back* takes you to 6,0 first. If you want 3,12, it’s just one more *Navigate back* away. And you can *Navigate forward* to 8,15 now.

I have realized over time that this is kind of a prerequisite for my PR #1114. Otherwise it is very counter-intuitive that *Navigate back* does **not** take you to the position you just pushed with *Remember location in history*.
