### PR TITLE
support for fwd bkwd mouse buttons

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -354,15 +354,18 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 		return TRUE;
 	}
 
-	else if (event->button == 8 /*backwards*/)
+	else if (event->button == 8 /*backwards*/ && editor_prefs.mouse_back_forward_enabled)
 	{
 		navqueue_go_back();
 	}
 
-	else if (event->button == 9 /*forwards*/)
+	else if (event->button == 9 /*forwards*/ && editor_prefs.mouse_back_forward_enabled)
 	{
 		navqueue_go_forward();
 	}
+
+	else if (event->button > 5 && app->debug_mode)
+		g_warning("Unknown mouse button was pressed %i", event->button);
 
 	return FALSE;
 }

--- a/src/editor.c
+++ b/src/editor.c
@@ -354,12 +354,12 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 		return TRUE;
 	}
 
-	else if (event->button == 8 /*backwards*/ && editor_prefs.mouse_back_forward_enabled)
+	else if (event->button == 8 && editor_prefs.mouse_back_forward_enabled)
 	{
 		navqueue_go_back();
 	}
 
-	else if (event->button == 9 /*forwards*/ && editor_prefs.mouse_back_forward_enabled)
+	else if (event->button == 9 && editor_prefs.mouse_back_forward_enabled)
 	{
 		navqueue_go_forward();
 	}

--- a/src/editor.c
+++ b/src/editor.c
@@ -47,6 +47,7 @@
 #include "geanyobject.h"
 #include "highlighting.h"
 #include "keybindings.h"
+#include "navqueue.h"
 #include "main.h"
 #include "prefs.h"
 #include "projectprivate.h"
@@ -329,7 +330,7 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 	}
 
 	/* calls the edit popup menu in the editor */
-	if (event->button == 3)
+	else if (event->button == 3)
 	{
 		gboolean can_goto;
 
@@ -352,6 +353,17 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 
 		return TRUE;
 	}
+
+	else if (event->button == 8 /*backwards*/)
+	{
+		navqueue_go_back();
+	}
+
+	else if (event->button == 9 /*forwards*/)
+	{
+		navqueue_go_forward();
+	}
+
 	return FALSE;
 }
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -139,6 +139,7 @@ typedef struct GeanyEditorPrefs
 	gint		autocompletion_update_freq;
 	gint		scroll_lines_around_cursor;
 	gint		ime_interaction; /* input method editor's candidate window behaviour */
+	gboolean	mouse_back_forward_enabled;
 }
 GeanyEditorPrefs;
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -259,6 +259,8 @@ static void init_pref_groups(void)
 		"replace_and_find_by_default", TRUE);
 	stash_group_add_integer(group, &editor_prefs.ime_interaction,
 		"editor_ime_interaction", SC_IME_WINDOWED);
+	stash_group_add_boolean(group, &editor_prefs.mouse_back_forward_enabled,
+		"mouse_back_forward_enabled", TRUE);
 
 	/* Note: Interface-related various prefs are in ui_init_prefs() */
 


### PR DESCRIPTION
Fixes #1646
I'm almost sure that button values are the same on Windows, macOS or other types of mice