### PR TITLE
GI compatible msgwin_*_add

### DIFF
--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -334,7 +334,15 @@ void msgwin_compiler_add(gint msg_color, const gchar *format, ...)
 	g_free(string);
 }
 
-
+/**
+ *  Adds a new message in the compiler tab treeview in the messages window.
+ *
+ *  @param msg_color A color to be used for the text. It must be an element of #MsgColors.
+ *  @param msg Compiler message to be added.
+ *
+ *  @since @todo
+ **/
+GEANY_API_SYMBOL
 void msgwin_compiler_add_string(gint msg_color, const gchar *msg)
 {
 	GtkTreeIter iter;
@@ -410,7 +418,18 @@ void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *
 }
 
 
-/* adds string to the msg treeview */
+/**
+ *  Adds a new message in the messages tab treeview in the messages window.
+ *  If @a line and @a doc are set, clicking on this line jumps into the
+ *  file which is specified by @a doc into the line specified with @a line.
+ *
+ *  @param msg_color A color to be used for the text. It must be an element of #MsgColors.
+ *  @param line The document's line where the message belongs to. Set to @c -1 to ignore.
+ *  @param doc The document. Set to @c NULL to ignore.
+ *  @param string Message to be added.
+ *
+ *  @since @todo
+ **/
 void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const gchar *string)
 {
 	GtkTreeIter iter;
@@ -451,26 +470,20 @@ void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const 
  *  Logs a status message *without* setting the status bar.
  *  (Use ui_set_statusbar() to display text on the statusbar)
  *
- *  @param format @c printf()-style format string.
- *  @param ... Arguments for the @c format string.
+ *  @param string Status message to be logged.
+ *
+ *  @since @todo
  **/
 GEANY_API_SYMBOL
-void msgwin_status_add(const gchar *format, ...)
+void msgwin_status_add_string(const gchar *string)
 {
 	GtkTreeIter iter;
-	gchar *string;
 	gchar *statusmsg, *time_str;
-	va_list args;
-
-	va_start(args, format);
-	string = g_strdup_vprintf(format, args);
-	va_end(args);
 
 	/* add a timestamp to status messages */
 	time_str = utils_get_current_time_string();
 	statusmsg = g_strconcat(time_str, ": ", string, NULL);
 	g_free(time_str);
-	g_free(string);
 
 	/* add message to Status window */
 	gtk_list_store_append(msgwindow.store_status, &iter);
@@ -486,6 +499,29 @@ void msgwin_status_add(const gchar *format, ...)
 			gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_STATUS);
 		gtk_tree_path_free(path);
 	}
+}
+
+/**
+ *  Logs a status message *without* setting the status bar.
+ *  (Use ui_set_statusbar() to display text on the statusbar)
+ *
+ *  @param format @c printf()-style format string.
+ *  @param ... Arguments for the @c format string.
+ **/
+GEANY_API_SYMBOL
+void msgwin_status_add(const gchar *format, ...)
+{
+	GtkTreeIter iter;
+	gchar *string;
+	gchar *statusmsg, *time_str;
+	va_list args;
+
+	va_start(args, format);
+	string = g_strdup_vprintf(format, args);
+	va_end(args);
+
+	msgwin_status_add_string(string);
+	g_free(string);
 }
 
 

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -106,9 +106,11 @@ void msgwin_show_hide_tabs(void)
 }
 
 
-/** Sets the Messages path for opening any parsed filenames without absolute path
- * from message lines.
- * @param messages_dir The directory. **/
+/**
+ * Sets the Messages path for opening any parsed filenames without absolute path from message lines.
+ *
+ * @param messages_dir The directory.
+ **/
 GEANY_API_SYMBOL
 void msgwin_set_messages_dir(const gchar *messages_dir)
 {
@@ -315,11 +317,13 @@ static const GdkColor *get_color(gint msg_color)
 
 
 /**
- *  Adds a new message in the compiler tab treeview in the messages window.
+ * Adds a new message in the compiler tab treeview in the messages window.
  *
- *  @param msg_color A color to be used for the text. It must be an element of #MsgColors.
- *  @param format @c printf()-style format string.
- *  @param ... Arguments for the @c format string.
+ * @param msg_color A color to be used for the text. It must be an element of #MsgColors.
+ * @param format    @c printf()-style format string.
+ * @param ...       Arguments for the @c format string.
+ *
+ * @since 0.15
  **/
 GEANY_API_SYMBOL
 void msgwin_compiler_add(gint msg_color, const gchar *format, ...)
@@ -335,12 +339,12 @@ void msgwin_compiler_add(gint msg_color, const gchar *format, ...)
 }
 
 /**
- *  Adds a new message in the compiler tab treeview in the messages window.
+ * Adds a new message in the compiler tab treeview in the messages window.
  *
- *  @param msg_color A color to be used for the text. It must be an element of #MsgColors.
- *  @param msg Compiler message to be added.
+ * @param msg_color A color to be used for the text. It must be an element of #MsgColors.
+ * @param msg       Compiler message to be added.
  *
- *  @since @todo
+ * @since @todo
  **/
 GEANY_API_SYMBOL
 void msgwin_compiler_add_string(gint msg_color, const gchar *msg)
@@ -391,15 +395,16 @@ void msgwin_show_hide(gboolean show)
 
 
 /**
- *  Adds a new message in the messages tab treeview in the messages window.
- *  If @a line and @a doc are set, clicking on this line jumps into the file which is specified
- *  by @a doc into the line specified with @a line.
+ * Adds a new message in the messages tab treeview in the messages window.
  *
- *  @param msg_color A color to be used for the text. It must be an element of #MsgColors.
- *  @param line The document's line where the message belongs to. Set to @c -1 to ignore.
- *  @param doc The document. Set to @c NULL to ignore.
- *  @param format @c printf()-style format string.
- *  @param ... Arguments for the @c format string.
+ * If @a line and @a doc are set, clicking on this line jumps into the file
+ * which is specified by @a doc into the line specified with @a line.
+ *
+ * @param msg_color A color to be used for the text. It must be an element of #MsgColors.
+ * @param line      The document's line where the message belongs to. Set to @c -1 to ignore.
+ * @param doc       @nullable The document. Set to @c NULL to ignore.
+ * @param format    @c printf()-style format string.
+ * @param ...       Arguments for the @c format string.
  *
  * @since 0.15
  **/
@@ -419,16 +424,17 @@ void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *
 
 
 /**
- *  Adds a new message in the messages tab treeview in the messages window.
- *  If @a line and @a doc are set, clicking on this line jumps into the
- *  file which is specified by @a doc into the line specified with @a line.
+ * Adds a new message in the messages tab treeview in the messages window.
  *
- *  @param msg_color A color to be used for the text. It must be an element of #MsgColors.
- *  @param line The document's line where the message belongs to. Set to @c -1 to ignore.
- *  @param doc The document. Set to @c NULL to ignore.
- *  @param string Message to be added.
+ * If @a line and @a doc are set, clicking on this line jumps into the
+ * file which is specified by @a doc into the line specified with @a line.
  *
- *  @since @todo
+ * @param msg_color A color to be used for the text. It must be an element of #MsgColors.
+ * @param line      The document's line where the message belongs to. Set to @c -1 to ignore.
+ * @param doc       @nullable The document. Set to @c NULL to ignore.
+ * @param string    Message to be added.
+ *
+ * @since @todo
  **/
 void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const gchar *string)
 {
@@ -467,12 +473,13 @@ void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const 
 
 
 /**
- *  Logs a status message *without* setting the status bar.
- *  (Use ui_set_statusbar() to display text on the statusbar)
+ * Logs a status message *without* setting the status bar.
  *
- *  @param string Status message to be logged.
+ * Use @ref ui_set_statusbar() to display text on the statusbar.
  *
- *  @since @todo
+ * @param string Status message to be logged.
+ *
+ * @since @todo
  **/
 GEANY_API_SYMBOL
 void msgwin_status_add_string(const gchar *string)
@@ -502,11 +509,12 @@ void msgwin_status_add_string(const gchar *string)
 }
 
 /**
- *  Logs a status message *without* setting the status bar.
- *  (Use ui_set_statusbar() to display text on the statusbar)
+ * Logs a status message *without* setting the status bar.
  *
- *  @param format @c printf()-style format string.
- *  @param ... Arguments for the @c format string.
+ * Use @ref ui_set_statusbar() to display text on the statusbar.
+ *
+ * @param format @c printf()-style format string.
+ * @param ...    Arguments for the @c format string.
  **/
 GEANY_API_SYMBOL
 void msgwin_status_add(const gchar *format, ...)
@@ -1273,12 +1281,13 @@ static gboolean on_msgwin_button_press_event(GtkWidget *widget, GdkEventButton *
 
 
 /**
- *  Switches to the given notebook tab of the messages window and shows the messages window
- *  if it was previously hidden and @a show is set to @c TRUE.
+ * Switches to the given notebook tab of the messages window.
  *
- *  @param tabnum An index of a tab in the messages window. Valid values are all elements of
- *                #MessageWindowTabNum.
- *  @param show Whether to show the messages window at all if it was hidden before.
+ * The messages window is shown if it was previously hidden and @a show is set to @c TRUE.
+ *
+ * @param tabnum An index of a tab in the messages window. Valid values are
+ *                all elements of #MessageWindowTabNum.
+ * @param show   Whether to show the messages window at all if it was hidden before.
  *
  * @since 0.15
  **/
@@ -1310,9 +1319,9 @@ void msgwin_switch_tab(gint tabnum, gboolean show)
 
 
 /**
- *  Removes all messages from a tab specified by @a tabnum in the messages window.
+ * Removes all messages from a tab specified by @a tabnum in the messages window.
  *
- *  @param tabnum An index of a tab in the messages window which should be cleared.
+ * @param tabnum An index of a tab in the messages window which should be cleared.
  *                Valid values are @c MSG_STATUS, @c MSG_COMPILER and @c MSG_MESSAGE.
  *
  * @since 0.15

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -444,6 +444,7 @@ void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *
  *
  * @since @todo
  **/
+GEANY_API_SYMBOL
 void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const gchar *string)
 {
 	GtkTreeIter iter;
@@ -533,9 +534,7 @@ void msgwin_status_add_string(const gchar *string)
 GEANY_API_SYMBOL
 void msgwin_status_add(const gchar *format, ...)
 {
-	GtkTreeIter iter;
 	gchar *string;
-	gchar *statusmsg, *time_str;
 	va_list args;
 
 	va_start(args, format);

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -325,7 +325,7 @@ static const GdkColor *get_color(gint msg_color)
  *
  * @see msgwin_compiler_add_string()
  *
- * @since 0.15
+ * @since 0.16
  **/
 GEANY_API_SYMBOL
 void msgwin_compiler_add(gint msg_color, const gchar *format, ...)
@@ -412,7 +412,7 @@ void msgwin_show_hide(gboolean show)
  *
  * @see msgwin_msg_add_string()
  *
- * @since 0.15
+ * @since 0.16
  **/
 GEANY_API_SYMBOL
 void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *format, ...)

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -317,11 +317,13 @@ static const GdkColor *get_color(gint msg_color)
 
 
 /**
- * Adds a new message in the compiler tab treeview in the messages window.
+ * Adds a formatted message in the compiler tab treeview in the messages window.
  *
  * @param msg_color A color to be used for the text. It must be an element of #MsgColors.
  * @param format    @c printf()-style format string.
  * @param ...       Arguments for the @c format string.
+ *
+ * @see msgwin_compiler_add_string()
  *
  * @since 0.15
  **/
@@ -343,6 +345,8 @@ void msgwin_compiler_add(gint msg_color, const gchar *format, ...)
  *
  * @param msg_color A color to be used for the text. It must be an element of #MsgColors.
  * @param msg       Compiler message to be added.
+ *
+ * @see msgwin_compiler_add()
  *
  * @since @todo
  **/
@@ -395,7 +399,7 @@ void msgwin_show_hide(gboolean show)
 
 
 /**
- * Adds a new message in the messages tab treeview in the messages window.
+ * Adds a formatted message in the messages tab treeview in the messages window.
  *
  * If @a line and @a doc are set, clicking on this line jumps into the file
  * which is specified by @a doc into the line specified with @a line.
@@ -405,6 +409,8 @@ void msgwin_show_hide(gboolean show)
  * @param doc       @nullable The document. Set to @c NULL to ignore.
  * @param format    @c printf()-style format string.
  * @param ...       Arguments for the @c format string.
+ *
+ * @see msgwin_msg_add_string()
  *
  * @since 0.15
  **/
@@ -433,6 +439,8 @@ void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *
  * @param line      The document's line where the message belongs to. Set to @c -1 to ignore.
  * @param doc       @nullable The document. Set to @c NULL to ignore.
  * @param string    Message to be added.
+ *
+ * @see msgwin_msg_add()
  *
  * @since @todo
  **/
@@ -473,11 +481,13 @@ void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const 
 
 
 /**
- * Logs a status message *without* setting the status bar.
+ * Logs a new status message *without* setting the status bar.
  *
  * Use @ref ui_set_statusbar() to display text on the statusbar.
  *
  * @param string Status message to be logged.
+ *
+ * @see msgwin_status_add()
  *
  * @since @todo
  **/
@@ -509,12 +519,16 @@ void msgwin_status_add_string(const gchar *string)
 }
 
 /**
- * Logs a status message *without* setting the status bar.
+ * Logs a formatted status message *without* setting the status bar.
  *
  * Use @ref ui_set_statusbar() to display text on the statusbar.
  *
  * @param format @c printf()-style format string.
  * @param ...    Arguments for the @c format string.
+ *
+ * @see msgwin_status_add_string()
+ *
+ * @since 0.15
  **/
 GEANY_API_SYMBOL
 void msgwin_status_add(const gchar *format, ...)

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -529,7 +529,7 @@ void msgwin_status_add_string(const gchar *string)
  *
  * @see msgwin_status_add_string()
  *
- * @since 0.15
+ * @since 0.12
  **/
 GEANY_API_SYMBOL
 void msgwin_status_add(const gchar *format, ...)

--- a/src/msgwindow.h
+++ b/src/msgwindow.h
@@ -96,10 +96,6 @@ void msgwin_finalize(void);
 
 void msgwin_show_hide(gboolean show);
 
-void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const gchar *string);
-
-void msgwin_compiler_add_string(gint msg_color, const gchar *msg);
-
 void msgwin_show_hide_tabs(void);
 
 

--- a/src/msgwindow.h
+++ b/src/msgwindow.h
@@ -53,11 +53,14 @@ typedef enum
 
 
 void msgwin_status_add(const gchar *format, ...) G_GNUC_PRINTF (1, 2);
+void msgwin_status_add_string(const gchar *msg);
 
 void msgwin_compiler_add(gint msg_color, const gchar *format, ...) G_GNUC_PRINTF (2, 3);
+void msgwin_compiler_add_string(gint msg_color, const gchar *msg);
 
 void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *format, ...)
 			G_GNUC_PRINTF (4, 5);
+void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const char *msg);
 
 void msgwin_clear_tab(gint tabnum);
 


### PR DESCRIPTION
This adds _string variants to 3 msgwin_{compiler,status,msg}_add(), since those cannot be gobject-introspected (functions with variadic arguments generally can't because the parameters couldn't be marshalled).

So I simply add _string variants which take the string after g_strdup_vprintf(). I found that two of them already existed, so I only needed to add one and export all 3 to plugins.

@sagarchalise wants this in peasy and the functions are currently not available in any form.

GEANY_API_VERSION increment is TODO, will do once this lands.