### PR TITLE
Fix configure to show "default=auto" for --enable-api-docs

### DIFF
--- a/m4/geany-doxygen.m4
+++ b/m4/geany-doxygen.m4
@@ -7,7 +7,7 @@ AC_DEFUN([GEANY_CHECK_DOXYGEN],
 			[AS_HELP_STRING([--enable-api-docs],
 					[generate API documentation using Doxygen [default=no]])],
 			[geany_with_doxygen="$enableval"],
-			[geany_with_doxygen="auto"])
+			[geany_with_doxygen="no"])
 
 	AC_ARG_VAR([DOXYGEN], [Path to Doxygen executable])
 

--- a/m4/geany-doxygen.m4
+++ b/m4/geany-doxygen.m4
@@ -5,9 +5,9 @@ AC_DEFUN([GEANY_CHECK_DOXYGEN],
 [
 	AC_ARG_ENABLE([api-docs],
 			[AS_HELP_STRING([--enable-api-docs],
-					[generate API documentation using Doxygen [default=no]])],
+					[generate API documentation using Doxygen [default=auto]])],
 			[geany_with_doxygen="$enableval"],
-			[geany_with_doxygen="no"])
+			[geany_with_doxygen="auto"])
 
 	AC_ARG_VAR([DOXYGEN], [Path to Doxygen executable])
 


### PR DESCRIPTION
This fixes the discrepancy where `configure --help` shows "default=no"
but the api-docs are built anyway (only if dependencies are found).

The actuall default is auto which is intended.

Fixes #2189