### PR TITLE
 Always allow user filetype extensions to override system config file

### DIFF
--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -196,9 +196,6 @@ extern GPtrArray *filetypes_array;
 extern GSList *filetypes_by_title;
 
 
-GeanyFiletype *filetypes_find(GCompareFunc predicate, gpointer user_data);
-
-
 void filetypes_init(void);
 
 void filetypes_init_types(void);

--- a/src/filetypesprivate.h
+++ b/src/filetypesprivate.h
@@ -40,6 +40,7 @@ typedef struct GeanyFiletypePrivate
 	gboolean	xml_indent_tags; /* XML tag autoindentation, for HTML and XML filetypes */
 	GSList		*tag_files;
 	gboolean	warn_color_scheme;
+	gboolean	user_extensions;	// true if extensions were read from user config file
 
 	/* TODO: move to structure in build.h and only put a pointer here */
 	GeanyBuildCommand *filecmds;


### PR DESCRIPTION
Before the user would sometimes have to override `UnwantedFiletype=` in the user config file to remove an extension written in the system file. Geany would ignore an overridden filetype in the user config file that also matches the extension. This happened when the wanted filetype had a higher index than the unwanted one in `filetypes_array`.

This also first refactors the code without `filetypes_find` (which I wrote ages ago) - It's not worth abstracting finding through `filetypes_array`, it's not bug prone, and it may even cause bugs with non-type-safe predicate signature. It was only used once anyway.