### PR TITLE
Use non-symlinked VTE libraries on macOS

### DIFF
--- a/src/vte.c
+++ b/src/vte.c
@@ -286,7 +286,7 @@ void vte_init(void)
 # ifdef __APPLE__
 			"libvte.9.dylib", "libvte.dylib",
 # endif
-			"libvte.so", "libvte.so.4", "libvte.so.8", "libvte.so.9",
+			"libvte.so", "libvte.so.9", "libvte.so.8", "libvte.so.4",
 #endif
 			NULL
 		};

--- a/src/vte.c
+++ b/src/vte.c
@@ -276,10 +276,17 @@ void vte_init(void)
 		gint i;
 		const gchar *sonames[] = {
 #if GTK_CHECK_VERSION(3, 0, 0)
-			"libvte-2.91.so", "libvte-2.91.so.0", "libvte-2.91.dylib",
-			"libvte2_90.so", "libvte2_90.so.9", "libvte2_90.dylib",
-#else
-			"libvte.so", "libvte.so.4", "libvte.so.8", "libvte.so.9", "libvte.dylib",
+# ifdef __APPLE__
+			"libvte-2.91.0.dylib", "libvte-2.91.dylib",
+			"libvte2_90.9.dylib", "libvte2_90.dylib",
+# endif
+			"libvte-2.91.so", "libvte-2.91.so.0",
+			"libvte2_90.so", "libvte2_90.so.9",
+#else /* GTK 2 */
+# ifdef __APPLE__
+			"libvte.9.dylib", "libvte.dylib",
+# endif
+			"libvte.so", "libvte.so.4", "libvte.so.8", "libvte.so.9",
 #endif
 			NULL
 		};


### PR DESCRIPTION
Plugins using VTE such as multiterm or debugger are linked against the
non-symlinked version of the library like libvte.9.dylib and not
libvte.dylib. When a bundle is created, all symlinks are replaced by
a copy of the symlinked file. This means there are both libvte.dylib
and libvte.9.dylib in the bundle both containing the same code. When
Geany loads libvte.dylib and plugins load libvte.9.dylib the same code
gets loaded twice and when the same type gets registered by GTK, it fails
and the whole application freezes.

This problem doesn't exist on linux or when running from the command line
on macOS because the operating system detects it's the same library
because of the symlink and it's loaded only once.

Loading the same library as the one used by plugins fixes the issue with
macOS bundle.

Fixes #1555 