### PR TITLE
Make geany -g tags output reproducible

### DIFF
--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -370,23 +370,6 @@ gboolean tm_workspace_load_global_tags(const char *tags_file, TMParserType mode)
 }
 
 
-static guint tm_file_inode_hash(gconstpointer key)
-{
-	GStatBuf file_stat;
-	const char *filename = (const char*)key;
-
-	if (g_stat(filename, &file_stat) == 0)
-	{
-#ifdef TM_DEBUG
-		g_message ("Hash for '%s' is '%d'\n", filename, file_stat.st_ino);
-#endif
-		return g_direct_hash ((gpointer)(intptr_t)file_stat.st_ino);
-	}
-
-	return 0;
-}
-
-
 static void tm_move_entries_to_g_list(gpointer key, gpointer value, gpointer user_data)
 {
 	GList **pp_list = (GList**)user_data;
@@ -477,7 +460,7 @@ static GList *lookup_includes(const gchar **includes, gint includes_count)
 	size_t idx_glob;
 #endif
 
-	table = g_hash_table_new_full(tm_file_inode_hash, g_direct_equal, NULL, g_free);
+	table = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, g_free);
 
 #ifdef HAVE_GLOB_H
 	globbuf.gl_offs = 0;


### PR DESCRIPTION
Without this patch, openSUSE's glfw package would always differ in `/usr/share/geany/tags/glfw.c.tags`
because inode numbers differ between builds (that happen in disposable VMs)

This was previously discussed in https://bugzilla.opensuse.org/show_bug.cgi?id=1049382