### PR TITLE
Update link to GTK+3 bundle for test builds to self-hosted version

### DIFF
--- a/scripts/cross-build-mingw.sh
+++ b/scripts/cross-build-mingw.sh
@@ -16,7 +16,7 @@
 # You may change those
 HOST=i686-w64-mingw32
 GTK2_BUNDLE_ZIP="http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-bundle_2.24.10-20120208_win32.zip"
-GTK3_BUNDLE_ZIP="http://win32builder.gnome.org/gtk+-bundle_3.8.2-20131001_win32.zip"
+GTK3_BUNDLE_ZIP="https://download.geany.org/contrib/gtk/gtk+-bundle_3.8.2-20131001_win32.zip"
 BUILDDIR=_build-cross-mingw
 GTK3=no
 CONFIGUREFLAGS="--enable-nls"


### PR DESCRIPTION
The host win32builder.gnome.org seems dead and so host the GTK+3 bundle
we use to test builds for Windows cross-compilation on our own.

Closes #1930.