### PR TITLE
Allow to select the Python command, and use `py` on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,14 @@ AM_COND_IF([MINGW],
 AC_SUBST([GEANY_DATA_DIR], [$(eval echo $(eval echo $pkgdatadir))])
 AC_SUBST([pkgdatadir])
 
+# The default Python command
+AC_ARG_WITH([python-command],
+			[AS_HELP_STRING([--with-python-command],
+							[the default Python command [default=python]])],
+			[with_python_command=$withval],
+			[with_python_command=python])
+AC_SUBST([PYTHON_COMMAND], [$with_python_command])
+
 # Documentation tools
 GEANY_CHECK_DOCUTILS
 GEANY_CHECK_DOXYGEN
@@ -176,6 +184,7 @@ AC_CONFIG_FILES([
 		plugins/Makefile
 		po/Makefile.in
 		data/Makefile
+		data/filedefs/filetypes.python
 		doc/Makefile
 		doc/geany.1
 		geany.pc

--- a/configure.ac
+++ b/configure.ac
@@ -145,12 +145,14 @@ AM_COND_IF([MINGW],
 AC_SUBST([GEANY_DATA_DIR], [$(eval echo $(eval echo $pkgdatadir))])
 AC_SUBST([pkgdatadir])
 
-# The default Python command
+# The default Python command.  On Windows, use the `py` launcher by default
 AC_ARG_WITH([python-command],
 			[AS_HELP_STRING([--with-python-command],
-							[the default Python command [default=python]])],
+							[the default Python command [defaults to "py" on Windows and "python" otherwise]])],
 			[with_python_command=$withval],
-			[with_python_command=python])
+			[with_python_command=auto])
+AS_IF([test "x$with_python_command" = xauto],
+	  [AM_COND_IF([MINGW], [with_python_command=py], [with_python_command=python])])
 AC_SUBST([PYTHON_COMMAND], [$with_python_command])
 
 # Documentation tools

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -2,7 +2,7 @@
 colorschemes = \
 	colorschemes/alt.conf
 
-filetypes = \
+filetypes_dist = \
 	filedefs/filetypes.abaqus \
 	filedefs/filetypes.abc \
 	filedefs/filetypes.actionscript \
@@ -57,7 +57,6 @@ filetypes = \
 	filedefs/filetypes.php \
 	filedefs/filetypes.po \
 	filedefs/filetypes.powershell \
-	filedefs/filetypes.python \
 	filedefs/filetypes.r \
 	filedefs/filetypes.restructuredtext \
 	filedefs/filetypes.ruby \
@@ -74,6 +73,10 @@ filetypes = \
 	filedefs/filetypes.xml \
 	filedefs/filetypes.yaml \
 	filedefs/filetypes.zephir
+
+# generated filetypes
+filetypes_nodist = \
+	filedefs/filetypes.python
 
 tagfiles = \
 	tags/std99.c.tags \
@@ -106,7 +109,7 @@ templates = \
 
 nobase_dist_pkgdata_DATA = \
 	$(colorschemes) \
-	$(filetypes) \
+	$(filetypes_dist) \
 	$(tagfiles) \
 	$(template_files) \
 	$(templates) \
@@ -114,6 +117,9 @@ nobase_dist_pkgdata_DATA = \
 	snippets.conf \
 	ui_toolbar.xml \
 	geany.glade
+
+nobase_pkgdata_DATA = \
+	$(filetypes_nodist)
 
 if GTK3
 nobase_dist_pkgdata_DATA += \

--- a/data/filedefs/filetypes.python.in
+++ b/data/filedefs/filetypes.python.in
@@ -72,12 +72,12 @@ context_action_cmd=
 # %e will be replaced by the filename without extension
 # (use only one of it at one time)
 FT_00_LB=_Compile
-FT_00_CM=python -m py_compile "%f"
+FT_00_CM=@PYTHON_COMMAND@ -m py_compile "%f"
 FT_00_WD=
 FT_02_LB=_Lint
 FT_02_CM=pep8 --max-line-length=80 "%f"
 FT_02_WD=
 error_regex=(.+):([0-9]+):([0-9]+)
 EX_00_LB=_Execute
-EX_00_CM=python "%f"
+EX_00_CM=@PYTHON_COMMAND@ "%f"
 EX_00_WD=


### PR DESCRIPTION
The first commit can be generally useful if e.g. Python is not generally found in the PATH, for selecting `python3` by default, or if the environment doesn't provide a generic `python` link but only versioned ones (like `python2` and `python3`).

The second one implements the suggestion from #2211 on top of this.  I have no idea if that suggestion makes sense as I don't use Windows and don't have enough Python-on-Windows knowledge.  @eht16 what do you think?

@novel-yet-trivial could you test this if you can build Geany?  I didn't actually test it on Winodws so it properly working is only theoretical, although I'm quite confident.