### PR TITLE
Line breaking broken on existing lines

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -556,7 +556,7 @@ static void check_line_breaking(GeanyEditor *editor, gint pos)
 		return;
 
 	/* look for the last space before line_break_column */
-	pos = sci_get_position_from_col(sci, lstart, get_project_pref(line_break_column));
+	pos = sci_get_position_from_col(sci, line, get_project_pref(line_break_column));
 
 	while (pos > lstart)
 	{


### PR DESCRIPTION
When editing existing lines that are longer than the break column the break is inserted in the wrong place.

Fix: sci_get_position_from_col() takes line number, not position of start of line.