### PR TITLE
Normalise key events when creating/processing keybindings

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1296,7 +1296,8 @@ static guint key_kp_translate(guint key_in)
 void keybindings_get_normalised_event(GdkEventKey *ev, guint *state, guint *keyval)
 {
 	GdkModifierType consumed;
-	GdkKeymap *keymap = gdk_keymap_get_default();
+	GdkDisplay *display = gdk_window_get_display(ev->window);
+	GdkKeymap *keymap = gdk_keymap_get_for_display(display);
 
 	gdk_keymap_translate_keyboard_state(keymap, ev->hardware_keycode,
 		ev->state, ev->group, keyval, NULL, NULL, &consumed);

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1357,7 +1357,7 @@ static gboolean run_kb(GeanyKeyBinding *kb, GeanyKeyGroup *group)
 /* central keypress event handler, almost all keypress events go to this function */
 static gboolean on_key_press_event(GtkWidget *widget, GdkEventKey *ev, gpointer user_data)
 {
-	guint state, keyval;
+	guint state, keyval, legacy_state;
 	gsize g, i;
 	GeanyDocument *doc;
 	GeanyKeyGroup *group;
@@ -1371,6 +1371,9 @@ static gboolean on_key_press_event(GtkWidget *widget, GdkEventKey *ev, gpointer 
 		document_check_disk_status(doc, FALSE);
 
 	keybindings_get_normalised_event(ev, &state, &keyval);
+	/* User keybindings of old Geany versions may contain extra modifiers
+	 * such as shift - make sure these still work. */
+	legacy_state = keybindings_get_modifiers(ev->state);
 
 	/*geany_debug("%d (%d) %d (%d)", keyval, ev->keyval, state, ev->state);*/
 
@@ -1386,7 +1389,7 @@ static gboolean on_key_press_event(GtkWidget *widget, GdkEventKey *ev, gpointer 
 	{
 		foreach_ptr_array(kb, i, group->key_items)
 		{
-			if (keyval == kb->key && state == kb->mods)
+			if (keyval == kb->key && (state == kb->mods || legacy_state == kb->mods))
 			{
 				if (run_kb(kb, group))
 					return TRUE;

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1321,20 +1321,6 @@ void keybindings_get_normalised_event(GdkEventKey *ev, guint *state, guint *keyv
 }
 
 
-/* Check if event keypress matches keybinding combo */
-gboolean keybindings_check_event(GdkEventKey *ev, GeanyKeyBinding *kb)
-{
-	guint state, keyval;
-
-	if (ev->keyval == 0)
-		return FALSE;
-
-	keybindings_get_normalised_event(ev, &state, &keyval);
-
-	return (keyval == kb->key && state == kb->mods);
-}
-
-
 static gboolean run_kb(GeanyKeyBinding *kb, GeanyKeyGroup *group)
 {
 	gboolean handled = TRUE;

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -324,6 +324,8 @@ void keybindings_show_shortcuts(void);
 
 gboolean keybindings_check_event(GdkEventKey *ev, GeanyKeyBinding *kb);
 
+void keybindings_get_normalised_event(GdkEventKey *ev, guint *state, guint *keyval);
+
 void keybindings_dialog_show_prefs_scroll(const gchar *name);
 
 #endif /* GEANY_PRIVATE */

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -322,8 +322,6 @@ void keybindings_write_to_file(void);
 
 void keybindings_show_shortcuts(void);
 
-gboolean keybindings_check_event(GdkEventKey *ev, GeanyKeyBinding *kb);
-
 void keybindings_get_normalised_event(GdkEventKey *ev, guint *state, guint *keyval);
 
 void keybindings_dialog_show_prefs_scroll(const gchar *name);

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1415,16 +1415,16 @@ static void kb_cell_edited_cb(GtkCellRendererText *cellrenderertext,
 static gboolean kb_grab_key_dialog_key_press_cb(GtkWidget *dialog, GdkEventKey *event, GtkLabel *label)
 {
 	gchar *str;
-	guint state;
+	guint state, keyval;
 
 	g_return_val_if_fail(GTK_IS_LABEL(label), FALSE);
-
-	state = keybindings_get_modifiers(event->state);
 
 	if (event->keyval == GDK_Escape)
 		return FALSE;	/* close the dialog, don't allow escape when detecting keybindings. */
 
-	str = gtk_accelerator_name(event->keyval, state);
+	keybindings_get_normalised_event(event, &state, &keyval);
+
+	str = gtk_accelerator_name(keyval, state);
 
 	gtk_label_set_text(label, str);
 	g_free(str);

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1633,8 +1633,14 @@ static gboolean prefs_dialog_key_press_response_cb(GtkWidget *dialog, GdkEventKe
 												   gpointer data)
 {
 	GeanyKeyBinding *kb = keybindings_lookup_item(GEANY_KEY_GROUP_HELP, GEANY_KEYS_HELP_HELP);
+	guint state, keyval;
 
-	if (keybindings_check_event(event, kb))
+	if (event->keyval == 0)
+		return FALSE;
+
+	keybindings_get_normalised_event(event, &state, &keyval);
+
+	if (keyval == kb->key && state == kb->mods)
 	{
 		open_preferences_help();
 		return TRUE;


### PR DESCRIPTION
At the moment there's a problem with keybinding creation and processing.
When a keybinding is accessed using shift such as the zoom in keybinding
`Ctrl-+` which on English keyboard requires pressing `<Ctrl><Shift>=`, the
`<Shift>` key is preserved right now. This is visible when changing
keybindings - pressing the above key combination leads to
`<Primary><Shift>+`. This is incorrect - the keybinding should either
be `<Primary><Shift>=` or `<Primary>+` but in `<Primary><Shift>+` there's
extra `<Shift>` which leads to problems.

On linux the problems aren't so much visible - the problem is visible
when changing keybindings as mentioned above. Even though this
particular keybinding isn't executed through on_key_press_event()
because the combination `<Primary><Shift>+` doesn't correspond to the
default `<Primary>+` value, it's executed by GTK as an accelerator so
the problem isn't directly visible.

This might however break when a user modifies this keybinding to the
wrong value `<Primary><Shift>+` and when the user is using multiple
keyboards such as English where + has to be accessed over shift
and German where typing + doesn't require shift. The keybinding will
stop working on the German keyboard in this case because of the
extra shift.

On MacOS the accelerator isn't executed for some reason and non-
letter keybindings don't work when shift is used.

To fix the issue we can use gdk_keymap_translate_keyboard_state()
which reports "consumed" modifiers - that is those which lead to
typing the secondary character. However, we don't want this to happen
when typing alphabetical characters because it's easier to notice
the use of shift in `<Ctrl><Shift>r` than in `<Ctrl>R`. Modifier
consumption is undone in this case.

~~Should also fix https://github.com/geany/geany/issues/694~~ Nope, it doesn't :-(