### PR TITLE
Fix boldface and italics in markdown

### DIFF
--- a/data/filedefs/filetypes.markdown
+++ b/data/filedefs/filetypes.markdown
@@ -2,8 +2,8 @@
 [styling]
 # Edit these in the colorscheme .conf file instead
 default=default
-strong=string_3
-emphasis=string_4
+strong=default,bold
+emphasis=default,italic
 header1=keyword_1
 header2=keyword_1
 header3=keyword_1


### PR DESCRIPTION
Before, **boldface** or *italics* (also _italics_) would not generally show as that, definitely not with the default color scheme. After this change, they appear with the same color as normal text but with that typography, in all color schemes.