### PR TITLE
Add appdata file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Makefile.in
 /depcomp
 /geany.1
 /geany.desktop
+/org.geany.Geany.appdata.xml
 /geany.glade.bak
 /geany.gladep.bak
 /geany.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@ EXTRA_DIST = \
 	autogen.sh \
 	scripts/gen-api-gtkdoc.py \
 	geany.desktop.in \
+	org.geany.Geany.appdata.xml.in \
 	geany.pc.in \
 	geany.spec \
 	ChangeLog.pre-1-22 \
@@ -30,6 +31,7 @@ EXTRA_DIST = \
 
 DISTCLEANFILES = \
 	geany.desktop \
+	org.geany.Geany.appdata.xml \
 	intltool-extract \
 	intltool-merge \
 	intltool-update
@@ -83,3 +85,8 @@ desktopdir = $(datadir)/applications
 desktop_in_files = geany.desktop
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 @INTLTOOL_DESKTOP_RULE@
+
+appdatadir = $(datadir)/metainfo
+appdata_in_files = org.geany.Geany.appdata.xml.in
+appdata_DATA = $(appdata_in_files:.xml.in=.xml)
+@INTLTOOL_XML_RULE@

--- a/org.geany.Geany.appdata.xml.in
+++ b/org.geany.Geany.appdata.xml.in
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component>
+  <id type="desktop">org.geany.Geany</id>
+  <launchable type="desktop-id">geany.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <_name>Geany</_name>
+  <developer_name>Geany</developer_name>
+  <project_license>GPL-2.0+</project_license>
+  <_summary>A fast and lightweight IDE</_summary>
+  <url type="homepage">https://geany.org/</url>
+  <url type="bugtracker">https://github.com/geany/geany/issues</url>
+  <description>
+    <_p>Geany was developed to provide a small and fast IDE, which has only a
+few dependencies on other packages. Another goal was to be as independent
+as possible from a specific Desktop Environment like KDE or GNOME.</_p>
+    <_p>Geany includes the following features:</_p>
+    <ul>
+      <_li>Syntax highlighting</_li>
+      <_li>Code completion</_li>
+      <_li>Auto completion of often used constructs like if, for and while</_li>
+      <_li>Auto completion of XML and HTML tags</_li>
+      <_li>Call tips</_li>
+      <_li>Code folding</_li>
+      <_li>Many supported filetypes like C, Java, PHP, HTML, Python, Perl, Pascal</_li>
+      <_li>Symbol lists</_li>
+      <_li>Embedded terminal emulation</_li>
+      <_li>Extensibility through plugins</_li>
+    </ul>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image height="808" width="942">https://www.geany.org/uploads/Gallery/geany_main.png</image>
+    </screenshot>
+    <screenshot>
+      <image height="808" width="942">https://www.geany.org/uploads/Gallery/geany_build.png</image>
+    </screenshot>
+    <screenshot>
+      <image height="808" width="942">https://www.geany.org/uploads/Gallery/geany_vte.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release date="2018-02-25" version="1.33"/>
+  </releases>
+  <update_contact>https://github.com/geany/geany</update_contact>
+  <translation type="gettext">geany</translation>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,6 +1,7 @@
 # List of source files containing translatable strings.
 
 geany.desktop.in
+org.geany.Geany.appdata.xml.in
 data/geany.glade
 src/about.c
 src/build.c


### PR DESCRIPTION
This is shown by appstores such as GNOME-Software, Plasma-Discover, Mint's Software Center, Pop!_OS's Software Center, Flathub, etc.