### PR TITLE
Reduce minimum-width of Replace dialog

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -305,7 +305,7 @@ static void on_widget_toggled_set_insensitive(
 static GtkWidget *add_find_checkboxes(GtkDialog *dialog)
 {
 	GtkWidget *checkbox1, *checkbox2, *check_regexp, *checkbox5,
-			  *checkbox7, *check_multiline, *hbox, *fbox, *mbox;
+			  *checkbox7, *check_multiline, *fbox;
 
 	check_regexp = gtk_check_button_new_with_mnemonic(_("_Use regular expressions"));
 	ui_hookup_widget(dialog, check_regexp, "check_regexp");
@@ -362,16 +362,11 @@ static GtkWidget *add_find_checkboxes(GtkDialog *dialog)
 	g_signal_connect(checkbox2, "toggled",
 		G_CALLBACK(on_widget_toggled_set_insensitive), checkbox5);
 
-	/* Matching options */
-	mbox = gtk_vbox_new(FALSE, 0);
-	gtk_box_pack_start(GTK_BOX(mbox), checkbox1, FALSE, FALSE, 0);
-	gtk_box_pack_start(GTK_BOX(mbox), checkbox2, FALSE, FALSE, 0);
-	gtk_box_pack_start(GTK_BOX(mbox), checkbox5, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(fbox), checkbox1, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(fbox), checkbox2, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(fbox), checkbox5, FALSE, FALSE, 0);
 
-	hbox = gtk_hbox_new(TRUE, 6);
-	gtk_container_add(GTK_CONTAINER(hbox), fbox);
-	gtk_container_add(GTK_CONTAINER(hbox), mbox);
-	return hbox;
+	return fbox;
 }
 
 

--- a/src/search.c
+++ b/src/search.c
@@ -613,12 +613,11 @@ on_widget_key_pressed_set_focus(GtkWidget *widget, GdkEventKey *event, gpointer 
 static void create_replace_dialog(void)
 {
 	GtkWidget *label_find, *label_replace,
-		*check_close, *button, *rbox, *fbox, *vbox, *exp, *bbox;
+		*check_close, *button, *fbox, *vbox, *exp, *bbox;
 	GtkSizeGroup *label_size;
 
-	replace_dlg.dialog = gtk_dialog_new_with_buttons(_("Replace"),
-		GTK_WINDOW(main_widgets.window), GTK_DIALOG_DESTROY_WITH_PARENT,
-		GTK_STOCK_CLOSE, GTK_RESPONSE_CANCEL, NULL);
+	replace_dlg.dialog = gtk_dialog_new();
+	gtk_window_set_title(GTK_WINDOW(replace_dlg.dialog), _("Replace"));
 	vbox = ui_dialog_vbox_new(GTK_DIALOG(replace_dlg.dialog));
 	gtk_box_set_spacing(GTK_BOX(vbox), 9);
 	gtk_widget_set_name(replace_dlg.dialog, "GeanyDialogSearch");
@@ -668,21 +667,15 @@ static void create_replace_dialog(void)
 	g_signal_connect(replace_dlg.dialog, "delete-event",
 			G_CALLBACK(gtk_widget_hide_on_delete), NULL);
 
-	fbox = gtk_hbox_new(FALSE, 6);
-	gtk_box_pack_start(GTK_BOX(fbox), label_find, FALSE, FALSE, 0);
-	gtk_box_pack_start(GTK_BOX(fbox), replace_dlg.find_combobox, TRUE, TRUE, 0);
-
-	rbox = gtk_hbox_new(FALSE, 6);
-	gtk_box_pack_start(GTK_BOX(rbox), label_replace, FALSE, FALSE, 0);
-	gtk_box_pack_start(GTK_BOX(rbox), replace_dlg.replace_combobox, TRUE, TRUE, 0);
-
 	label_size = gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL);
 	gtk_size_group_add_widget(label_size, label_find);
 	gtk_size_group_add_widget(label_size, label_replace);
 	g_object_unref(G_OBJECT(label_size));	/* auto destroy the size group */
 
-	gtk_box_pack_start(GTK_BOX(vbox), fbox, TRUE, FALSE, 0);
-	gtk_box_pack_start(GTK_BOX(vbox), rbox, TRUE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(vbox), label_find, TRUE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(vbox), replace_dlg.find_combobox, TRUE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(vbox), label_replace, TRUE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(vbox), replace_dlg.replace_combobox, TRUE, FALSE, 0);
 	gtk_container_add(GTK_CONTAINER(vbox),
 		add_find_checkboxes(GTK_DIALOG(replace_dlg.dialog)));
 
@@ -717,13 +710,15 @@ static void create_replace_dialog(void)
 	gtk_button_set_focus_on_click(GTK_BUTTON(check_close), FALSE);
 	gtk_widget_set_tooltip_text(check_close,
 			_("Disable this option to keep the dialog open"));
-	gtk_container_add(GTK_CONTAINER(bbox), check_close);
-	gtk_button_box_set_child_secondary(GTK_BUTTON_BOX(bbox), check_close, TRUE);
+
+	fbox = gtk_vbox_new(FALSE, 6);
+	gtk_box_pack_start(GTK_BOX(fbox), check_close, FALSE, FALSE, 0);
+	gtk_box_pack_start(GTK_BOX(fbox), bbox, FALSE, TRUE, 0);
 
 	ui_hbutton_box_copy_layout(
 		GTK_BUTTON_BOX(gtk_dialog_get_action_area(GTK_DIALOG(replace_dlg.dialog))),
 		GTK_BUTTON_BOX(bbox));
-	gtk_container_add(GTK_CONTAINER(exp), bbox);
+	gtk_container_add(GTK_CONTAINER(exp), fbox);
 	gtk_container_add(GTK_CONTAINER(vbox), exp);
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -647,14 +647,12 @@ static void create_replace_dialog(void)
 	replace_dlg.find_entry = gtk_bin_get_child(GTK_BIN(replace_dlg.find_combobox));
 	ui_entry_add_clear_icon(GTK_ENTRY(replace_dlg.find_entry));
 	gtk_label_set_mnemonic_widget(GTK_LABEL(label_find), replace_dlg.find_combobox);
-	gtk_entry_set_width_chars(GTK_ENTRY(replace_dlg.find_entry), 50);
 	ui_hookup_widget(replace_dlg.dialog, replace_dlg.find_combobox, "entry_find");
 
 	replace_dlg.replace_combobox = gtk_combo_box_text_new_with_entry();
 	replace_dlg.replace_entry = gtk_bin_get_child(GTK_BIN(replace_dlg.replace_combobox));
 	ui_entry_add_clear_icon(GTK_ENTRY(replace_dlg.replace_entry));
 	gtk_label_set_mnemonic_widget(GTK_LABEL(label_replace), replace_dlg.replace_combobox);
-	gtk_entry_set_width_chars(GTK_ENTRY(replace_dlg.replace_entry), 50);
 	ui_hookup_widget(replace_dlg.dialog, replace_dlg.replace_combobox, "entry_replace");
 
 	/* tab from find to the replace entry */
@@ -1705,7 +1703,7 @@ search_find_in_files(const gchar *utf8_search_text, const gchar *utf8_dir, const
 		NULL, &error))
  	{
 		gchar *utf8_str;
- 
+
  		ui_progress_bar_start(_("Searching..."));
  		msgwin_set_messages_dir(dir);
 		utf8_str = g_strdup_printf(_("%s %s -- %s (in directory: %s)"),


### PR DESCRIPTION
I use Geany's **Replace** dialog by default (bound to CTRL-F).
It is not very nice to use on a small screen as it is very wide
and either blocks some code or it blocks my list of files.

I think it should be vertically oriented to minimise this disruption.

The PR reduces the minimum-width of the **Replace** dialog by
37% on my laptop screen.

Even if you do not like it then please consider the first commit on its own.

This could be further improved by putting the 6 buttons at the bottom in rows of 2,
and perhaps putting the regex options in their own GtkExpander.

Any approved changes can then be copied to the **Find** dialog.

What do you think?

Original:
![1_orig](https://user-images.githubusercontent.com/1383407/35925325-56f9d918-0c1d-11e8-9372-d8f05bcdfac6.png)

Remove min-width of combo-boxes
![2_no_min_width](https://user-images.githubusercontent.com/1383407/35925329-58c98216-0c1d-11e8-9d7b-cbe538be112c.png)

Make combo-box labels and **Replace All** contents vertically oriented
![3_more_vertical](https://user-images.githubusercontent.com/1383407/35925338-5abf2be8-0c1d-11e8-8c0a-0513435702b5.png)

Make the checkbox options vertically oriented
![4_single_col](https://user-images.githubusercontent.com/1383407/35925340-5c94ff2e-0c1d-11e8-990e-00d1bd113268.png)
