### PR TITLE
Restart the shell if VTE restart is requested

### DIFF
--- a/src/vte.c
+++ b/src/vte.c
@@ -526,6 +526,7 @@ static void vte_restart(GtkWidget *widget)
 		pid = 0;
 	}
 	vf->vte_terminal_reset(VTE_TERMINAL(widget), TRUE, TRUE);
+	vte_start(widget);
 	set_clean(TRUE);
 }
 


### PR DESCRIPTION
This happened in the past until d35e66493c7f80768dc5b8761d62ec74434bfdae
because of https://sourceforge.net/p/geany/bugs/163/ and
https://bugzilla.gnome.org/show_bug.cgi?id=540161.
But since the VTE bug has been fixed for long, we can remove the
workaround.

Closes #352.