### PR TITLE
Reset im_context when mouse is clicked

### DIFF
--- a/scintilla/gtk/ScintillaGTK.cxx
+++ b/scintilla/gtk/ScintillaGTK.cxx
@@ -650,6 +650,8 @@ void ScintillaGTK::Init() {
 		caret.period = 0;
 	}
 
+	g_signal_connect(PWidget(wMain), "button-press-event", G_CALLBACK(ScintillaGTK::OnButtonPress), NULL);
+
 	for (TickReason tr = tickCaret; tr <= tickDwell; tr = static_cast<TickReason>(tr + 1)) {
 		timers[tr].reason = tr;
 		timers[tr].scintilla = this;
@@ -2189,6 +2191,18 @@ gboolean ScintillaGTK::KeyRelease(GtkWidget *widget, GdkEventKey *event) {
 	if (gtk_im_context_filter_keypress(sciThis->im_context, event)) {
 		return TRUE;
 	}
+	return FALSE;
+}
+
+gboolean ScintillaGTK::OnButtonPress(GtkWidget *widget, GdkEvent *event, gpointer user_data) {
+	ScintillaGTK *sciThis = FromWidget(widget);
+
+	if (sciThis->im_context) {
+		PreEditString pes(sciThis->im_context);
+		if (strlen(pes.str) > 0)
+			gtk_im_context_reset(sciThis->im_context);
+	}
+
 	return FALSE;
 }
 

--- a/scintilla/gtk/ScintillaGTK.h
+++ b/scintilla/gtk/ScintillaGTK.h
@@ -193,6 +193,7 @@ private:
 	gboolean KeyThis(GdkEventKey *event);
 	static gboolean KeyPress(GtkWidget *widget, GdkEventKey *event);
 	static gboolean KeyRelease(GtkWidget *widget, GdkEventKey *event);
+	static gboolean OnButtonPress(GtkWidget *widget, GdkEvent *event, gpointer user_data);
 #if GTK_CHECK_VERSION(3,0,0)
 	gboolean DrawPreeditThis(GtkWidget *widget, cairo_t *cr);
 	static gboolean DrawPreedit(GtkWidget *widget, cairo_t *cr, ScintillaGTK *sciThis);


### PR DESCRIPTION
Hello.
im_context doesn't reset input method when mouse is clicked.
So, the last character of Hangul is malfunctioning when mouse is clicked.
This patch resets the input method if necessary when the mouse is clicked.
No side effects.
Do not test with ibus. The ibus itself has a bug.
Test with nimf or imhangul.

For information about nimf, visit https://nimf-i18n.gitlab.io/installation/

Related issues with the Hangul last character bugs:

https://github.com/wxWidgets/wxWidgets/pull/1357
https://bugs.chromium.org/p/chromium/issues/detail?id=966148
https://bugs.eclipse.org/bugs/show_bug.cgi?id=371397
https://bugs.documentfoundation.org/show_bug.cgi?id=117008
ibus/ibus#1282