### PR TITLE
Fix 'changed' flag being altered when all documents are closing.

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -704,7 +704,7 @@ static gboolean remove_page(guint page_num)
 
 	g_return_val_if_fail(doc != NULL, FALSE);
 
-	if (doc->changed && ! dialogs_show_unsaved_file(doc))
+	if (! main_status.closing_all && doc->changed && ! dialogs_show_unsaved_file(doc))
 		return FALSE;
 
 	/* tell any plugins that the document is about to be closed */
@@ -3387,11 +3387,7 @@ gboolean document_account_for_unsaved(void)
 				return FALSE;
 		}
 	}
-	/* all documents should now be accounted for, so ignore any changes */
-	foreach_document (i)
-	{
-		documents[i]->changed = FALSE;
-	}
+
 	return TRUE;
 }
 
@@ -3400,14 +3396,6 @@ static void force_close_all(void)
 {
 	guint i, len = documents_array->len;
 
-	/* check all documents have been accounted for */
-	for (i = 0; i < len; i++)
-	{
-		if (documents[i]->is_valid)
-		{
-			g_return_if_fail(!documents[i]->changed);
-		}
-	}
 	main_status.closing_all = TRUE;
 
 	foreach_document(i)

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1262,16 +1262,20 @@ static void queue_free(GQueue *queue)
 }
 
 
-static void do_main_quit(void)
+static gboolean do_main_quit(void)
 {
 	geany_debug("Quitting...");
 
 	configuration_save();
 
 	if (app->project != NULL)
-		project_close(FALSE);   /* save project session files */
+	{
+		if (!project_close(FALSE))   /* save project session files */
+			return FALSE;
+	}
 
-	document_close_all();
+	if (!document_close_all())
+		return FALSE;
 
 	main_status.quitting = TRUE;
 
@@ -1364,6 +1368,8 @@ static void do_main_quit(void)
 	ui_finalize_builder();
 
 	gtk_main_quit();
+
+	return TRUE;
 }
 
 
@@ -1389,19 +1395,16 @@ gboolean main_quit(void)
 
 	if (! check_no_unsaved())
 	{
-		if (document_account_for_unsaved())
-		{
-			do_main_quit();
+		if (do_main_quit())
 			return TRUE;
-		}
 	}
 	else
 	if (! prefs.confirm_exit ||
 		dialogs_show_question_full(NULL, GTK_STOCK_QUIT, GTK_STOCK_CANCEL, NULL,
 			_("Do you really want to quit?")))
 	{
-		do_main_quit();
-		return TRUE;
+		if (do_main_quit())
+			return TRUE;
 	}
 
 	main_status.quitting = FALSE;


### PR DESCRIPTION
Patch document.c to ensure document_account_for_save does not alter changed flag when closing a document.