### PR TITLE
Improve IPC socket handling

### DIFF
--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1174,8 +1174,18 @@ gint main_lib(gint argc, gchar **argv)
 
 	ui_set_statusbar(TRUE, _("This is Geany %s."), main_get_version_string());
 	if (config_dir_result != 0)
-		ui_set_statusbar(TRUE, _("Configuration directory could not be created (%s)."),
-			g_strerror(config_dir_result));
+	{
+		const gchar *message = _("Configuration directory could not be created (%s).");
+		ui_set_statusbar(TRUE, message, g_strerror(config_dir_result));
+		g_warning(message, g_strerror(config_dir_result));
+	}
+	if (socket_info.lock_socket == -1)
+	{
+		const gchar *message =
+			_("IPC socket could not be created, see Help->Debug Messages for details.");
+		ui_set_statusbar(TRUE, message);
+		g_warning(message);
+	}
 
 	/* apply all configuration options */
 	apply_settings();

--- a/src/socket.c
+++ b/src/socket.c
@@ -524,7 +524,7 @@ static gint socket_fd_open_inet(gushort port)
 	}
 
 	val = 1;
-	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) < 0)
+	if (setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, &val, sizeof(val)) < 0)
 	{
 		log_error("Failed to set IPC socket exclusive option", -1);
 		socket_fd_close(sock);

--- a/src/socket.c
+++ b/src/socket.c
@@ -326,15 +326,16 @@ gint socket_init(gint argc, gchar **argv)
 
 	/* remote command mode, here we have another running instance and want to use it */
 
-#ifdef G_OS_WIN32
-	/* first we send a request to retrieve the window handle and focus the window */
-	socket_fd_write_all(sock, "window\n", 7);
-	if (socket_fd_read(sock, (gchar *)&hwnd, sizeof(hwnd)) == sizeof(hwnd))
-		SetForegroundWindow(hwnd);
-#endif
 	/* now we send the command line args */
 	if (argc > 1)
 	{
+#ifdef G_OS_WIN32
+		/* first we send a request to retrieve the window handle and focus the window */
+		socket_fd_write_all(sock, "window\n", 7);
+		if (socket_fd_read(sock, (gchar *)&hwnd, sizeof(hwnd)) == sizeof(hwnd))
+			SetForegroundWindow(hwnd);
+#endif
+
 		send_open_command(sock, argc, argv);
 	}
 


### PR DESCRIPTION
- improve and extend logging of IPC socket errors (Windows and non-Windows)
- do not raise the main window on Windows when `--list-documents` is used
- bind the TCP port used for the IPC socket exclusively on Windows (should help with #641 & #2101)