### PR TITLE
windres - fixing fatal error: when writing output to : Invalid argument

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -147,7 +147,7 @@ geany_LDADD += geany_private.res
 WINDRES = $(host_alias)-windres
 
 geany_private.res: $(top_srcdir)/geany_private.rc
-	$(WINDRES) -i $(top_srcdir)/geany_private.rc --input-format=rc -o $@ -O coff
+	$(WINDRES) -i $(top_srcdir)/geany_private.rc --input-format=rc -o $@ -O coff --use-temp-file
 
 libgeany_la_SOURCES += win32.c win32.h
 libgeany_la_LIBADD  += -lole32 -lwsock32 -lcomdlg32


### PR DESCRIPTION
I compiled git version in msys2 for x86_64  architecture according to the steps posted in the following link:
https://wiki.geany.org/howtos/win32/msys2 

I ended up with the following errors.  I fixed it by adding option "--use-temp-file" to "windres" in src/Makefile.am 

make[3]: Entering directory '/home/Dreli/geanyTemp/geany/src'
windres -i ../geany_private.rc --input-format=rc -o geany_private.res -O coff
../geany_private.rc:2:0: fatal error: when writing output to : Invalid argument

compilation terminated.
C:\msys64\mingw64\bin\windres.exe: can't open file `page:': Invalid argument
C:\msys64\mingw64\bin\windres.exe: preprocessing failed.
make[3]: [Makefile:1505: geany_private.res] Error 1 (ignored)
CCLD geany.exe

