### PR TITLE
Save main and project configuration whenever documents are opened/closed

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2636,6 +2636,16 @@ reload_clean_doc_on_file_change   Whether to automatically reload documents    f
                                   on disk.
                                   If unsaved changes exist then the user is
                                   prompted to reload manually.
+save_config_on_file_change        Automatically save Geany's configuration     true        immediately
+                                  to disk once the document list changes
+                                  (i.e. new documents are opened, saved or
+                                  closed). This helps to prevent accidentally
+                                  losing the session file list or other
+                                  changed settings when Geany is not shut
+                                  down cleanly. Disable this option if your
+                                  configuration directory is on a slow drive,
+                                  network share or similar and you experience
+                                  problems.
 extract_filetype_regex            Regex to extract filetype name from file     See link    immediately
                                   via capture group one.
                                   See `ft_regex`_ for default.
@@ -4714,8 +4724,8 @@ The key names cannot be configured.
     Group membership is only read at startup.
 
 .. tip::
-    You can make commonly used filetypes appear in the top-level of the 
-    filetype menu by adding them to the `None` group, e.g. 
+    You can make commonly used filetypes appear in the top-level of the
+    filetype menu by adding them to the `None` group, e.g.
     `None=C;Python`.
 
 Preferences file format

--- a/doc/pluginsignals.c
+++ b/doc/pluginsignals.c
@@ -141,7 +141,8 @@ signal void (*document_close)(GObject *obj, GeanyDocument *doc, gpointer user_da
 signal void (*project_open)(GObject *obj, GKeyFile *config, gpointer user_data);
 
 /** Sent when a project is saved (happens when the project is created, the properties
- *  dialog is closed, before the project is closed, or when Geany is exited).
+ *  dialog is closed, before the project is closed, when Geany automatically
+ *  saves its configuration by opening/closing documents or when Geany is exited).
  *  This signal is emitted shortly before Geany will write the contents of the
  *  GKeyFile to the disc.
  *

--- a/src/document.h
+++ b/src/document.h
@@ -66,6 +66,7 @@ typedef struct GeanyFilePrefs
 	gboolean		keep_edit_history_on_reload; /* Keep undo stack upon, and allow undoing of, document reloading. */
 	gboolean		show_keep_edit_history_on_reload_msg; /* whether to show the message introducing the above feature */
  	gboolean		reload_clean_doc_on_file_change;
+ 	gboolean		save_config_on_file_change;
 }
 GeanyFilePrefs;
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -259,6 +259,8 @@ static void init_pref_groups(void)
 		"show_keep_edit_history_on_reload_msg", TRUE);
 	stash_group_add_boolean(group, &file_prefs.reload_clean_doc_on_file_change,
 		"reload_clean_doc_on_file_change", FALSE);
+	stash_group_add_boolean(group, &file_prefs.save_config_on_file_change,
+		"save_config_on_file_change", TRUE);
 	stash_group_add_string(group, &file_prefs.extract_filetype_regex,
 		"extract_filetype_regex", GEANY_DEFAULT_FILETYPE_REGEX);
 	stash_group_add_boolean(group, &ui_prefs.allow_always_save,
@@ -275,7 +277,7 @@ static void init_pref_groups(void)
 	/* Note: Interface-related various prefs are in ui_init_prefs() */
 
 	/* various build-menu prefs */
-	// Warning: don't move PACKAGE group name items here 
+	// Warning: don't move PACKAGE group name items here
 	group = stash_group_new("build-menu");
 	configuration_add_various_pref_group(group, "build");
 
@@ -1346,7 +1348,8 @@ static void document_list_changed_cb(GObject *obj, GeanyDocument *doc, gpointer 
 
 	/* save configuration, especially session file list, but only if we are not just starting
 	 * and not about to quit */
-	if (main_status.main_window_realized &&
+	if (file_prefs.save_config_on_file_change &&
+		main_status.main_window_realized &&
 		!main_status.opening_session_files &&
 		!main_status.quitting)
 	{


### PR DESCRIPTION
The main idea is to save the session file list more often to prevent
accidental lost but saving the rest of the configuration might help
as well.
To prevent too many save attempts, an idle function is used and it's
only added once until it was executed.

This might help #1826, #1416 and replaces #1860.

IIRC at the very beginning I was a bit concerned about IO access and performance when writing the settings too often. At least performance doesn't seem to be a problem: `configuration_save` takes about 1-2 milliseconds on my system and IO access happens in the document-related actions in any way.

Even though I tested the code, I would like to use it "in production" for some time to get sure there are no unseen side effects or similar.