### PR TITLE
Updated error_regex in filetypes.CUDA.conf

### DIFF
--- a/data/filedefs/filetypes.CUDA.conf
+++ b/data/filedefs/filetypes.CUDA.conf
@@ -52,4 +52,4 @@ context_action_cmd=
 compiler=nvcc -c "%f"
 linker=nvcc -o "%e" "%f"
 run_cmd="./%e"
-
+error_regex=^(.+)\\(([0-9]+)\\)


### PR DESCRIPTION
- CUDA/nvcc-compiler does not generate errors in standard format. #2213 
- Having this regular expression solves the problem.
- Now, clicking on the error does take the cursor to that line number.

Let me know if this is okay. It is my 2nd PR ever. :-) 
Thanks