### PR TITLE
FIX: filebrowser plugin: the first rightclick not working with some items on popup:

### DIFF
--- a/plugins/filebrowser.c
+++ b/plugins/filebrowser.c
@@ -68,6 +68,8 @@ enum
 	FILEVIEW_N_COLUMNS
 };
 
+static GtkWidget *popup_menu = NULL;
+
 static gboolean fb_set_project_base_path = FALSE;
 static gboolean fb_follow_path = FALSE;
 static gboolean show_hidden_files = FALSE;
@@ -686,6 +688,7 @@ static GtkWidget *create_popup_menu(void)
 	gtk_container_add(GTK_CONTAINER(menu), item);
 
 	item = gtk_check_menu_item_new_with_mnemonic(_("Show _Hidden Files"));
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(item),show_hidden_files);
 	gtk_widget_show(item);
 	gtk_container_add(GTK_CONTAINER(menu), item);
 	g_signal_connect(item, "activate", G_CALLBACK(on_hidden_files_clicked), NULL);
@@ -736,13 +739,9 @@ static gboolean on_button_press(GtkWidget *widget, GdkEventButton *event, gpoint
 	}
 	else if (event->button == 3)
 	{
-		static GtkWidget *popup_menu = NULL;
-
 		if (popup_menu == NULL)
 			popup_menu = create_popup_menu();
 
-		gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(popup_items.show_hidden_files),
-			show_hidden_files);
 		gtk_menu_popup(GTK_MENU(popup_menu), NULL, NULL, NULL, NULL, event->button, event->time);
 		/* don't return TRUE here, unless the selection won't be changed */
 	}


### PR DESCRIPTION
- open in geany and open external not starting
- find in files don't have the clicked path