### PR TITLE
Fix horizontal and page scroll on GTK3

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -4748,6 +4748,10 @@ on_editor_scroll_event(GtkWidget *widget, GdkEventScroll *event, gpointer user_d
 {
 	GeanyEditor *editor = user_data;
 
+	/* we only handle up and down, leave the rest to Scintilla */
+	if (event->direction != GDK_SCROLL_UP && event->direction != GDK_SCROLL_DOWN)
+		return FALSE;
+
 	/* Handle scroll events if Alt is pressed and scroll whole pages instead of a
 	 * few lines only, maybe this could/should be done in Scintilla directly */
 	if (event->state & GDK_MOD1_MASK)


### PR DESCRIPTION
Our custom scroll handler for horizontal (Shift+Scroll) and page (Alt+Scroll) scroll didn't properly check the scroll direction and assume that if it's not down it's up.  This was mostly not a problem because the other types only were left and right scroll events, which are a lot less common.

However, it became a lot more problematic with GTK 3.4 that introduced "smooth scrolling", and thus a new scroll type that can happen for events in any direction.  We then would scroll up (as we assume "not down" is up) regardless of the actual direction of the event.

It's still not clear why we'd get smooth scroll events on X11 as no code I can find asks for it and we generally don't get those, but sometimes a Scintilla widget starts receiving them, leading to the bug. On Wayland on the other hand, Scintilla asks for smooth scroll events, so we need to have a fix for it in any case.