### PR TITLE
Size symbols and fold margins proportional to line height

### DIFF
--- a/data/filedefs/filetypes.common
+++ b/data/filedefs/filetypes.common
@@ -19,9 +19,6 @@ margin_linenumber=margin_line_number
 margin_folding=margin_folding
 fold_symbol_highlight=fold_symbol_highlight
 
-# width of the folding margin on the right of the line numbers
-folding_margin_width=12
-
 # background colour of the current line, only the second and third argument is interpreted
 # use the third argument to enable or disable the highlighting of the current line (has to be true/false)
 current_line=current_line

--- a/src/editor.c
+++ b/src/editor.c
@@ -1187,6 +1187,8 @@ static gboolean on_editor_notify(G_GNUC_UNUSED GObject *object, GeanyEditor *edi
 		case SCN_ZOOM:
 			/* recalculate line margin width */
 			sci_set_line_numbers(sci, editor_prefs.show_linenumber_margin);
+			sci_set_symbol_margin(sci, editor_prefs.show_markers_margin);
+			sci_set_folding_margin_visible(sci, editor_prefs.folding);
 			break;
 	}
 	/* we always return FALSE here to let plugins handle the event too */

--- a/src/editor.c
+++ b/src/editor.c
@@ -1065,6 +1065,15 @@ void editor_sci_notify_cb(G_GNUC_UNUSED GtkWidget *widget, G_GNUC_UNUSED gint sc
 }
 
 
+/* recalculate margins width */
+static void update_margins(ScintillaObject *sci)
+{
+	sci_set_line_numbers(sci, editor_prefs.show_linenumber_margin);
+	sci_set_symbol_margin(sci, editor_prefs.show_markers_margin);
+	sci_set_folding_margin_visible(sci, editor_prefs.folding);
+}
+
+
 static gboolean on_editor_notify(G_GNUC_UNUSED GObject *object, GeanyEditor *editor,
 								 SCNotification *nt, G_GNUC_UNUSED gpointer data)
 {
@@ -1185,10 +1194,7 @@ static gboolean on_editor_notify(G_GNUC_UNUSED GObject *object, GeanyEditor *edi
 			break;
 
 		case SCN_ZOOM:
-			/* recalculate line margin width */
-			sci_set_line_numbers(sci, editor_prefs.show_linenumber_margin);
-			sci_set_symbol_margin(sci, editor_prefs.show_markers_margin);
-			sci_set_folding_margin_visible(sci, editor_prefs.folding);
+			update_margins(sci);
 			break;
 	}
 	/* we always return FALSE here to let plugins handle the event too */
@@ -4610,6 +4616,7 @@ void editor_set_font(GeanyEditor *editor, const gchar *font)
 
 	g_free(font_name);
 
+	update_margins(editor->sci);
 	/* zoom to 100% to prevent confusion */
 	sci_zoom_off(editor->sci);
 }

--- a/src/editor.c
+++ b/src/editor.c
@@ -5189,6 +5189,8 @@ void editor_apply_update_prefs(GeanyEditor *editor)
 	sci_set_symbol_margin(sci, editor_prefs.show_markers_margin);
 	sci_set_line_numbers(sci, editor_prefs.show_linenumber_margin);
 
+	sci_set_folding_margin_visible(sci, editor_prefs.folding);
+
 	/* virtual space */
 	SSM(sci, SCI_SETVIRTUALSPACEOPTIONS, editor_prefs.show_virtual_space, 0);
 

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -96,7 +96,6 @@ enum	/* Geany common styling */
 	GCS_LINE_HEIGHT,
 	GCS_CALLTIPS,
 	GCS_INDICATOR_ERROR,
-	GCS_FOLDING_MARGIN_WIDTH,
 	GCS_MAX
 };
 
@@ -565,8 +564,6 @@ static void styleset_common_init(GKeyFile *config, GKeyFile *config_home)
 		1, 1, &common_style_set.fold_marker, &common_style_set.fold_lines);
 	get_keyfile_ints(config, config_home, "styling", "folding_horiz_line",
 		2, 0, &common_style_set.fold_draw_line, NULL);
-	get_keyfile_ints(config, config_home, "styling", "folding_margin_width",
-		1, 0, &common_style_set.styling[GCS_FOLDING_MARGIN_WIDTH].background, NULL);
 	get_keyfile_ints(config, config_home, "styling", "caret_width",
 		1, 0, &common_style_set.styling[GCS_CARET].background, NULL); /* caret.foreground used earlier */
 	get_keyfile_int(config, config_home, "styling", "line_wrap_visuals",
@@ -808,22 +805,6 @@ static void styleset_common(ScintillaObject *sci, guint ft_id)
 }
 
 
-/* folding margin visibility */
-static void set_folding_margin_visible(ScintillaObject *sci, gboolean set)
-{
-	if (set)
-	{
-		SSM(sci, SCI_SETMARGINWIDTHN, 2, common_style_set.styling[GCS_FOLDING_MARGIN_WIDTH].background);
-		SSM(sci, SCI_SETMARGINSENSITIVEN, 2, TRUE);
-	}
-	else
-	{
-		SSM(sci, SCI_SETMARGINSENSITIVEN, 2, FALSE);
-		SSM(sci, SCI_SETMARGINWIDTHN, 2, 0);
-	}
-}
-
-
 /* Merge & assign global typedefs and user secondary keywords.
  * keyword_idx is used for both style_sets[].keywords and scintilla keyword style number */
 static void merge_type_keywords(ScintillaObject *sci, guint ft_id, guint keyword_idx)
@@ -898,8 +879,6 @@ static void styleset_from_mapping(ScintillaObject *sci, guint ft_id, guint lexer
 			set_sci_style(sci, styles[i].style, ft_id, i);
 		}
 	}
-
-	set_folding_margin_visible(sci, editor_prefs.folding);
 
 	/* keywords */
 	foreach_range(i, n_keywords)

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -144,12 +144,31 @@ void sci_set_mark_long_lines(ScintillaObject *sci, gint type, gint column, const
 }
 
 
+/* compute margin width based on ratio of line height */
+static gint margin_width_from_line_height(ScintillaObject *sci, gdouble ratio, gint threshold)
+{
+	const gint line_height = SSM(sci, SCI_TEXTHEIGHT, 0, 0);
+	gint width;
+
+	width = line_height * ratio;
+	/* round down to an even size */
+	width = width - (width % 2);
+	/* if under threshold, just use the line height */
+	if (width < threshold)
+		width = MIN(threshold, line_height);
+
+	return width;
+}
+
+
 /* symbol margin visibility */
 void sci_set_symbol_margin(ScintillaObject *sci, gboolean set)
 {
 	if (set)
 	{
-		SSM(sci, SCI_SETMARGINWIDTHN, 1, 16);
+		const gint width = margin_width_from_line_height(sci, 0.88, 16);
+
+		SSM(sci, SCI_SETMARGINWIDTHN, 1, width);
 		SSM(sci, SCI_SETMARGINSENSITIVEN, 1, TRUE);
 	}
 	else
@@ -165,7 +184,9 @@ void sci_set_folding_margin_visible(ScintillaObject *sci, gboolean set)
 {
 	if (set)
 	{
-		SSM(sci, SCI_SETMARGINWIDTHN, 2, 12);
+		const gint width = margin_width_from_line_height(sci, 0.66, 12);
+
+		SSM(sci, SCI_SETMARGINWIDTHN, 2, width);
 		SSM(sci, SCI_SETMARGINSENSITIVEN, 2, TRUE);
 	}
 	else

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -160,6 +160,22 @@ void sci_set_symbol_margin(ScintillaObject *sci, gboolean set)
 }
 
 
+/* folding margin visibility */
+void sci_set_folding_margin_visible(ScintillaObject *sci, gboolean set)
+{
+	if (set)
+	{
+		SSM(sci, SCI_SETMARGINWIDTHN, 2, 12);
+		SSM(sci, SCI_SETMARGINSENSITIVEN, 2, TRUE);
+	}
+	else
+	{
+		SSM(sci, SCI_SETMARGINSENSITIVEN, 2, FALSE);
+		SSM(sci, SCI_SETMARGINWIDTHN, 2, 0);
+	}
+}
+
+
 /* end of lines */
 void sci_set_visible_eols(ScintillaObject *sci, gboolean set)
 {

--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -157,6 +157,7 @@ void 				sci_toggle_fold				(ScintillaObject *sci, gint line);
 gint				sci_get_fold_level			(ScintillaObject *sci, gint line);
 gint				sci_get_fold_parent			(ScintillaObject *sci, gint start_line);
 
+void 				sci_set_folding_margin_visible (ScintillaObject *sci, gboolean set);
 gboolean			sci_get_fold_expanded		(ScintillaObject *sci, gint line);
 
 void				sci_colourise				(ScintillaObject *sci, gint start, gint end);


### PR DESCRIPTION
This makes those margin better adapt larger font sizes and zooms.

Fixes #1733.