### PR TITLE
Comment system file contents when opening `Tools->Configuration Files`

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -36,6 +36,7 @@
 #include "filetypes.h"
 #include "geanymenubuttonaction.h"
 #include "keyfile.h"
+#include "keybindings.h"
 #include "main.h"
 #include "msgwindow.h"
 #include "prefs.h"
@@ -2096,6 +2097,7 @@ static void on_config_file_clicked(GtkWidget *widget, gpointer user_data)
 		gchar *global_file;
 		gchar *base_name = NULL;
 		gchar *global_content = NULL;
+		GeanyDocument *doc = NULL;
 
 		/* get the path inside app->configdir - can contain subdirectories */
 		if (g_str_has_prefix(file_name, app->configdir))
@@ -2115,8 +2117,17 @@ static void on_config_file_clicked(GtkWidget *widget, gpointer user_data)
 		if (g_file_test(global_file, G_FILE_TEST_EXISTS))
 			g_file_get_contents(global_file, &global_content, NULL, NULL);
 
-		document_new_file(utf8_filename, ft, global_content);
-
+		doc = document_new_file(utf8_filename, ft, global_content);
+		if (global_content)
+		{
+			sci_select_all(doc->editor->sci);
+			keybindings_send_command(GEANY_KEY_GROUP_FORMAT,
+				GEANY_KEYS_FORMAT_COMMENTLINETOGGLE);
+			sci_set_current_line(doc->editor->sci, 0);
+			document_set_text_changed(doc, FALSE);
+			sci_empty_undo_buffer(doc->editor->sci);
+			ui_document_show_hide(doc); /* update the document menu */
+		}
 		utils_free_pointers(4, utf8_filename, base_name, global_file, global_content, NULL);
 	}
 }


### PR DESCRIPTION
Discourage the user from overriding system settings unnecessarily.

This fixes #1552.