### PR TITLE
Renamed pep8 to pycodestyle

### DIFF
--- a/data/filedefs/filetypes.python.in
+++ b/data/filedefs/filetypes.python.in
@@ -75,7 +75,7 @@ FT_00_LB=_Compile
 FT_00_CM=@PYTHON_COMMAND@ -m py_compile "%f"
 FT_00_WD=
 FT_02_LB=_Lint
-FT_02_CM=pep8 --max-line-length=80 "%f"
+FT_02_CM=pycodestyle --max-line-length=80 "%f"
 FT_02_WD=
 error_regex=(.+):([0-9]+):([0-9]+)
 EX_00_LB=_Execute

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3012,7 +3012,7 @@ division by zero, constant conditions, etc. Linters inspect the code and
 issue warnings much like the compilers do. This is formally referred to as
 static code analysis.
 
-Some common linters are pre-configured for you in the Build menu (``pep8``
+Some common linters are pre-configured for you in the Build menu (``pycodestyle``
 for Python, ``cppcheck`` for C/C++, JSHint for JavaScript, ``xmllint`` for
 XML, ``hlint`` for Haskell, ``shellcheck`` for shell code, ...), but all
 these are standalone tools you need to obtain before using.


### PR DESCRIPTION
pep8 has been renamed to pycodestyle, see [this](https://github.com/PyCQA/pycodestyle/issues/466) , [this](https://github.com/PyCQA/pycodestyle/issues/481) and [this](https://github.com/PyCQA/pycodestyle/commit/2344a34a628b2f2e9df1c2539d9316005a35053d) for more info.

In fact, if I run the lint option from Geany I get the following warning:
```
/usr/local/lib/python3.5/dist-packages/pep8.py:2124: UserWarning: 

pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.

$ pip install pycodestyle
$ pycodestyle ...

  '\n\n'
```

This PR replaces pep8 by pycodestyle, thus removing the warning.