### PR TITLE
Show status message on attempt to execute empty context action.

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1500,6 +1500,10 @@ void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 		}
 		g_free(command_line);
 	}
+	else
+	{
+		ui_set_statusbar(TRUE, _("No context action set."));
+	}
 	g_free(word);
 	g_free(command);
 }


### PR DESCRIPTION
If a user selects "context action" from the context menu then now the status message
'No context action command set for file type "%s".' will be shown. Closes #1641.