### PR TITLE
Disable Prefs/Files/Saving-files if project open

### DIFF
--- a/src/prefs.c
+++ b/src/prefs.c
@@ -399,12 +399,14 @@ static void prefs_init_dialog(void)
 {
 	GtkWidget *widget;
 	GdkColor color = {0};
+	gboolean project_open;
 
 	/* Synchronize with Stash settings */
 	prefs_action(PREF_DISPLAY);
 
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "label_project_indent_warning");
 	ui_widget_show_hide(widget, app->project != NULL);
+	project_open = app->project != NULL;
 
 	/* General settings */
 	/* startup */
@@ -577,6 +579,11 @@ static void prefs_init_dialog(void)
 
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_trailing_spaces");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.strip_trailing_spaces);
+
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "frame2");
+	gtk_widget_set_sensitive(widget, ! project_open);
+	const char* tooltip = project_open ? _("These settings are overridden by your project settings") : "";
+	gtk_widget_set_tooltip_text(widget, tooltip);
 
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_new_line");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), file_prefs.final_new_line);


### PR DESCRIPTION
This PR aims to fix issue https://github.com/geany/geany/issues/1363 by disabling overridden settings in the preferences dialog if a project is open.

It also sets the section-tooltip to an informative message when the section is disabled.

It only covers the saving-files section for now but if you like it then it can be extended to the other sections