### PR TITLE
plugin-manager: sync buttons on "button-release-event"

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1700,6 +1700,24 @@ static gboolean pm_treeview_button_press_cb(GtkWidget *widget, GdkEventButton *e
 }
 
 
+static gboolean pm_treeview_button_release_cb(GtkWidget *widget, GdkEventButton *event,
+		G_GNUC_UNUSED gpointer user_data)
+{
+	GtkTreeIter iter;
+	GtkTreeModel *model;
+	Plugin *p;
+
+	if (gtk_tree_selection_get_selected(gtk_tree_view_get_selection(GTK_TREE_VIEW(widget)), &model, &iter))
+	{
+		gtk_tree_model_get(model, &iter, PLUGIN_COLUMN_PLUGIN, &p, -1);
+
+		if (p != NULL)
+			pm_update_buttons(p);
+	}
+	return FALSE;
+}
+
+
 static gint pm_tree_sort_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b,
 		gpointer user_data)
 {
@@ -1834,6 +1852,7 @@ static void pm_prepare_treeview(GtkWidget *tree, GtkTreeStore *store)
 	g_signal_connect(sel, "changed", G_CALLBACK(pm_selection_changed), NULL);
 
 	g_signal_connect(tree, "button-press-event", G_CALLBACK(pm_treeview_button_press_cb), NULL);
+	g_signal_connect(tree, "button-release-event", G_CALLBACK(pm_treeview_button_release_cb), NULL);
 
 	/* filter */
 	filter_model = gtk_tree_model_filter_new(GTK_TREE_MODEL(store), NULL);

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1884,7 +1884,10 @@ static void pm_on_plugin_button_clicked(G_GNUC_UNUSED GtkButton *button, gpointe
 			if (GPOINTER_TO_INT(user_data) == PM_BUTTON_CONFIGURE)
 				plugin_show_configure(&p->public);
 			else if (GPOINTER_TO_INT(user_data) == PM_BUTTON_HELP)
+			{
+				g_return_if_fail(p->cbs.help != NULL);
 				p->cbs.help(&p->public, p->cb_data);
+			}
 			else if (GPOINTER_TO_INT(user_data) == PM_BUTTON_KEYBINDINGS && p->key_group && p->key_group->plugin_key_count > 0)
 				keybindings_dialog_show_prefs_scroll(p->info.name);
 		}


### PR DESCRIPTION
On fast-clicks/double-clicks on a plugin row the selected row can change
and the buttons (e.g. the "Help" button) can get out of sync. That means
that e.g. a plugin is selected which has not got an help function but
the "Help" button is activated. Clicking the button is such a situation
leads to a crash. Syncing buttons on "button-release-event" solves the
problem. Fixes #1781.