### PR TITLE
Skip the format specifier when loading a global tag file

### DIFF
--- a/src/tagmanager/tm_source_file.c
+++ b/src/tagmanager/tm_source_file.c
@@ -537,7 +537,7 @@ GPtrArray *tm_source_file_read_tags_file(const gchar *tags_file, TMParserType mo
 		return NULL; /* early out on error */
 	}
 	else
-	{	/* We read the first line for the format specification. */
+	{	/* We read (and discard) the first line for the format specification. */
 		if (buf[0] == '#' && strstr((gchar*) buf, "format=pipe") != NULL)
 			format = TM_FILE_FORMAT_PIPE;
 		else if (buf[0] == '#' && strstr((gchar*) buf, "format=tagmanager") != NULL)
@@ -562,8 +562,9 @@ GPtrArray *tm_source_file_read_tags_file(const gchar *tags_file, TMParserType mo
 				format = TM_FILE_FORMAT_PIPE;
 			else if (tab_cnt > 1)
 				format = TM_FILE_FORMAT_CTAGS;
+			/* reset the file pointer, to start reading again from the beginning */
+			rewind(fp);
 		}
-		rewind(fp); /* reset the file pointer, to start reading again from the beginning */
 	}
 
 	file_tags = g_ptr_array_new();


### PR DESCRIPTION
This prevents loading a spurious tag for the format specifier line, as well as fixing loading of CTags format with a format specifier line.

Before this change, the file pointer was rewound after reading a format specifier line; but this had various unwanted side effects depending on the recognized format:

* For TagManager and Pipe formats, it led to loading a tag named after   the format specifier (e.g. a literal `# format=tagmanager`).  This was fairly harmless and only introduced a spurious tag seldom even used because `#` isn't usually considered for looking up completions.
* For CTags format, having an explicit specifier led to failure to load the file in most cases because the specifier line would be parsed but doesn't usually follow the format's requirements, leading to early abortion loading that file.  On some very specific specifier lines actually following CTags format, it could have led to loading a spurious tag instead.

Fixes #1814 and closes #1816.