### PR TITLE
Added Context Action Patterns.

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1454,7 +1454,7 @@ static void on_load_tags1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	gchar *word, *command;
+	gchar *word, *command, *context_action_cmd;
 	GError *error = NULL;
 	GeanyDocument *doc = document_get_current();
 	const gchar *check_msg;
@@ -1471,10 +1471,11 @@ void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	}
 
 	/* use the filetype specific command if available, fallback to global command otherwise */
+	context_action_cmd = filetypes_get_action_cmd(doc->file_type, word);
 	if (doc->file_type != NULL &&
-		!EMPTY(doc->file_type->context_action_cmd))
+		!EMPTY(context_action_cmd))
 	{
-		command = g_strdup(doc->file_type->context_action_cmd);
+		command = g_strdup(context_action_cmd);
 		check_msg = _("Check the path setting in Filetype configuration.");
 	}
 	else

--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -153,6 +153,7 @@ typedef struct GeanyFiletype
 	gchar			 *extension;		/**< Default file extension for new files, or @c NULL. */
 	gchar			**pattern;			/**< Array of filename-matching wildcard strings. */
 	gchar			 *context_action_cmd;
+	GPtrArray		 *context_action_patterns; /**< Array of GeanyCtxtActionPattern. */
 	gchar			 *comment_open;
 	gchar			 *comment_close;
 	gboolean		  comment_use_indent;
@@ -232,6 +233,8 @@ gboolean filetypes_parse_error_message(GeanyFiletype *ft, const gchar *message,
 
 gboolean filetype_get_comment_open_close(const GeanyFiletype *ft, gboolean single_first,
 		const gchar **co, const gchar **cc);
+
+gchar *filetypes_get_action_cmd(const GeanyFiletype *ft, gchar *word);
 
 #endif /* GEANY_PRIVATE */
 


### PR DESCRIPTION
It is now possible to use patterns to specify the context action command to be executed
if the user selects "Context Action" from the context menu. The patterns can be configured
in the filetypes configuration files.

Each action pattern entry needs to have a key of the form "context_action_pattern" followed by
a number from 1 to 99 (e.g. "context_action_pattern1", "context_action_pattern2"). The value
assigned must be a ';' separated string list with two entries. First, the pattern to match and
then the command to execute. So a complete entry looks like this:

context_action_pattern1=pattern;command;

Loading of the patterns stops after the 99th entry or if no more entries are found.
A gap in the entries numeration would lead to early abort of loading.

To find the corresponding action command for the current word/selection the following
procedure is performed:
1. Try to match the current selection/word against a pattern.
   If there is a match then the corresponding command is returned.
   Patterns are matched in the order in which they are specified in the filetype config file.
   The pattern matching uses the flag "G_REGEX_MATCH_ANCHORED" which means the pattern
   needs to match the word from the start. This is equal to using "^" at the start
   of the pattern.
2. If there is no match return the "context_action_cmd" for the filetype.
3. If that is empty use the context action from the global "Tools" preferences

Here is an example config for ```filetype.c``` to try out the feature:
```
# context action command (please see Geany's main documentation for details)
context_action_cmd=firefox --new-tab "http://www.cplusplus.com/search.do?q=%s"
context_action_pattern1=g_.*;firefox --new-tab "https://developer.gnome.org/symbols/search?q=%s";
context_action_pattern2=xml.*;firefox --new-tab "http://xmlsoft.org/search.php?query=%s";
```
This config will open/search the cplusplus website if there is no match in the patterns. If the current word/selection starts with ```g_``` then it searches the gnome API. If the current word/selection starts with ```xml``` then it searches the Libxml2 website.