### PR TITLE
Remove requirement to fail build on aggregate return

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - sudo apt-get install -y --no-install-recommends doxygen
   - sudo apt-get install -y python-lxml
 before_script:
-  - export CFLAGS="-g -O2 -Werror=pointer-arith -Werror=aggregate-return -Werror=implicit-function-declaration"
+  - export CFLAGS="-g -O2 -Werror=pointer-arith -Werror=implicit-function-declaration"
 script:
   - NOCONFIGURE=1 ./autogen.sh
   - >


### PR DESCRIPTION
Returning large aggregates as values is a potential performance problem, but preventing all aggregate returns is inappropriate because:

1. returning small aggregates that are mostly handled as complete objects as return values often makes code clearer.

2. Modern (well not so modern actually) ABIs allow for small aggregates to be returned in registers, so forcing all returns to memory is actually likely to be slower.

3. if code review does not notice a large aggregate return and nobody notices a performance issue then it doesn't matter

[Edit: 4. matches Geany-Plugins]