### PR TITLE
Fix modifier for creating rectangular selections on Windows

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -4900,6 +4900,7 @@ static gboolean register_named_icon(ScintillaObject *sci, guint id, const gchar 
 static ScintillaObject *create_new_sci(GeanyEditor *editor)
 {
 	ScintillaObject *sci;
+	int rectangular_selection_modifier;
 
 	sci = SCINTILLA(scintilla_new());
 
@@ -4931,8 +4932,14 @@ static ScintillaObject *create_new_sci(GeanyEditor *editor)
 	/* necessary for column mode editing, implemented in Scintilla since 2.0 */
 	SSM(sci, SCI_SETADDITIONALSELECTIONTYPING, 1, 0);
 
-	/* rectangular selection modifier for creating rectangular selections with the mouse */
-	SSM(sci, SCI_SETRECTANGULARSELECTIONMODIFIER, SCMOD_CTRL, 0);
+	/* rectangular selection modifier for creating rectangular selections with the mouse.
+	 * We use the historical Scintilla values by default. */
+#ifdef G_OS_WIN32
+	rectangular_selection_modifier = SCMOD_ALT;
+#else
+	rectangular_selection_modifier = SCMOD_CTRL;
+#endif
+	SSM(sci, SCI_SETRECTANGULARSELECTIONMODIFIER, rectangular_selection_modifier, 0);
 
 	/* virtual space */
 	SSM(sci, SCI_SETVIRTUALSPACEOPTIONS, editor_prefs.show_virtual_space, 0);


### PR DESCRIPTION
33dafac8f0713de79f04e2ebce2399fb914d6792 restored the pre-Scintilla 3.10 default on non-Windows, but also changed the Windows one.  Fix this so the modifier keeps its historical value on Windows as well.