### PR TITLE
Consume closing brackets, braces, parenthesis, single and double quotes

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -3648,88 +3648,181 @@
                             <property name="can_focus">False</property>
                             <property name="left_padding">12</property>
                             <child>
-                              <object class="GtkVBox" id="vbox10">
+                              <object class="GtkHBox" id="hbox19">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
-                                  <object class="GtkCheckButton" id="check_autoclose_parenthesis">
-                                    <property name="label" translatable="yes">Parenthesis ( )</property>
+                                  <object class="GtkVBox" id="vbox10">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close parenthesis when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_parenthesis">
+                                        <property name="label" translatable="yes">Parenthesis ( )</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Auto-close parenthesis when typing an opening one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_cbracket">
+                                        <property name="label" translatable="yes">Curly brackets { }</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Auto-close curly bracket when typing an opening one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_sbracket">
+                                        <property name="label" translatable="yes">Square brackets [ ]</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Auto-close square-bracket when typing an opening one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_squote">
+                                        <property name="label" translatable="yes">Single quotes ' '</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Auto-close single quote when typing an opening one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_dquote">
+                                        <property name="label" translatable="yes">Double quotes " "</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Auto-close double quote when typing an opening one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">4</property>
+                                      </packing>
+                                    </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
                                 </child>
+                                
                                 <child>
-                                  <object class="GtkCheckButton" id="check_autoclose_cbracket">
-                                    <property name="label" translatable="yes">Curly brackets { }</property>
+                                  <object class="GtkVBox" id="vbox10c">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close curly bracket when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_consume_parenthesis">
+                                        <property name="label" translatable="yes">Closing-Parenthesis )</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Consume a following close-parenthesis when typing an closeing one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_consume_cbracket">
+                                        <property name="label" translatable="yes">Closing-Curly brackets }</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Consume a following close-curly bracket when typing an closing one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_consume_sbracket">
+                                        <property name="label" translatable="yes">Closing-Square brackets ]</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Consume a following close-square-bracket when typing an closing one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_consume_squote">
+                                        <property name="label" translatable="yes">Single quotes ' '</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Consume a following single quote when typing one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="check_autoclose_consume_dquote">
+                                        <property name="label" translatable="yes">Double quotes " "</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Consume a following double quote when typing one</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">4</property>
+                                      </packing>
+                                    </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="check_autoclose_sbracket">
-                                    <property name="label" translatable="yes">Square brackets [ ]</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close square-bracket when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="check_autoclose_squote">
-                                    <property name="label" translatable="yes">Single quotes ' '</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close single quote when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="check_autoclose_dquote">
-                                    <property name="label" translatable="yes">Double quotes " "</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close double quote when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">4</property>
-                                  </packing>
                                 </child>
                               </object>
                             </child>

--- a/scintilla/include/Scintilla.h
+++ b/scintilla/include/Scintilla.h
@@ -49,6 +49,7 @@ typedef sptr_t (*SciFnDirect)(sptr_t ptr, unsigned int iMessage, uptr_t wParam, 
 #define SCI_CHANGEINSERTION 2672
 #define SCI_CLEARALL 2004
 #define SCI_DELETERANGE 2645
+#define SCI_DELETECHAR 2719
 #define SCI_CLEARDOCUMENTSTYLE 2005
 #define SCI_GETLENGTH 2006
 #define SCI_GETCHARAT 2007

--- a/scintilla/src/Editor.cxx
+++ b/scintilla/src/Editor.cxx
@@ -6173,8 +6173,11 @@ sptr_t Editor::WndProc(unsigned int iMessage, uptr_t wParam, sptr_t lParam) {
 		return 0;
 
 	case SCI_DELETERANGE:
-		pdoc->DeleteChars(static_cast<Sci::Position>(wParam), lParam);
+		pdoc->DeleteChars(static_cast<Sci::Position>(wParam), static_cast<Sci::Position>(lParam));
 		return 0;
+	
+	case SCI_DELETECHAR:
+		pdoc->DelChar(static_cast<Sci::Position>(wParam));
 
 	case SCI_CLEARDOCUMENTSTYLE:
 		ClearDocumentStyle();

--- a/src/editor.h
+++ b/src/editor.h
@@ -138,6 +138,7 @@ typedef struct GeanyEditorPrefs
 	gint		autocompletion_update_freq;
 	gint		scroll_lines_around_cursor;
 	gint		ime_interaction; /* input method editor's candidate window behaviour */
+	guint		autoclose_chars_consume;
 }
 GeanyEditorPrefs;
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -472,6 +472,7 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_string(config, PACKAGE, "comment_toggle_mark", editor_prefs.comment_toggle_mark);
 	g_key_file_set_boolean(config, PACKAGE, "scroll_stop_at_last_line", editor_prefs.scroll_stop_at_last_line);
 	g_key_file_set_integer(config, PACKAGE, "autoclose_chars", editor_prefs.autoclose_chars);
+	g_key_file_set_integer(config, PACKAGE, "autoclose_chars_consume", editor_prefs.autoclose_chars_consume);
 
 	/* files */
 	g_key_file_set_string(config, PACKAGE, "pref_editor_default_new_encoding", encodings[file_prefs.default_new_encoding].charset);
@@ -811,6 +812,7 @@ static void load_dialog_prefs(GKeyFile *config)
 	editor_prefs.auto_continue_multiline = utils_get_setting_boolean(config, PACKAGE, "auto_continue_multiline", TRUE);
 	editor_prefs.comment_toggle_mark = utils_get_setting_string(config, PACKAGE, "comment_toggle_mark", GEANY_TOGGLE_MARK);
 	editor_prefs.autoclose_chars = utils_get_setting_integer(config, PACKAGE, "autoclose_chars", 0);
+	editor_prefs.autoclose_chars_consume = utils_get_setting_integer(config, PACKAGE, "autoclose_chars_consume", 0);
 
 	/* Files
 	 * use current locale encoding as default for new files (should be UTF-8 in most cases) */

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -672,6 +672,26 @@ static void prefs_init_dialog(void)
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
 		(editor_prefs.autoclose_chars & GEANY_AC_DQUOTE));
 
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_parenthesis");
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
+		(editor_prefs.autoclose_chars_consume & GEANY_AC_PARENTHESIS));
+
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_cbracket");
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
+		(editor_prefs.autoclose_chars_consume & GEANY_AC_CBRACKET));
+
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_sbracket");
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
+		(editor_prefs.autoclose_chars_consume & GEANY_AC_SBRACKET));
+
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_squote");
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
+		(editor_prefs.autoclose_chars_consume & GEANY_AC_SQUOTE));
+
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_dquote");
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
+		(editor_prefs.autoclose_chars_consume & GEANY_AC_DQUOTE));
+
 	/* Tools Settings */
 
 	if (tool_prefs.term_cmd)
@@ -872,6 +892,7 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		GtkWidget *widget;
 		guint i;
 		gboolean autoclose_brackets[5];
+		gboolean autoclose_consume_brackets[5];
 		gboolean old_invert_all = interface_prefs.highlighting_invert_all;
 		gboolean old_sidebar_pos = interface_prefs.sidebar_pos;
 		GeanyDocument *doc = document_get_current();
@@ -1139,12 +1160,34 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_dquote");
 		autoclose_brackets[4] = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_parenthesis");
+		autoclose_consume_brackets[0] = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_cbracket");
+		autoclose_consume_brackets[1] = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_sbracket");
+		autoclose_consume_brackets[2] = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_squote");
+		autoclose_consume_brackets[3] = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_autoclose_consume_dquote");
+		autoclose_consume_brackets[4] = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
 		editor_prefs.autoclose_chars =
 		  (autoclose_brackets[0] ? GEANY_AC_PARENTHESIS : 0u)
 		| (autoclose_brackets[1] ? GEANY_AC_CBRACKET : 0u)
 		| (autoclose_brackets[2] ? GEANY_AC_SBRACKET : 0u)
 		| (autoclose_brackets[3] ? GEANY_AC_SQUOTE : 0u)
 		| (autoclose_brackets[4] ? GEANY_AC_DQUOTE : 0u);
+
+		editor_prefs.autoclose_chars_consume =
+		  (autoclose_consume_brackets[0] ? GEANY_AC_PARENTHESIS : 0u)
+		| (autoclose_consume_brackets[1] ? GEANY_AC_CBRACKET : 0u)
+		| (autoclose_consume_brackets[2] ? GEANY_AC_SBRACKET : 0u)
+		| (autoclose_consume_brackets[3] ? GEANY_AC_SQUOTE : 0u)
+		| (autoclose_consume_brackets[4] ? GEANY_AC_DQUOTE : 0u);
 
 		/* Tools Settings */
 

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -227,6 +227,15 @@ void sci_add_text(ScintillaObject *sci, const gchar *text)
 	}
 }
 
+void sci_delete_char(ScintillaObject *sci, const gint pos)
+{
+	SSM(sci, SCI_DELETECHAR, pos, 0);
+}
+
+void sci_delete_range(ScintillaObject *sci, const gint pos, const gint length)
+{
+	SSM(sci, SCI_DELETERANGE, pos, length);
+}
 
 /** Sets all text.
  * @param sci Scintilla widget.

--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -98,6 +98,9 @@ gint				sci_get_current_line		(ScintillaObject *sci);
 void				sci_indicator_set			(ScintillaObject *sci, gint indic);
 void				sci_indicator_clear			(ScintillaObject *sci, gint pos, gint len);
 
+void				sci_delete_char				(ScintillaObject *sci, gint pos);
+void				sci_delete_range			(ScintillaObject *sci, gint pos, gint len);
+
 void				sci_set_line_indentation	(ScintillaObject *sci, gint line, gint indent);
 gint				sci_get_line_indentation	(ScintillaObject *sci, gint line);
 gint				sci_find_matching_brace		(ScintillaObject *sci, gint pos);


### PR DESCRIPTION
For a fluent coding I love to not change my hand position to use the
arrow keys!
I realy like auto-closing.

If I activate the auto closing brackets, braces, parenthesis  and
quotes feature, the closing characters are inserted, but to continue after
these, the arrow keys are necessary.

The modification I made: if autoclosing AND consuming is activated in
options, if a closing character is typed and the following character
matches this, not both characters stay - one deleted - curr pos
afterwards.

Example: the | marks the curr position:

"|"
"hallo|"
[Then the " is hit]
"hallo"|

The " is reachable without changing hand pos. Same for the other
"autoclosers".

I saw this in other IDEs and I want it in my Geany.

I don't know about internationatlization, so this is an incomplete
feature.