### PR TITLE
VTE: fix double popup menu on right click

### DIFF
--- a/src/vte.c
+++ b/src/vte.c
@@ -541,7 +541,12 @@ static gboolean vte_button_pressed(GtkWidget *widget, GdkEventButton *event, gpo
 	{
 		gtk_widget_grab_focus(widget);
 	}
-	return FALSE;
+	else
+	{
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 


### PR DESCRIPTION
The button signal handler didn't return TRUE when it handled a key, which
inadvertently chains up other button handler (i.e. more popup menus).

Made visible by commit 1f71ccd40.