### PR TITLE
Show Various pref group prefixes

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2539,7 +2539,7 @@ documents before restart.
 ================================  ===========================================  ==========  ===========
 Key                               Description                                  Default     Applies
 ================================  ===========================================  ==========  ===========
-**Editor related**
+**``editor`` group**
 use_gtk_word_boundaries           Whether to look for the end of a word        true        to new
                                   when using word-boundary related                         documents
                                   Scintilla commands (see `Scintilla
@@ -2560,17 +2560,10 @@ indent_hard_tab_width             The size of a tab character. Don't change    8
 editor_ime_interaction            Input method editor (IME)'s candidate        0           to new
                                   window behaviour. May be 0 (windowed) or                 documents
                                   1 (inline)
-**Interface related**
+**``interface`` group**
 show_symbol_list_expanders        Whether to show or hide the small            true        to new
                                   expander icons on the symbol list                        documents
                                   treeview.
-allow_always_save                 Whether files can be saved always, even      false       immediately
-                                  if they don't have any changes.
-                                  By default, the Save button and menu
-                                  item are disabled when a file is
-                                  unchanged. When setting this option to
-                                  true, the Save button and menu item are
-                                  always active and files can be saved.
 compiler_tab_autoscroll           Whether to automatically scroll to the       true        immediately
                                   last line of the output in the Compiler
                                   tab.
@@ -2586,7 +2579,7 @@ msgwin_messages_visible           Whether to show the Messages tab in the      t
                                   Messages Window
 msgwin_scribble_visible           Whether to show the Scribble tab in the      true        immediately
                                   Messages Window
-**VTE related**
+**``terminal`` group**
 send_selection_unsafe             By default, Geany strips any trailing        false       immediately
                                   newline characters from the current
                                   selection before sending it to the terminal
@@ -2604,7 +2597,14 @@ send_cmd_prefix                   String with which prefix the commands sent   E
                                   setting this to a space.  Note that leading
                                   spaces must be escaped using `\s` in the
                                   configuration file.
-**File related**
+**``files`` group**
+allow_always_save                 Whether files can be saved always, even      false       immediately
+                                  if they don't have any changes.
+                                  By default, the Save button and menu
+                                  item are disabled when a file is
+                                  unchanged. When setting this option to
+                                  true, the Save button and menu item are
+                                  always active and files can be saved.
 use_atomic_file_saving            Defines the mode how Geany saves files to    false       immediately
                                   disk. If disabled, Geany directly writes
                                   the content of the document to disk. This
@@ -2636,17 +2636,16 @@ reload_clean_doc_on_file_change   Whether to automatically reload documents    f
                                   on disk.
                                   If unsaved changes exist then the user is
                                   prompted to reload manually.
-**Filetype related**
-extract_filetype_regex            Regex to extract filetype name from file     See below.  immediately
+extract_filetype_regex            Regex to extract filetype name from file     See link    immediately
                                   via capture group one.
-**Search related**
+                                  See `ft_regex`_ for default.
+**``search`` group**
 find_selection_type               See `Find selection`_.                       0           immediately
-**Replace related**
 replace_and_find_by_default       Set ``Replace & Find`` button as default so  true        immediately
                                   it will be activated when the Enter key is
                                   pressed while one of the text fields has
                                   focus.
-**Build Menu related**
+**``build`` group**
 number_ft_menu_items              The maximum number of menu items in the      2           on restart
                                   filetype section of the Build menu.
 number_non_ft_menu_items          The maximum number of menu items in the      3           on restart
@@ -2654,8 +2653,6 @@ number_non_ft_menu_items          The maximum number of menu items in the      3
 number_exec_menu_items            The maximum number of menu items in the      2           on restart
                                   execute section of the Build menu.
 ================================  ===========================================  ==========  ===========
-
-The extract_filetype_regex has the default value GEANY_DEFAULT_FILETYPE_REGEX.
 
 Statusbar Templates
 ```````````````````
@@ -5461,6 +5458,8 @@ GEANY_MAX_AUTOCOMPLETE_WORDS    How many autocompletion suggestions should    30
 GEANY_DEFAULT_FILETYPE_REGEX    The default regex to extract filetypes from   See below.
                                 files.
 ==============================  ============================================  ==================
+
+.. _ft_regex:
 
 The GEANY_DEFAULT_FILETYPE_REGEX default value is  -\\*-\\s*([^\\s]+)\\s*-\\*- which finds Emacs filetypes.
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -132,11 +132,13 @@ void configuration_add_pref_group(struct StashGroup *group, gboolean for_prefs_d
 }
 
 
-/* The group will be free'd on quitting. */
-void configuration_add_various_pref_group(struct StashGroup *group)
+/* The group will be free'd on quitting.
+ * prefix can be NULL to use group name */
+void configuration_add_various_pref_group(struct StashGroup *group,
+	const gchar *prefix)
 {
 	configuration_add_pref_group(group, TRUE);
-	stash_group_set_various(group, TRUE);
+	stash_group_set_various(group, TRUE, prefix);
 }
 
 
@@ -225,7 +227,7 @@ static void init_pref_groups(void)
 
 	/* various geany prefs */
 	group = stash_group_new(PACKAGE);
-	configuration_add_various_pref_group(group);
+	configuration_add_various_pref_group(group, "editor");
 
 	stash_group_add_boolean(group, &editor_prefs.show_scrollbars,
 		"show_editor_scrollbars", TRUE);
@@ -235,6 +237,15 @@ static void init_pref_groups(void)
 		"use_gtk_word_boundaries", TRUE);
 	stash_group_add_boolean(group, &editor_prefs.complete_snippets_whilst_editing,
 		"complete_snippets_whilst_editing", FALSE);
+	/* for backwards-compatibility */
+	stash_group_add_integer(group, &editor_prefs.indentation->hard_tab_width,
+		"indent_hard_tab_width", 8);
+	stash_group_add_integer(group, &editor_prefs.ime_interaction,
+		"editor_ime_interaction", SC_IME_WINDOWED);
+
+	group = stash_group_new(PACKAGE);
+	configuration_add_various_pref_group(group, "files");
+
 	stash_group_add_boolean(group, &file_prefs.use_safe_file_saving,
 		atomic_file_saving_key, FALSE);
 	stash_group_add_boolean(group, &file_prefs.gio_unsafe_save_backup,
@@ -247,23 +258,25 @@ static void init_pref_groups(void)
 		"show_keep_edit_history_on_reload_msg", TRUE);
 	stash_group_add_boolean(group, &file_prefs.reload_clean_doc_on_file_change,
 		"reload_clean_doc_on_file_change", FALSE);
-	/* for backwards-compatibility */
-	stash_group_add_integer(group, &editor_prefs.indentation->hard_tab_width,
-		"indent_hard_tab_width", 8);
-	stash_group_add_integer(group, (gint*)&search_prefs.find_selection_type,
-		"find_selection_type", GEANY_FIND_SEL_CURRENT_WORD);
 	stash_group_add_string(group, &file_prefs.extract_filetype_regex,
 		"extract_filetype_regex", GEANY_DEFAULT_FILETYPE_REGEX);
+	stash_group_add_boolean(group, &ui_prefs.allow_always_save,
+		"allow_always_save", FALSE);
+
+	group = stash_group_new(PACKAGE);
+	configuration_add_various_pref_group(group, "search");
+
+	stash_group_add_integer(group, (gint*)&search_prefs.find_selection_type,
+		"find_selection_type", GEANY_FIND_SEL_CURRENT_WORD);
 	stash_group_add_boolean(group, &search_prefs.replace_and_find_by_default,
 		"replace_and_find_by_default", TRUE);
-	stash_group_add_integer(group, &editor_prefs.ime_interaction,
-		"editor_ime_interaction", SC_IME_WINDOWED);
 
 	/* Note: Interface-related various prefs are in ui_init_prefs() */
 
 	/* various build-menu prefs */
+	// Warning: don't move PACKAGE group name items here 
 	group = stash_group_new("build-menu");
-	configuration_add_various_pref_group(group);
+	configuration_add_various_pref_group(group, "build");
 
 	stash_group_add_integer(group, &build_menu_prefs.number_ft_menu_items,
 		"number_ft_menu_items", 0);
@@ -903,7 +916,7 @@ static void load_dialog_prefs(GKeyFile *config)
 		 * this can't be done in init_pref_groups() because we need to know the value of
 		 * vte_info.load_vte, and `vc` to be initialized */
 		group = stash_group_new("VTE");
-		configuration_add_various_pref_group(group);
+		configuration_add_various_pref_group(group, "terminal");
 
 		stash_group_add_string(group, &vc->send_cmd_prefix, "send_cmd_prefix", "");
 		stash_group_add_boolean(group, &vc->send_selection_unsafe, "send_selection_unsafe", FALSE);

--- a/src/keyfile.h
+++ b/src/keyfile.h
@@ -37,7 +37,8 @@ struct StashGroup;
 
 void configuration_add_pref_group(struct StashGroup *group, gboolean for_prefs_dialog);
 
-void configuration_add_various_pref_group(struct StashGroup *group);
+void configuration_add_various_pref_group(struct StashGroup *group,
+	const gchar *prefix);
 
 void configuration_save(void);
 

--- a/src/stash.c
+++ b/src/stash.c
@@ -126,6 +126,7 @@ struct StashGroup
 	const gchar *name;			/* group name to use in the keyfile */
 	GPtrArray *entries;			/* array of (StashPref*) */
 	gboolean various;		/* mark group for display/edit in stash treeview */
+	const gchar *prefix;	/* text to display for Various UI instead of name */
 	gboolean use_defaults;		/* use default values if there's no keyfile entry */
 };
 
@@ -427,10 +428,13 @@ G_DEFINE_BOXED_TYPE(StashGroup, stash_group, stash_group_dup, stash_group_free);
 
 
 /* Used for selecting groups passed to stash_tree_setup().
- * @c FALSE by default. */
-void stash_group_set_various(StashGroup *group, gboolean various)
+ * @param various @c FALSE by default.
+ * @param prefix @nullable Group prefix or @c NULL to use @c group->name. */
+void stash_group_set_various(StashGroup *group, gboolean various,
+	const gchar *prefix)
 {
 	group->various = various;
+	group->prefix = prefix;
 }
 
 
@@ -1114,6 +1118,7 @@ static void stash_tree_append_pref(StashGroup *group, StashPref *entry, GtkListS
 {
 	GtkTreeIter iter;
 	StashTreeValue *value;
+	gchar *text = NULL;
 
 	value = g_new0(StashTreeValue, 1);
 
@@ -1121,8 +1126,11 @@ static void stash_tree_append_pref(StashGroup *group, StashPref *entry, GtkListS
 	value->pref = entry;
 
 	gtk_list_store_append(store, &iter);
-	gtk_list_store_set(store, &iter, STASH_TREE_NAME, entry->key_name,
+	text = g_strconcat(group->prefix ? group->prefix : group->name,
+		".", entry->key_name, NULL);
+	gtk_list_store_set(store, &iter, STASH_TREE_NAME, text,
 		STASH_TREE_VALUE, value, -1);
+	g_free(text);
 }
 
 

--- a/src/stash.h
+++ b/src/stash.h
@@ -93,7 +93,8 @@ void stash_group_free_settings(StashGroup *group);
 
 #ifdef GEANY_PRIVATE
 
-void stash_group_set_various(StashGroup *group, gboolean write_once);
+void stash_group_set_various(StashGroup *group, gboolean various,
+	const gchar *prefix);
 
 void stash_group_set_use_defaults(StashGroup *group, gboolean use_defaults);
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2323,14 +2323,12 @@ void ui_init_prefs(void)
 	StashGroup *group = stash_group_new(PACKAGE);
 
 	/* various prefs */
-	configuration_add_various_pref_group(group);
+	configuration_add_various_pref_group(group, "interface");
 
 	stash_group_add_boolean(group, &interface_prefs.show_symbol_list_expanders,
 		"show_symbol_list_expanders", TRUE);
 	stash_group_add_boolean(group, &interface_prefs.compiler_tab_autoscroll,
 		"compiler_tab_autoscroll", TRUE);
-	stash_group_add_boolean(group, &ui_prefs.allow_always_save,
-		"allow_always_save", FALSE);
 	stash_group_add_string(group, &ui_prefs.statusbar_template,
 		"statusbar_template", _(DEFAULT_STATUSBAR_TEMPLATE));
 	stash_group_add_boolean(group, &ui_prefs.new_document_after_close,


### PR DESCRIPTION
E.g. *editor.use_gtk_word_boundaries*. This really helps to organise the Various tab.
* stash_tree_setup() will now show a prefix string before the key name.
* stash_group_set_various() can now set a prefix otherwise `group->name` is used. This is useful as Geany prefs all use PACKAGE for the group name apart from "build-menu". This allows us to regroup various prefs without breaking user config.
* Put `allow_always_save` in `files` group rather than `interface`.
* Put `extract_filetype_regex` in `files` group, add link in docs to default value.