### PR TITLE
warning support

### DIFF
--- a/data/filedefs/filetypes.common
+++ b/data/filedefs/filetypes.common
@@ -95,6 +95,7 @@ calltips=call_tips
 
 # error indicator color
 indicator_error=0xff0000
+indicator_warning=0xffcc00
 
 [settings]
 # which characters should be skipped when moving (or included when deleting) to word boundaries

--- a/src/build.c
+++ b/src/build.c
@@ -1009,7 +1009,8 @@ static void process_build_output_line(gchar *msg, gint color)
 	{
 		SETPTR(current_dir_entered, tmp);
 	}
-	msgwin_parse_compiler_error_line(msg, current_dir_entered, &filename, &line);
+	GeanyLineType linetype;
+	msgwin_parse_compiler_error_line(msg, current_dir_entered, &filename, &line, &linetype);
 
 	if (line != -1 && filename != NULL)
 	{
@@ -1021,10 +1022,14 @@ static void process_build_output_line(gchar *msg, gint color)
 		{
 			if (line > 0) /* some compilers, like pdflatex report errors on line 0 */
 				line--;   /* so only adjust the line number if it is greater than 0 */
-			editor_indicator_set_on_line(doc->editor, GEANY_INDICATOR_ERROR, line);
+			GeanyIndicator indic = GEANY_INDICATOR_ERROR;
+			if(linetype == LINE_WARNING)
+				indic = GEANY_INDICATOR_WARNING;
+			if(linetype == LINE_ERROR || linetype == LINE_WARNING)
+				editor_indicator_set_on_line(doc->editor, indic, line);
 		}
 		build_info.message_count++;
-		color = COLOR_RED;	/* error message parsed on the line */
+		color = linetype == LINE_WARNING ? COLOR_YELLOW : COLOR_RED;	/* error message parsed on the line */
 
 		if (build_info.message_count == 1)
 		{

--- a/src/editor.h
+++ b/src/editor.h
@@ -66,6 +66,9 @@ typedef enum
 {
 	/** Indicator to highlight errors in the document text. This is a red squiggly underline. */
 	GEANY_INDICATOR_ERROR = 0,
+	GEANY_INDICATOR_NOTE = 1,
+	GEANY_INDICATOR_WARNING = 2,
+
 	/** Indicator used to highlight search results in the document. This is a
 	 *  rounded box around the text. */
 	/* start container indicator outside of lexer indicators (0..7), see Scintilla docs */

--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -37,6 +37,14 @@ G_BEGIN_DECLS
 /* Forward-declared to avoid including document.h since it includes this header */
 struct GeanyDocument;
 
+typedef enum
+{
+	LINE_ERROR = 0,
+	LINE_WARNING,
+	LINE_NOTE,
+	LINE_TEXT
+} GeanyLineType;
+
 /** IDs of known filetypes
  *
  * @ref filetypes will contain an item for each. Use GeanyData::filetypes_array to
@@ -227,7 +235,7 @@ GtkFileFilter *filetypes_create_file_filter_all_source(void);
 gboolean filetype_has_tags(GeanyFiletype *ft);
 
 gboolean filetypes_parse_error_message(GeanyFiletype *ft, const gchar *message,
-		gchar **filename, gint *line);
+		gchar **filename, gint *line, GeanyLineType *linetype);
 
 gboolean filetype_get_comment_open_close(const GeanyFiletype *ft, gboolean single_first,
 		const gchar **co, const gchar **cc);

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -96,6 +96,7 @@ enum	/* Geany common styling */
 	GCS_LINE_HEIGHT,
 	GCS_CALLTIPS,
 	GCS_INDICATOR_ERROR,
+	GCS_INDICATOR_WARNING,
 	GCS_MAX
 };
 
@@ -559,6 +560,7 @@ static void styleset_common_init(GKeyFile *config, GKeyFile *config_home)
 	get_keyfile_style(config, config_home, "marker_mark", &common_style_set.styling[GCS_MARKER_MARK]);
 	get_keyfile_style(config, config_home, "calltips", &common_style_set.styling[GCS_CALLTIPS]);
 	get_keyfile_style(config, config_home, "indicator_error", &common_style_set.styling[GCS_INDICATOR_ERROR]);
+	get_keyfile_style(config, config_home, "indicator_warning", &common_style_set.styling[GCS_INDICATOR_WARNING]);
 
 	get_keyfile_ints(config, config_home, "styling", "folding_style",
 		1, 1, &common_style_set.fold_marker, &common_style_set.fold_lines);
@@ -650,6 +652,11 @@ static void styleset_common(ScintillaObject *sci, guint ft_id)
 	SSM(sci, SCI_INDICSETSTYLE, GEANY_INDICATOR_ERROR, INDIC_SQUIGGLEPIXMAP);
 	SSM(sci, SCI_INDICSETFORE, GEANY_INDICATOR_ERROR,
 		invert(common_style_set.styling[GCS_INDICATOR_ERROR].foreground));
+
+	/* Warning indicator */
+	SSM(sci, SCI_INDICSETSTYLE, GEANY_INDICATOR_WARNING, INDIC_SQUIGGLEPIXMAP);
+	SSM(sci, SCI_INDICSETFORE, GEANY_INDICATOR_WARNING,
+		invert(common_style_set.styling[GCS_INDICATOR_WARNING].foreground));
 
 	/* Search indicator, used for 'Mark' matches */
 	SSM(sci, SCI_INDICSETSTYLE, GEANY_INDICATOR_SEARCH, INDIC_ROUNDBOX);

--- a/src/msgwindow.h
+++ b/src/msgwindow.h
@@ -36,7 +36,8 @@ enum MsgColors
 	COLOR_RED,		/**< Color red */
 	COLOR_DARK_RED,	/**< Color dark red */
 	COLOR_BLACK,	/**< Color black */
-	COLOR_BLUE		/**< Color blue */
+	COLOR_BLUE,		/**< Color blue */
+	COLOR_YELLOW
 };
 
 /** Indices of the notebooks in the messages window. */
@@ -49,7 +50,6 @@ typedef enum
 	MSG_SCRATCH,	/**< Index of the scratch tab */
 	MSG_VTE			/**< Index of the VTE tab */
 } MessageWindowTabNum;
-
 
 void msgwin_status_add(const gchar *format, ...) G_GNUC_PRINTF (1, 2);
 void msgwin_status_add_string(const gchar *msg);
@@ -103,7 +103,7 @@ void msgwin_menu_add_common_items(GtkMenu *menu);
 gboolean msgwin_goto_compiler_file_line(gboolean focus_editor);
 
 void msgwin_parse_compiler_error_line(const gchar *string, const gchar *dir,
-									  gchar **filename, gint *line);
+									  gchar **filename, gint *line, GeanyLineType*linetype);
 
 gboolean msgwin_goto_messages_file_line(gboolean focus_editor);
 


### PR DESCRIPTION
Fix #864 
Note that I didn't workout regex since it seems to break group number conventions.
Also for this to work we must reset LANG envvar (maybe provide an option?) since gcc translates words "error", "warning", "note".
![image](https://user-images.githubusercontent.com/7345761/31590454-3365d686-b219-11e7-8009-a9af11f5a859.png)
