### PR TITLE
HACKING:remove rule that shouldn't be used

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -89,8 +89,6 @@ Please, make sure contributions you make follow these rules:
 * only one feature should be in each pull request (or patch).
 * pull requests (or patches) should not contain changes unrelated to the feature,
   and commits should be sensible units of change.
-* the submitter should squash together corrections that are part of
-  the development process, especially correcting your own mistakes.
 * Please make sure your modifications follow the style of existing code:
   see `Coding`_ for more information.
 

--- a/HACKING
+++ b/HACKING
@@ -89,6 +89,9 @@ Please, make sure contributions you make follow these rules:
 * only one feature should be in each pull request (or patch).
 * pull requests (or patches) should not contain changes unrelated to the feature,
   and commits should be sensible units of change.
+* If making minor corrections to a previous commit, the submitter should use
+  'commit --amend' (if the branch has already been pushed, then push again using
+  'force').
 * Please make sure your modifications follow the style of existing code:
   see `Coding`_ for more information.
 


### PR DESCRIPTION
This is suggested due to a conversation in IRC with @elextr @codebrainz.
The squashing, if done, should be done by the person merging, otherwise
the submitter has to rebase and/or force-push...