### PR TITLE
Use utils_get_uri_file_prefix() as file URI prefix

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -1237,13 +1237,14 @@ static void on_build_menu_item(GtkWidget *w, gpointer user_data)
 		bc = get_build_cmd(doc, grp, cmd, NULL);
 		if (bc != NULL && strcmp(bc->command, "builtin") == 0)
 		{
+			const gchar *uri_file_prefix;
 			gchar *uri;
 			if (doc == NULL)
 				return;
-			uri = g_strconcat("file:///", g_path_skip_root(doc->file_name), NULL);
+			uri_file_prefix = utils_get_uri_file_prefix();
+			uri = g_strconcat(uri_file_prefix, doc->file_name, NULL);
 			utils_open_browser(uri);
 			g_free(uri);
-
 		}
 		else
 			build_run_cmd(doc, cmd);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1688,6 +1688,17 @@ gboolean utils_spawn_async(const gchar *dir, gchar **argv, gchar **env, GSpawnFl
 }
 
 
+/* Returns "file:///" on Windows, "file://" everywhere else */
+const gchar *utils_get_uri_file_prefix(void)
+{
+#ifdef G_OS_WIN32
+	return "file:///";
+#else
+	return "file://";
+#endif
+}
+
+
 /* Retrieves the path for the given URI.
  * It returns:
  * - the path which was determined by g_filename_from_uri() or GIO
@@ -1893,16 +1904,13 @@ GSList *utils_get_config_files(const gchar *subdir)
  * an anchor link, e.g. "#some_anchor". */
 gchar *utils_get_help_url(const gchar *suffix)
 {
-	gint skip;
 	gchar *uri;
+	const gchar *uri_file_prefix = utils_get_uri_file_prefix();
+	gint skip = strlen(uri_file_prefix);
 
+	uri = g_strconcat(uri_file_prefix, app->docdir, "/index.html", NULL);
 #ifdef G_OS_WIN32
-	skip = 8;
-	uri = g_strconcat("file:///", app->docdir, "/index.html", NULL);
 	g_strdelimit(uri, "\\", '/'); /* replace '\\' by '/' */
-#else
-	skip = 7;
-	uri = g_strconcat("file://", app->docdir, "/index.html", NULL);
 #endif
 
 	if (! g_file_test(uri + skip, G_FILE_TEST_IS_REGULAR))
@@ -2115,7 +2123,7 @@ const gchar *utils_resource_dir(GeanyResourceDirType type)
 		{
 # ifdef MAC_INTEGRATION
 			gchar *prefix = gtkosx_application_get_resource_path();
-			
+
 			resdirs[RESOURCE_DIR_DATA] = g_build_filename(prefix, "share", "geany", NULL);
 			resdirs[RESOURCE_DIR_ICON] = g_build_filename(prefix, "share", "icons", NULL);
 			resdirs[RESOURCE_DIR_DOC] = g_build_filename(prefix, "share", "doc", "geany", "html", NULL);

--- a/src/utils.h
+++ b/src/utils.h
@@ -309,6 +309,7 @@ gboolean utils_str_has_upper(const gchar *str);
 
 gint utils_is_file_writable(const gchar *locale_filename);
 
+const gchar *utils_get_uri_file_prefix(void);
 
 gchar *utils_get_path_from_uri(const gchar *uri);
 


### PR DESCRIPTION
Use utils_get_uri_file_prefix() as file URI prefix

utils_get_uri_file_prefix() gives "file:///" for Windows and
"file://" for all other platforms. So we don't need "g_path_skip_root()"
any longer.
Using "g_path_skip_root()" removed the drive letter from the URI which
worked only as long as the file to be opened was on drive C: (or
whatever drive Windows considers as the default). But since local file
URIs including the drive letter are supported on Windows, we should use
it, so opening files on other drives works as well.

Fixes #1018.