### PR TITLE
Make sure GDK_MOD2_MASK is cleared when getting modifiers

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -124,7 +124,10 @@ GdkModifierType keybindings_get_modifiers(GdkModifierType mods)
 {
 #ifdef __APPLE__
 	if (mods & GDK_MOD2_MASK)
+	{
 		mods |= GEANY_PRIMARY_MOD_MASK;
+		mods &= ~GDK_MOD2_MASK;
+	}
 #endif
 	return mods & gtk_accelerator_get_default_mod_mask();
 }


### PR DESCRIPTION
`gtk_accelerator_get_default_mod_mask()` behaves differently on OS X under
GTK 3 when compared to GTK 2. On GTK 2 it used to clear the `GDK_MOD2_MASK`
bit while on GTK 3 it's preserved. We need to clear it ourselves
otherwise e.g. `<Command>S` leads to `<Commands><Mod2>S` and none of the
keybindings work under GTK 3.