### PR TITLE
Various fixes reported in #1876

### DIFF
--- a/ctags/parsers/perl.c
+++ b/ctags/parsers/perl.c
@@ -324,6 +324,7 @@ static void findPerlTags (void)
 				if (true == isSubroutineDeclaration(cp)) {
 					if (true == PerlKinds[K_SUBROUTINE_DECLARATION].enabled) {
 						kind = K_SUBROUTINE_DECLARATION;
+						e.kind = &(PerlKinds[kind]);
 					} else {
 						vStringClear (name);
 						continue;

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -492,6 +492,7 @@ static gboolean handle_save_as(const gchar *utf8_filename, gboolean rename_file)
 	GeanyDocument *doc = document_get_current();
 	gboolean success = FALSE;
 
+	g_return_val_if_fail(doc != NULL, FALSE);
 	g_return_val_if_fail(!EMPTY(utf8_filename), FALSE);
 
 	if (doc->file_name != NULL)

--- a/src/editor.c
+++ b/src/editor.c
@@ -3931,7 +3931,7 @@ static void smart_line_indentation(GeanyEditor *editor, gint first_line, gint la
 
 
 /* simple indentation to indent the current line with the same indent as the previous one */
-void editor_smart_line_indentation(GeanyEditor *editor, gint pos)
+void editor_smart_line_indentation(GeanyEditor *editor)
 {
 	gint first_line, last_line;
 	gint first_sel_start, first_sel_end;
@@ -3948,9 +3948,6 @@ void editor_smart_line_indentation(GeanyEditor *editor, gint pos)
 	/* Find the last line with chars selected (not EOL char) */
 	last_line = sci_get_line_from_position(sci, first_sel_end - editor_get_eol_char_len(editor));
 	last_line = MAX(first_line, last_line);
-
-	if (pos == -1)
-		pos = first_sel_start;
 
 	sci_start_undo_action(sci);
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -3116,7 +3116,7 @@ void editor_do_comment_toggle(GeanyEditor *editor)
 	gint count_commented = 0, count_uncommented = 0;
 	gchar sel[256];
 	const gchar *co, *cc;
-	gboolean break_loop = FALSE, single_line = FALSE;
+	gboolean single_line = FALSE;
 	gboolean first_line_was_comment = FALSE;
 	gboolean last_line_was_comment = FALSE;
 	gsize co_len;
@@ -3148,7 +3148,7 @@ void editor_do_comment_toggle(GeanyEditor *editor)
 
 	sci_start_undo_action(editor->sci);
 
-	for (i = first_line; (i <= last_line) && (! break_loop); i++)
+	for (i = first_line; i <= last_line; i++)
 	{
 		gint buf_len;
 
@@ -3208,7 +3208,6 @@ void editor_do_comment_toggle(GeanyEditor *editor)
 			}
 
 			/* break because we are already on the last line */
-			break_loop = TRUE;
 			break;
 		}
 	}
@@ -3287,7 +3286,7 @@ gint editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_line
 	gint count = 0;
 	gchar sel[256];
 	const gchar *co, *cc;
-	gboolean break_loop = FALSE, single_line = FALSE;
+	gboolean single_line = FALSE;
 	GeanyFiletype *ft;
 
 	g_return_val_if_fail(editor != NULL && editor->document->file_type != NULL, 0);
@@ -3320,7 +3319,7 @@ gint editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_line
 
 	sci_start_undo_action(editor->sci);
 
-	for (i = first_line; (i <= last_line) && (! break_loop); i++)
+	for (i = first_line; i <= last_line; i++)
 	{
 		gint buf_len;
 
@@ -3372,7 +3371,6 @@ gint editor_do_comment(GeanyEditor *editor, gint line, gboolean allow_empty_line
 				count = 1;
 
 				/* break because we are already on the last line */
-				break_loop = TRUE;
 				break;
 			}
 		}

--- a/src/editor.h
+++ b/src/editor.h
@@ -258,7 +258,7 @@ void editor_insert_alternative_whitespace(GeanyEditor *editor);
 
 void editor_indent(GeanyEditor *editor, gboolean increase);
 
-void editor_smart_line_indentation(GeanyEditor *editor, gint pos);
+void editor_smart_line_indentation(GeanyEditor *editor);
 
 void editor_indentation_by_one_space(GeanyEditor *editor, gint pos, gboolean decrease);
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -2489,7 +2489,7 @@ static gboolean cb_func_format_action(guint key_id)
 			editor_indentation_by_one_space(doc->editor, -1, TRUE);
 			break;
 		case GEANY_KEYS_FORMAT_AUTOINDENT:
-			editor_smart_line_indentation(doc->editor, -1);
+			editor_smart_line_indentation(doc->editor);
 			break;
 		case GEANY_KEYS_FORMAT_TOGGLECASE:
 			on_toggle_case1_activate(NULL, NULL);


### PR DESCRIPTION
Addresses relevant issues mentioned in #1876. I didn't care about several "dead assignments", because they are initial values for variables, or make mirrors similar logic in the same function (like successive calls moving a pointer, I left the last one storing the move even if it's not (currently) used afterward), etc.

**:warning: WARNING :warning:**  The Perl change should be checked by a Perl person, I don't really know if it actually makes sense to report this differently. Also, should be upstreamed if relevant. BTW, I can move this out of this PR.