### PR TITLE
Scintilla: faster a11y

### DIFF
--- a/scintilla/gtk/ScintillaGTK.cxx
+++ b/scintilla/gtk/ScintillaGTK.cxx
@@ -859,7 +859,7 @@ sptr_t ScintillaGTK::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam
 			if (accessible) {
 				ScintillaGTKAccessible *sciAccessible = ScintillaGTKAccessible::FromAccessible(accessible);
 				if (sciAccessible) {
-					sciAccessible->SetAccessibility();
+					sciAccessible->SetAccessibility(accessibilityEnabled);
 				}
 			}
 			break;

--- a/scintilla/gtk/ScintillaGTKAccessible.h
+++ b/scintilla/gtk/ScintillaGTKAccessible.h
@@ -18,9 +18,6 @@ private:
 	GtkAccessible *accessible;
 	ScintillaGTK *sci;
 
-	// cache holding character offset for each line start, see CharacterOffsetFromByteOffset()
-	std::vector<Sci::Position> character_offsets;
-
 	// cached length of the deletion, in characters (see Notify())
 	int deletionLengthChar;
 	// local state for comparing
@@ -37,6 +34,19 @@ private:
 	}
 
 	Sci::Position ByteOffsetFromCharacterOffset(Sci::Position startByte, int characterOffset) {
+		if (!(sci->pdoc->LineCharacterIndex() & SC_LINECHARACTERINDEX_UTF32)) {
+			return startByte + characterOffset;
+		}
+		if (characterOffset > 0) {
+			// Try and reduce the range by reverse-looking into the character offset cache
+			Sci::Line lineStart = sci->pdoc->LineFromPosition(startByte);
+			Sci::Position posStart = sci->pdoc->IndexLineStart(lineStart, SC_LINECHARACTERINDEX_UTF32);
+			Sci::Line line = sci->pdoc->LineFromPositionIndex(posStart + characterOffset, SC_LINECHARACTERINDEX_UTF32);
+			if (line != lineStart) {
+				startByte += sci->pdoc->LineStart(line) - sci->pdoc->LineStart(lineStart);
+				characterOffset -= sci->pdoc->IndexLineStart(line, SC_LINECHARACTERINDEX_UTF32) - posStart;
+			}
+		}
 		Sci::Position pos = sci->pdoc->GetRelativePosition(startByte, characterOffset);
 		if (pos == INVALID_POSITION) {
 			// clamp invalid positions inside the document
@@ -54,18 +64,12 @@ private:
 	}
 
 	Sci::Position CharacterOffsetFromByteOffset(Sci::Position byteOffset) {
-		const Sci::Line line = sci->pdoc->LineFromPosition(byteOffset);
-		if (character_offsets.size() <= static_cast<size_t>(line)) {
-			if (character_offsets.empty())
-				character_offsets.push_back(0);
-			for (Sci::Position i = character_offsets.size(); i <= line; i++) {
-				const Sci::Position start = sci->pdoc->LineStart(i - 1);
-				const Sci::Position end = sci->pdoc->LineStart(i);
-				character_offsets.push_back(character_offsets[i - 1] + sci->pdoc->CountCharacters(start, end));
-			}
+		if (!(sci->pdoc->LineCharacterIndex() & SC_LINECHARACTERINDEX_UTF32)) {
+			return byteOffset;
 		}
+		const Sci::Line line = sci->pdoc->LineFromPosition(byteOffset);
 		const Sci::Position lineStart = sci->pdoc->LineStart(line);
-		return character_offsets[line] + sci->pdoc->CountCharacters(lineStart, byteOffset);
+		return sci->pdoc->IndexLineStart(line, SC_LINECHARACTERINDEX_UTF32) + sci->pdoc->CountCharacters(lineStart, byteOffset);
 	}
 
 	void CharacterRangeFromByteRange(Sci::Position startByte, Sci::Position endByte, int *startChar, int *endChar) {
@@ -135,7 +139,7 @@ public:
 	// So ScintillaGTK can notify us
 	void ChangeDocument(Document *oldDoc, Document *newDoc);
 	void NotifyReadOnly();
-	void SetAccessibility();
+	void SetAccessibility(bool enabled);
 
 	// Helper GtkWidget methods
 	static AtkObject *WidgetGetAccessibleImpl(GtkWidget *widget, AtkObject **cache, gpointer widget_parent_class);


### PR DESCRIPTION
2 changes to make a11y quite a bit faster especially when performing bulk search & replace.

The first commit makes use of the character offset cache when performing reverse-lookup, e.g. when we need to convert a position given by the a11y layer to one understood by Scintilla.

The second avoids clearing the cache when it gets invalidated, and instead updates it to be valid right away. This avoids potentially costly re-computation of the cache that becomes problematic when we often need a position near the end of the file but keep invalidating everything after lines near the start.  This happens especially when performing bulk search & replace with the cursor near the end.  This gives a slightly higher cost at invalidating the cache (that now updates it based on a known delta), but a lot less when it's content is needed again.

Fixes #2092.