### PR TITLE
Use REM as single comment marker for Batch files

### DIFF
--- a/data/filedefs/filetypes.batch
+++ b/data/filedefs/filetypes.batch
@@ -23,7 +23,7 @@ extension=bat
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file
-comment_single=::
+comment_single=REM\s
 # multiline comments
 #comment_open=
 #comment_close=


### PR DESCRIPTION
REM seems to be the standard comment marker while "::" is rather
deprecated.

Closes #1912.