### PR TITLE
Enable popup menu on sidebar and message window notebooks

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -6578,8 +6578,8 @@
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">_Edit</property>
                     <property name="use_underline">True</property>
-                    <signal name="select" handler="on_edit1_select" swapped="no"/>
                     <signal name="deselect" handler="on_edit1_deselect" swapped="no"/>
+                    <signal name="select" handler="on_edit1_select" swapped="no"/>
                     <child type="submenu">
                       <object class="GtkMenu" id="edit1_menu">
                         <property name="can_focus">False</property>
@@ -8199,6 +8199,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="scrollable">True</property>
+                    <property name="enable_popup">True</property>
                     <signal name="key-press-event" handler="on_escape_key_press_event" swapped="no"/>
                     <signal name="switch-page" handler="on_tv_notebook_switch_page" swapped="no"/>
                     <signal name="switch-page" handler="on_tv_notebook_switch_page_after" after="yes" swapped="no"/>
@@ -8283,6 +8284,7 @@
                 <property name="can_focus">True</property>
                 <property name="tab_pos">left</property>
                 <property name="scrollable">True</property>
+                <property name="enable_popup">True</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow4">
                     <property name="visible">True</property>


### PR DESCRIPTION
With GTK+ 3 and certain, even default, themes, the notebook tabs are so massive as to not allow more than one tab visible at a time in certain notebooks like the sidebar and message window. This just sets the `enable-popup` property of those notebooks to true to give an alternative way to quickly change the current tab.

Related somewhat to #1718 and #1723.