### PR TITLE
keyfile: Output unescaped filename if session file cannot be opened

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -1206,7 +1206,7 @@ static gboolean open_session_file(gchar **tmp, guint len)
 	}
 	else
 	{
-		geany_debug("Could not find file '%s'.", tmp[7]);
+		geany_debug("Could not find file '%s'.", unescaped_filename);
 	}
 
 	g_free(locale_filename);


### PR DESCRIPTION
Fixes #779.