### PR TITLE
Correction and enhancements for context action

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -664,7 +664,8 @@ static void clear_all_errors(void)
 
 /* Replaces occurrences of %e and %p with the appropriate filenames and
  * %l with current line number. %d and %p replacements should be in UTF8 */
-static gchar *build_replace_placeholder(const GeanyDocument *doc, const gchar *src)
+GEANY_API_SYMBOL
+gchar *build_replace_placeholder(const GeanyDocument *doc, const gchar *src)
 {
 	GString *stack;
 	gchar *replacement;

--- a/src/build.h
+++ b/src/build.h
@@ -73,6 +73,7 @@ void build_set_menu_item(const GeanyBuildSource src, const GeanyBuildGroup grp,
 
 guint build_get_group_count(const GeanyBuildGroup grp);
 
+gchar *build_replace_placeholder(const GeanyDocument *doc, const gchar *src);
 
 #ifdef GEANY_PRIVATE
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1467,6 +1467,9 @@ void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	}
 	else
 	{
+        /* take a current word under caret */
+        editor_find_current_word_sciwc(doc->editor, -1,
+            editor_info.current_word, GEANY_MAX_WORD_LENGTH);
 		word = g_strdup(editor_info.current_word);
 	}
 
@@ -1486,8 +1489,11 @@ void on_context_action1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	/* substitute the wildcard %s and run the command if it is non empty */
 	if (G_LIKELY(!EMPTY(command)))
 	{
-		gchar *command_line = g_strdup(command);
-
+        /* add %f, %d, %e, %p, %l placeholders */
+        gchar *command_tmp = g_strdup(command);
+        gchar *command_line = build_replace_placeholder(doc, command_tmp);
+        g_free(command_tmp);
+        /* add %s placeholder */
 		utils_str_replace_all(&command_line, "%s", word);
 
 		if (!spawn_async(NULL, command_line, NULL, NULL, NULL, &error))

--- a/src/editor.c
+++ b/src/editor.c
@@ -340,7 +340,23 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 			current_word, sizeof current_word, NULL);
 
 		can_goto = sci_has_selection(editor->sci) || current_word[0] != '\0';
-		ui_update_popup_goto_items(can_goto);
+
+
+		/* create a list of locks/unlocks for the goto and context actions */
+        gchar cangos[64];  // never reachable maximum
+        for (gint i=0; i<64; i++)
+            cangos[i]=(can_goto?'1':'0'); // flag the whole group
+        gchar* command;
+        if (doc->file_type != NULL &&
+        !EMPTY(doc->file_type->context_action_cmd))
+            command = g_strdup(doc->file_type->context_action_cmd);
+        else
+            command = g_strdup(tool_prefs.context_action_cmd);
+        /* flag the context action (see widgets.popup_goto_items[1] ) */
+        cangos[1] = (G_LIKELY(!EMPTY(command))?'1':'0');
+        g_free(command);
+        
+        ui_update_popup_goto_items(cangos);
 		ui_update_popup_copy_items(doc);
 		ui_update_insert_include_item(doc, 0);
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -2196,7 +2196,7 @@ static gboolean cb_func_editor_action(guint key_id)
 			editor_show_calltip(doc->editor, -1);
 			break;
 		case GEANY_KEYS_EDITOR_CONTEXTACTION:
-			if (check_current_word(doc, FALSE))
+			//do not check here: if (check_current_word(doc, FALSE))
 				on_context_action1_activate(GTK_MENU_ITEM(ui_lookup_widget(main_widgets.editor_menu,
 					"context_action1")), NULL);
 			break;

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -503,12 +503,12 @@ void ui_update_popup_copy_items(GeanyDocument *doc)
 }
 
 
-void ui_update_popup_goto_items(gboolean enable)
+void ui_update_popup_goto_items(gchar* enable)
 {
-	guint i, len;
-	len = G_N_ELEMENTS(widgets.popup_goto_items);
-	for (i = 0; i < len; i++)
-		ui_widget_set_sensitive(widgets.popup_goto_items[i], enable);
+    guint i, len;
+    len = G_N_ELEMENTS(widgets.popup_goto_items);
+    for (i = 0; i < len; i++)
+        ui_widget_set_sensitive(widgets.popup_goto_items[i], enable[i]=='1');
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -294,7 +294,7 @@ void ui_update_popup_reundo_items(GeanyDocument *doc);
 
 void ui_update_popup_copy_items(GeanyDocument *doc);
 
-void ui_update_popup_goto_items(gboolean enable);
+void ui_update_popup_goto_items(gchar* enable);
 
 
 void ui_menu_copy_items_set_sensitive(gboolean sensitive);


### PR DESCRIPTION

This commit provides 1 correction and 2.5 enhancements for Geany's context action:

1. The correction is:

  - In case you hadn't set the context action, calling a popup menu on a selected text/word brings up a menu with all 'goto & context' items being enabled. The context doesn't work at that, of course. It should not be enabled: 1) when no text is selected 2) even more important: when there is no context action set. This commit corrects this.

2. The enhancements are:

  - This commit introduces %f, %d, %e, %p, %l placeholders into the context string, i.e. the same ones as in Compile/ Build/ Run. Without them the context is somehow (indeed much) restricted.

  - (As consequence) the set context action is active when there is no selected text or a word under caret. Even if there are no placeholders in the context string it may contain a really useful command to access with a fast hotkey, all the more the context is specific to the file type. This commit always enables the context if it's defined in Geany's settings no matter there is or no placeholder in it.

  - (0.5 of enhancement) if there would be some new 'goto & context' menu items with their own requirements for access, this commit would facilitate their implementation.

There are a few bla-bla left. This new Geany's context can respond not only to %s, %f, %d etc., but to all Geany's surroundings. E.g. it can show a current state of the project from different viewpoints. Or perform the various actions for maintainance of it. All that done without leaving Geany IDE. One of innumerable possible implementations is here:
  https://wiki.geany.org/howtos/using_with_tcl_tk
As a matter of fact this commit was born of it.

----

About the modifications of code.

1. For the access to 'build_replace_placeholder' function (introducing %f, %d .. placeholders) I need to modify build.c and build.h.

2. It is included in the proper place of callbacks.c.

3. To unlock the context (and move its access check to other place) I need to comment a line of keybindings.c. Actually this unlocks the hotkey of context.

4. To enable a separate (from other 'goto' items) checking of context access, I need to modify ui_utils.c (and its ui_utils.h).

5. The real access to all 'goto' items (the context including) is checked in editor.c.
