### PR TITLE
src/app.h:remove unneeded #include (tm_tag.h)

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -28,7 +28,6 @@
 #ifndef GEANY_APP_H
 #define GEANY_APP_H 1
 
-#include "tm_tag.h" /* FIXME: should be included in tm_workspace.h */
 #include "tm_workspace.h"
 #include "project.h"
 


### PR DESCRIPTION
This is already #included in
[tm_workspace.h](https://github.com/geany/geany/blob/969e00a03f4e7d80f138498de78bb762cf844e60/src/tagmanager/tm_workspace.h#L16)