### PR TITLE
ctags: fix Ruby parsing for block assigns

### DIFF
--- a/ctags/parsers/ruby.c
+++ b/ctags/parsers/ruby.c
@@ -136,9 +136,72 @@ static bool isWhitespace (int c)
 	return c == 0 || isspace (c);
 }
 
+/*
+ * Advance 's' while the passed predicate is true. Returns true if
+ * advanced by at least one position.
+ */
+static bool advanceBy (const unsigned char** s, bool (*predicate) (int))
+{
+	const int s_length = strlen ((const char *)*s);
+	unsigned char this_char;
+	int i = 0;
+
+	for (i = 0; i < s_length; ++i)
+	{
+		this_char = **s;
+
+		if (! predicate (this_char))
+		{
+			return i > 0;
+		}
+
+		(*s)++;
+	}
+
+	return i > 0;
+}
+
 static bool canMatchKeyword (const unsigned char** s, const char* literal)
 {
 	return canMatch (s, literal, notIdentChar);
+}
+
+/*
+ * Extends canMatch. Works similarly, but allows assignment to precede
+ * the keyword, as block assignment is a common Ruby idiom.
+ */
+static bool canMatchKeywordWithAssign (const unsigned char** s, const char* literal)
+{
+	const unsigned char* original_pos = *s;
+
+	if (canMatchKeyword (s, literal))
+	{
+		return true;
+	}
+
+	if (! advanceBy (s, isIdentChar))
+	{
+		*s = original_pos;
+		return false;
+	}
+
+	advanceBy (s, isWhitespace);
+
+	if (**s != '=') {
+		*s = original_pos;
+		return false;
+	}
+
+	(*s)++;
+	advanceBy (s, isWhitespace);
+
+	if (canMatchKeyword (s, literal))
+	{
+		return true;
+	}
+
+	*s = original_pos;
+	return false;
 }
 
 /*
@@ -416,29 +479,22 @@ static void findRubyTags (void)
 		*
 		*   return if <exp>
 		*
-		* FIXME: this is fooled by code such as
-		*
-		*   result = if <exp>
-		*               <a>
-		*            else
-		*               <b>
-		*            end
-		*
-		* FIXME: we're also fooled if someone does something heinous such as
+		* FIXME: we're fooled if someone does something heinous such as
 		*
 		*   puts("hello") \
 		*       unless <exp>
 		*/
-		if (canMatchKeyword (&cp, "for") ||
-		    canMatchKeyword (&cp, "until") ||
-		    canMatchKeyword (&cp, "while"))
+
+		if (canMatchKeywordWithAssign (&cp, "for") ||
+		    canMatchKeywordWithAssign (&cp, "until") ||
+		    canMatchKeywordWithAssign (&cp, "while"))
 		{
 			expect_separator = true;
 			enterUnnamedScope ();
 		}
-		else if (canMatchKeyword (&cp, "case") ||
-		         canMatchKeyword (&cp, "if") ||
-		         canMatchKeyword (&cp, "unless"))
+		else if (canMatchKeywordWithAssign (&cp, "case") ||
+		         canMatchKeywordWithAssign (&cp, "if") ||
+		         canMatchKeywordWithAssign (&cp, "unless"))
 		{
 			enterUnnamedScope ();
 		}
@@ -447,15 +503,15 @@ static void findRubyTags (void)
 		* "module M", "class C" and "def m" should only be at the beginning
 		* of a line.
 		*/
-		if (canMatchKeyword (&cp, "module"))
+		if (canMatchKeywordWithAssign (&cp, "module"))
 		{
 			readAndEmitTag (&cp, K_MODULE);
 		}
-		else if (canMatchKeyword (&cp, "class"))
+		else if (canMatchKeywordWithAssign (&cp, "class"))
 		{
 			readAndEmitTag (&cp, K_CLASS);
 		}
-		else if (canMatchKeyword (&cp, "def"))
+		else if (canMatchKeywordWithAssign (&cp, "def"))
 		{
 			rubyKind kind = K_METHOD;
 			NestingLevel *nl = nestingLevelsGetCurrent (nesting);
@@ -495,11 +551,11 @@ static void findRubyTags (void)
 				*/
 				break;
 			}
-			else if (canMatchKeyword (&cp, "begin"))
+			else if (canMatchKeywordWithAssign (&cp, "begin"))
 			{
 				enterUnnamedScope ();
 			}
-			else if (canMatchKeyword (&cp, "do"))
+			else if (canMatchKeywordWithAssign (&cp, "do"))
 			{
 				if (! expect_separator)
 					enterUnnamedScope ();

--- a/ctags/parsers/ruby.c
+++ b/ctags/parsers/ruby.c
@@ -121,7 +121,7 @@ static bool notIdentChar (int c)
 	return ! isIdentChar (c);
 }
 
-static bool operatorChar (int c)
+static bool isOperatorChar (int c)
 {
 	return (c == '[' || c == ']' ||
 	        c == '=' || c == '!' || c == '~' ||
@@ -133,7 +133,12 @@ static bool operatorChar (int c)
 
 static bool notOperatorChar (int c)
 {
-	return ! operatorChar (c);
+	return ! isOperatorChar (c);
+}
+
+static bool isSigilChar (int c)
+{
+	return (c == '@' || c == '$');
 }
 
 static bool isWhitespace (int c)
@@ -180,6 +185,8 @@ static bool canMatchKeywordWithAssign (const unsigned char** s, const char* lite
 		return true;
 	}
 
+	advanceWhile (s, isSigilChar);
+
 	if (! advanceWhile (s, isIdentChar))
 	{
 		*s = original_pos;
@@ -188,7 +195,7 @@ static bool canMatchKeywordWithAssign (const unsigned char** s, const char* lite
 
 	advanceWhile (s, isWhitespace);
 
-	if (! (advanceWhile (s, operatorChar) && *(*s - 1) == '='))
+	if (! (advanceWhile (s, isOperatorChar) && *(*s - 1) == '='))
 	{
 		*s = original_pos;
 		return false;

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -257,6 +257,7 @@ test_sources = \
 	regexp.js						\
 	return-hint.zep					\
 	return-types.go					\
+	ruby-block-assign.rb			\
 	ruby-block-call.rb				\
 	ruby-doc.rb						\
 	ruby-namespaced-class.rb		\

--- a/tests/ctags/ruby-block-assign.rb
+++ b/tests/ctags/ruby-block-assign.rb
@@ -1,0 +1,43 @@
+m = module Foo
+end
+
+m += module Quux
+end
+
+c = class Bar
+  x = def method_a
+    if 1
+    else
+    end
+  end
+
+  def method_b
+    x = while 1 do
+      break
+    end
+  end
+
+  def method_c
+    x = if 1
+    else
+    end
+  end
+
+  def method_d
+    x += if 1
+    else
+    end
+  end
+
+  def method_e
+    x ||= if 1
+    else
+    end
+  end
+
+  def method_f
+  end
+end
+
+c ||= class Zook
+end

--- a/tests/ctags/ruby-block-assign.rb.tags
+++ b/tests/ctags/ruby-block-assign.rb.tags
@@ -1,0 +1,11 @@
+# format=tagmanager
+BarÌ1Ö0
+FooÌ256Ö0
+QuuxÌ256Ö0
+ZookÌ1Ö0
+method_aÌ128ÎBarÖ0
+method_bÌ128ÎBarÖ0
+method_cÌ128ÎBarÖ0
+method_dÌ128ÎBarÖ0
+method_eÌ128ÎBarÖ0
+method_fÌ128ÎBarÖ0


### PR DESCRIPTION
Assigning blocks' return values to variables is a common idiom in Ruby.
Fix the ctags parser to take this into account. Closes #1744.