### PR TITLE
Better highlighting for YAML keys

### DIFF
--- a/data/filedefs/filetypes.yaml
+++ b/data/filedefs/filetypes.yaml
@@ -11,6 +11,7 @@ document=preprocessor
 text=string_1
 error=error
 operator=operator
+identifier=keyword
 
 [keywords]
 # all items must be in one line

--- a/data/filedefs/filetypes.yaml
+++ b/data/filedefs/filetypes.yaml
@@ -3,7 +3,7 @@
 # Edit these in the colorscheme .conf file instead
 default=default
 comment=comment
-identifier=identifier
+identifier=type
 keyword=keyword_1
 number=number_1
 reference=function
@@ -11,7 +11,6 @@ document=preprocessor
 text=string_1
 error=error
 operator=operator
-identifier=keyword
 
 [keywords]
 # all items must be in one line


### PR DESCRIPTION
A more appropriate highlighting for keys in YAML files. The improvement can be noticed in any color scheme, particularly in the default one, where keys would have the same color and face than the ordinary text.