### PR TITLE
Added template file for CSS

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -86,6 +86,7 @@ tagfiles = \
 template_files = \
 	templates/files/file.html \
 	templates/files/file_html5.html \
+	templates/files/file.css \
 	templates/files/file.php \
 	templates/files/file.rb \
 	templates/files/file.tex \

--- a/data/templates/files/file.css
+++ b/data/templates/files/file.css
@@ -1,0 +1,34 @@
+{fileheader}
+body {
+    font: 16px arial, sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-weight: bold;
+}
+
+a {
+    text-decoration: none;
+}
+
+a:link {
+    color: blue;
+}
+
+a:visited {
+    color: darkblue;
+}
+
+a:link:hover,
+a:visited:hover,
+a:link:focus,
+a:visited:focus,
+a:link:active,
+a:visited:active {
+    text-decoration: underline;
+}


### PR DESCRIPTION
This PR adds a "new file" template for CSS files. It's meant to be a follow-up/replacement for PR #607.

Following the discussion there the template includes the ```{fileheader}``` token and only minimal CSS content without much placeholders bloating up the file.

IMHO we cannot predict much about how a typical CSS file would look like so a minimal template seems to be the best solution. The ```{fileheader}``` token might be the most important part of the template file   :smirk: