### PR TITLE
Don't perform line breaking in rectangular selection mode

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -542,7 +542,7 @@ static void check_line_breaking(GeanyEditor *editor, gint pos)
 	gint line, lstart, col;
 	gchar c;
 
-	if (!editor->line_breaking)
+	if (!editor->line_breaking || sci_get_selection_mode(editor->sci) != SC_SEL_STREAM)
 		return;
 
 	col = sci_get_col_from_position(sci, pos);


### PR DESCRIPTION
Doing so drops the rectangular selection, and there is no obvious correct behavior for line breaking with a rectangular selection. So, just don't do line breaking in this case.

Fixes #2051.

@elextr please test :)