### PR TITLE
Fixes and refactorings to utils_strv_shorten_file_list() and friends

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -2086,7 +2086,7 @@ gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len)
  * @return The common prefix that is part of all strings.
  */
 GEANY_EXPORT_SYMBOL
-gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len)
+gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len, const gchar *delim)
 {
 	gchar *first, *_sub, *sub;
 	gsize num;
@@ -2112,8 +2112,18 @@ gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len)
 		/* No point in continuing if the remainder is too short */
 		if (max > chars_left)
 			break;
+		/* If delimiters are given, we only need to compare substrings which start and
+		 * end with one of them, so skip any non-delim chars at front ... */
+		if (NZV(delim) && (strchr(delim, _sub[0]) == NULL))
+			continue;
 		for (n_chars = 1; n_chars <= chars_left; n_chars++)
 		{
+			if (NZV(delim))
+			{	/* ... and advance to the next delim char at the end, if any */
+				if (!_sub[n_chars] || strchr(delim, _sub[n_chars]) == NULL)
+					continue;
+				n_chars += 1;
+			}
 			g_strlcpy(sub, _sub, n_chars+1);
 			found = 1;
 			for (gsize i = 1; i < num; i++)
@@ -2199,7 +2209,7 @@ gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len)
 	}
 
 	lcs_len = 0;
-	substring = (i == num) ? utils_strv_find_lcs(names, num) : NULL;
+	substring = (i == num) ? utils_strv_find_lcs(names, num, G_DIR_SEPARATOR_S"/") : NULL;
 	if (NZV(substring))
 	{
 		/* Strip leading component. */

--- a/src/utils.c
+++ b/src/utils.c
@@ -1308,12 +1308,10 @@ void utils_free_pointers(gsize arg_count, ...)
 }
 
 
-/* currently unused */
-#if 0
 /* Creates a string array deep copy of a series of non-NULL strings.
- * The first argument is nothing special.
- * The list must be ended with NULL.
- * If first is NULL, NULL is returned. */
+ * The first argument is nothing special and must not be NULL.
+ * The list must be terminated with NULL. */
+GEANY_EXPORT_SYMBOL
 gchar **utils_strv_new(const gchar *first, ...)
 {
 	gsize strvlen, i;
@@ -1343,7 +1341,6 @@ gchar **utils_strv_new(const gchar *first, ...)
 	strv[i] = NULL;
 	return strv;
 }
-#endif
 
 
 /**
@@ -2053,7 +2050,8 @@ gchar **utils_strv_join(gchar **first, gchar **second)
  * @return The common prefix that is part of all strings (maybe empty), or NULL if an empty list
  *         was passed in.
  */
-static gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len)
+GEANY_EXPORT_SYMBOL
+gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len)
 {
 	gsize num;
 
@@ -2087,7 +2085,8 @@ static gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len)
  *
  * @return The common prefix that is part of all strings.
  */
-static gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len)
+GEANY_EXPORT_SYMBOL
+gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len)
 {
 	gchar *first, *_sub, *sub;
 	gsize num;

--- a/src/utils.c
+++ b/src/utils.c
@@ -2055,7 +2055,7 @@ gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len)
 {
 	gsize num;
 
-	if (!NZV(strv))
+	if (strv_len == 0)
 		return NULL;
 
 	num = (strv_len == -1) ? g_strv_length(strv) : (gsize) strv_len;
@@ -2096,9 +2096,10 @@ gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len, const gchar *delim)
 	char *lcs;
 	gsize found;
 
-	num = (strv_len == -1) ? g_strv_length(strv) : (gsize) strv_len;
-	if (num < 1)
+	if (strv_len == 0)
 		return NULL;
+
+	num = (strv_len == -1) ? g_strv_length(strv) : (gsize) strv_len;
 
 	first = strv[0];
 	len = strlen(first);
@@ -2168,86 +2169,71 @@ gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len)
 {
 	gsize num;
 	gsize i;
-	gchar *prefix, *substring, *lcs;
-	gchar *start, *end;
+	gchar *prefix, *lcs, *end;
 	gchar **names;
-	gsize prefix_len, lcs_len;
+	gsize prefix_len = 0, lcs_len = 0;
 
-	/* We don't dereference file_names if file_names_len == 0. */
-	g_return_val_if_fail(file_names_len == 0 || file_names != NULL, NULL);
+	if (file_names_len == 0)
+		return g_new0(gchar *, 1);
 
-	/* The return value shall have exactly the same size as the input. If the input is a
-	 * GStrv (last element is NULL), the output will follow suit. */
+	g_return_val_if_fail(file_names != NULL, NULL);
+
 	num = (file_names_len == -1) ? g_strv_length(file_names) : (gsize) file_names_len;
+	/* Always include a terminating NULL, enables easy freeing with g_strfreev()
+	 * We just copy the pointers so we can advance them here. But don't
+	 * forget to duplicate the strings before returning.
+	 */
+	names = g_new(gchar *, num + 1);
+	memcpy(names, file_names, num * sizeof(gchar *));
 	/* Always include a terminating NULL, enables easy freeing with g_strfreev() */
-	names = g_new0(gchar *, num + 1);
+	names[num] = NULL;
 
-	prefix = utils_strv_find_common_prefix(file_names, num);
 	/* First: determine the common prefix, that will be stripped.
-	 * Don't strip single-letter prefixes, such as '/' */
-	prefix_len = 0;
-	if (NZV(prefix) && prefix[1])
+	/* We only want to strip full path components, including the trailing slash.
+	 * Except if the component is just "/".
+	 */
+	prefix = utils_strv_find_common_prefix(names, num);
+	end = strrchr(prefix, G_DIR_SEPARATOR);
+	if (end && end > prefix)
 	{
-		/* Only strip directory components, include trailing '/' */
-		start = strrchr(prefix, G_DIR_SEPARATOR);
-		if (start)
-			prefix_len = start - prefix + 1;
+		prefix_len = end - prefix + 1; /* prefix_len includes the trailing slash */
+		for (i = 0; i < num; i++)
+			names[i] += prefix_len;
 	}
 
-	/* Second: determine the longest common substring (lcs), that will be ellipsized. Look
-	 * only at the directory parts since we don't want the file name to be detected as the lcs.
-	 * Also, the first component cannot be common (since it would be part of the common prefix),
-	 * so ignore that as well.
-	 * Surround with dir separators so that we can easily determine the boundaries for ellipsizing. */
-	for (i = 0; i < num; i++) {
-		start = strchr(file_names[i] + prefix_len, G_DIR_SEPARATOR);
-		end = start ? strrchr(start+1, G_DIR_SEPARATOR) : NULL;
-		/* Breaking out early will also skip looking for lcs (wouldn't succeed anyway). */
-		if (!start || !end)
-			break;
-		names[i] = g_strndup(start, end-start+1);
-	}
-
-	lcs_len = 0;
-	substring = (i == num) ? utils_strv_find_lcs(names, num, G_DIR_SEPARATOR_S"/") : NULL;
-	if (NZV(substring))
+	/* Second: determine the longest common substring (lcs), that will be ellipsized. Again,
+	 * we look only for full path compnents so that we ellipsize between separators. This implies
+	 * that the file name cannot be ellipsized which is desirable anyway.
+	 */
+	lcs = utils_strv_find_lcs(names, num, G_DIR_SEPARATOR_S"/");
+	if (lcs)
 	{
-		/* Strip leading component. */
-		start = strchr(substring, G_DIR_SEPARATOR);
-		if (start)
-		{
-			lcs = start + 1;
-			/* Strip trailing components (perhaps empty). */
-			end = strrchr(lcs, G_DIR_SEPARATOR);
-			if (end)
-			{
-				*end = '\0';
-				lcs_len = strlen(lcs);
-				/* Don't bother for tiny common parts (which are often just "." or "/"). */
-				if (lcs_len < 5)
-					lcs_len = 0;
-			}
-		}
+		lcs_len = strlen(lcs);
+		/* Don't bother for tiny common parts (which are often just "." or "/"). Beware
+		 * that lcs includes the enclosing dir separators so the part must be at least 5 chars
+		 * to be eligible for ellipsizing.
+		 */
+		if (lcs_len < 7)
+			lcs_len = 0;
 	}
 
-	/* Finally build the shortened list of unique file names */
+	/* Last: build the shortened list of unique file names */
 	for (i = 0; i < num; i++)
 	{
-		start = file_names[i] + prefix_len;
 		if (lcs_len == 0)
 		{	/* no lcs, copy without prefix */
-			SETPTR(names[i], g_strdup(start));
+			names[i] = g_strdup(names[i]);
 		}
 		else
 		{
-			const gchar *lcs_start = strstr(start, lcs);
+			const gchar *lcs_start = strstr(names[i], lcs);
 			const gchar *lcs_end = lcs_start + lcs_len;
-			/* Maybe replace with unicode's "…" ? */
-			SETPTR(names[i], g_strdup_printf("%.*s...%s", (int)(lcs_start - start), start, lcs_end));
+			/* Dir seperators are included in lcs but shouldn't be elipsized. */
+			names[i] = g_strdup_printf("%.*s...%s", (int)(lcs_start - names[i] + 1), names[i], lcs_end - 1);
 		}
 	}
 
-	g_free(substring);
+	g_free(lcs);
 	g_free(prefix);
 
 	return names;

--- a/src/utils.h
+++ b/src/utils.h
@@ -302,7 +302,7 @@ gchar **utils_strv_join(gchar **first, gchar **second) G_GNUC_WARN_UNUSED_RESULT
 
 gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len) G_GNUC_WARN_UNUSED_RESULT;
 
-gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len) G_GNUC_WARN_UNUSED_RESULT;
+gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len, const gchar *delim) G_GNUC_WARN_UNUSED_RESULT;
 
 gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -300,6 +300,10 @@ gchar **utils_strv_new(const gchar *first, ...) G_GNUC_NULL_TERMINATED;
 
 gchar **utils_strv_join(gchar **first, gchar **second) G_GNUC_WARN_UNUSED_RESULT;
 
+gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len) G_GNUC_WARN_UNUSED_RESULT;
+
+gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len) G_GNUC_WARN_UNUSED_RESULT;
+
 gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len);
 
 GSList *utils_get_config_files(const gchar *subdir);

--- a/src/utils.h
+++ b/src/utils.h
@@ -212,6 +212,8 @@ const gchar *utils_find_open_xml_tag_pos(const gchar sel[], gint size);
 
 gchar *utils_get_real_path(const gchar *file_name);
 
+gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len);
+
 #ifdef GEANY_PRIVATE
 
 typedef enum
@@ -303,8 +305,6 @@ gchar **utils_strv_join(gchar **first, gchar **second) G_GNUC_WARN_UNUSED_RESULT
 gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len) G_GNUC_WARN_UNUSED_RESULT;
 
 gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len, const gchar *delim) G_GNUC_WARN_UNUSED_RESULT;
-
-gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len);
 
 GSList *utils_get_config_files(const gchar *subdir);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,2 +1,13 @@
 
 SUBDIRS = ctags
+
+AM_CPPFLAGS  = -DGEANY_PRIVATE -DG_LOG_DOMAIN=\""Geany"\" @GTK_CFLAGS@ @GTHREAD_CFLAGS@
+AM_CPPFLAGS += -I$(top_srcdir)/src
+
+AM_LDFLAGS = $(GTK_LIBS) $(GTHREAD_LIBS) $(INTLLIBS) -no-install
+
+check_PROGRAMS = test_utils
+
+test_utils_LDADD = $(top_builddir)/src/libgeany.la
+
+TESTS = $(check_PROGRAMS)

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -106,51 +106,86 @@ static void test_utils_strv_find_common_prefix(void)
 	g_strfreev(data);
 }
 
+#define DIR_SEP "\\/"
 void test_utils_strv_find_lcs(void)
 {
 	gchar **data, *s;
 
-	s = utils_strv_find_lcs(NULL, 0);
+	s = utils_strv_find_lcs(NULL, 0, "");
 	g_assert_null(s);
 
 	data = utils_strv_new("", NULL);
-	s = utils_strv_find_lcs(data, -1);
+	s = utils_strv_find_lcs(data, -1, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "");
 	g_free(s);
 	g_strfreev(data);
 
 	data = utils_strv_new("1", "2", "3", NULL);
-	s = utils_strv_find_lcs(data, -1);
+	s = utils_strv_find_lcs(data, -1, "");
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "");
 	g_free(s);
 	g_strfreev(data);
 
 	data = utils_strv_new("abc", "amn", "axy", NULL);
-	s = utils_strv_find_lcs(data, -1);
+	s = utils_strv_find_lcs(data, -1, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "a");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("bca", "mna", "xya", NULL);
+	s = utils_strv_find_lcs(data, -1, "");
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "a");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
 	g_free(s);
 	g_strfreev(data);
 
 	data = utils_strv_new("abc", "", "axy", NULL);
-	s = utils_strv_find_lcs(data, -1);
+	s = utils_strv_find_lcs(data, -1, "");
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("a123b", "b123c", "c123d", NULL);
+	s = utils_strv_find_lcs(data, -1, "");
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "123");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "");
 	g_free(s);
 	g_strfreev(data);
 
 	data = utils_strv_new("22", "23", "33", NULL);
-	s = utils_strv_find_lcs(data, 1);
+	s = utils_strv_find_lcs(data, 1, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "22");
 	g_free(s);
-	s = utils_strv_find_lcs(data, 2);
+	s = utils_strv_find_lcs(data, 2, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "2");
 	g_free(s);
-	s = utils_strv_find_lcs(data, 3);
+	s = utils_strv_find_lcs(data, 3, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "");
 	g_free(s);
@@ -163,47 +198,76 @@ void test_utils_strv_find_lcs(void)
 	                      "/home/user/src/geany/src/main.c",
 	                      "/home/user/src/geany-plugins/addons/src/addons.c",
 	                      NULL);
-	s = utils_strv_find_lcs(data, 4);
+	s = utils_strv_find_lcs(data, 4, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "/home/user/src/geany/src/s");
 	g_free(s);
-	s = utils_strv_find_lcs(data, 5);
+	s = utils_strv_find_lcs(data, 4, DIR_SEP);
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "/home/user/src/geany/src/");
 	g_free(s);
-	s = utils_strv_find_lcs(data, -1);
+	s = utils_strv_find_lcs(data, 5, "");
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/home/user/src/geany/src/");
+	g_free(s);
+	s = utils_strv_find_lcs(data, 5, DIR_SEP);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/home/user/src/geany/src/");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "/home/user/src/geany");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/home/user/src/");
 	g_free(s);
 	g_strfreev(data);
 
 	data = utils_strv_new("/src/a/app-1.2.3/src/lib/module/source.c",
 	                      "/src/b/app-2.2.3/src/module/source.c", NULL);
-	s = utils_strv_find_lcs(data, -1);
+	s = utils_strv_find_lcs(data, -1, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "/module/source.c");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/module/");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("/src/a/app-1.2.3/src/lib/module\\source.c",
+	                      "/src/b/app-2.2.3/src/module\\source.c", NULL);
+	s = utils_strv_find_lcs(data, -1, "");
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/module\\source.c");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/module\\");
 	g_free(s);
 	g_strfreev(data);
 
 	data = utils_strv_new("/src/a/app-1.2.3/src/lib/module/",
 	                      "/src/b/app-2.2.3/src/module/", NULL);
-	s = utils_strv_find_lcs(data, -1);
+	s = utils_strv_find_lcs(data, -1, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, ".2.3/src/");
 	g_free(s);
-	g_strfreev(data);
-
-	data = utils_strv_new("a123b", "b123c", "c123d", NULL);
-	s = utils_strv_find_lcs(data, -1);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
 	g_assert_nonnull(s);
-	g_assert_cmpstr(s, ==, "123");
+	g_assert_cmpstr(s, ==, "/module/");
 	g_free(s);
 	g_strfreev(data);
 
 	data = utils_strv_new("/usr/local/bin/geany", "/usr/bin/geany", "/home/user/src/geany/src/geany", NULL);
-	s = utils_strv_find_lcs(data, -1);
+	s = utils_strv_find_lcs(data, -1, "");
 	g_assert_nonnull(s);
 	g_assert_cmpstr(s, ==, "/geany");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1, DIR_SEP);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
 	g_free(s);
 	g_strfreev(data);
 }
@@ -333,21 +397,11 @@ void test_utils_strv_shorten_file_list(void)
 	g_strfreev(result);
 	g_strfreev(data);
 
-	/* This case shows a weakness. It would be better to elipsize "module". Instead,
-	 * nothing is elipsized as the code determines ".2.3/src/" to be the
-	 * longest common substring. Then it reduces it to directory components, so "src" remains.
-	 * This is shorter than the threshold of 5 chars and consequently not elipsized
-	 *
-	 * Plain utils_strv_find_lcs() actually finds /module/source.c,
-	 * but utils_strv_shorten_file_list() calls it without the file name part, so
-	 * ".2.3/src/" is longer than "/module/". This is illustrated in the test
-	 * test_utils_strv_find_lcs()
-	 */
 	data = utils_strv_new("/src/a/app-1.2.3/src/lib/module/source.c",
 	                      "/src/b/app-2.2.3/src/module/source.c", NULL);
 	result = utils_strv_shorten_file_list(data, -1);
-	expected = utils_strv_new("a/app-1.2.3/src/lib/module/source.c",
-	                          "b/app-2.2.3/src/module/source.c", NULL);
+	expected = utils_strv_new("a/app-1.2.3/src/lib/.../source.c",
+	                          "b/app-2.2.3/src/.../source.c", NULL);
 	g_assert_true(strv_eq(result, expected));
 	g_strfreev(expected);
 	g_strfreev(result);

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -1,0 +1,367 @@
+
+#include "utils.h"
+
+#include "gtkcompat.h"
+
+#define UTIL_TEST_ADD(path, func) g_test_add_func("/utils/" path, func);
+
+
+static void test_utils_strv_new(void)
+{
+	gchar **data;
+
+	data = utils_strv_new("1", NULL);
+	g_assert_nonnull(data);
+	g_assert_cmpint(g_strv_length(data), ==, 1);
+	g_assert_cmpstr(data[0], ==, "1");
+	g_strfreev(data);
+
+	data = utils_strv_new("1", "2", "3", NULL);
+	g_assert_nonnull(data);
+	g_assert_cmpint(g_strv_length(data), ==, 3);
+	g_assert_cmpstr(data[0], ==, "1");
+	g_assert_cmpstr(data[1], ==, "2");
+	g_assert_cmpstr(data[2], ==, "3");
+	g_strfreev(data);
+
+	data = utils_strv_new("1", "", "", "4", NULL);
+	g_assert_nonnull(data);
+	g_assert_cmpint(g_strv_length(data), ==, 4);
+	g_assert_cmpstr(data[0], ==, "1");
+	g_assert_cmpstr(data[1], ==, "");
+	g_assert_cmpstr(data[2], ==, "");
+	g_assert_cmpstr(data[3], ==, "4");
+	g_strfreev(data);
+}
+
+static void test_utils_strv_find_common_prefix(void)
+{
+	gchar **data, *s;
+
+	s = utils_strv_find_common_prefix(NULL, 0);
+	g_assert_null(s);
+
+	data = utils_strv_new("", NULL);
+	s = utils_strv_find_common_prefix(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("1", "2", "3", NULL);
+	s = utils_strv_find_common_prefix(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("abc", "amn", "axy", NULL);
+	s = utils_strv_find_common_prefix(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "a");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("abc", "", "axy", NULL);
+	s = utils_strv_find_common_prefix(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("22", "23", "33", NULL);
+	s = utils_strv_find_common_prefix(data, 1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "22");
+	g_free(s);
+	s = utils_strv_find_common_prefix(data, 2);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "2");
+	g_free(s);
+	s = utils_strv_find_common_prefix(data, 3);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("/home/user/src/geany/src/stash.c", 
+	                      "/home/user/src/geany/src/sidebar.c", 
+	                      "/home/user/src/geany/src/sidebar.h", 
+	                      "/home/user/src/geany/src/sidebar.h",
+	                      "/home/user/src/geany/src/main.c",
+	                      "/home/user/src/geany-plugins/addons/src/addons.c",
+	                      NULL);
+	s = utils_strv_find_common_prefix(data, 4);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/home/user/src/geany/src/s");
+	g_free(s);
+	s = utils_strv_find_common_prefix(data, 5);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/home/user/src/geany/src/");
+	g_free(s);
+	s = utils_strv_find_common_prefix(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/home/user/src/geany");
+	g_free(s);
+	g_strfreev(data);
+}
+
+void test_utils_strv_find_lcs(void)
+{
+	gchar **data, *s;
+
+	s = utils_strv_find_lcs(NULL, 0);
+	g_assert_null(s);
+
+	data = utils_strv_new("", NULL);
+	s = utils_strv_find_lcs(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("1", "2", "3", NULL);
+	s = utils_strv_find_lcs(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("abc", "amn", "axy", NULL);
+	s = utils_strv_find_lcs(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "a");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("abc", "", "axy", NULL);
+	s = utils_strv_find_lcs(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("22", "23", "33", NULL);
+	s = utils_strv_find_lcs(data, 1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "22");
+	g_free(s);
+	s = utils_strv_find_lcs(data, 2);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "2");
+	g_free(s);
+	s = utils_strv_find_lcs(data, 3);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("/home/user/src/geany/src/stash.c", 
+	                      "/home/user/src/geany/src/sidebar.c", 
+	                      "/home/user/src/geany/src/sidebar.h", 
+	                      "/home/user/src/geany/src/sidebar.h",
+	                      "/home/user/src/geany/src/main.c",
+	                      "/home/user/src/geany-plugins/addons/src/addons.c",
+	                      NULL);
+	s = utils_strv_find_lcs(data, 4);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/home/user/src/geany/src/s");
+	g_free(s);
+	s = utils_strv_find_lcs(data, 5);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/home/user/src/geany/src/");
+	g_free(s);
+	s = utils_strv_find_lcs(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/home/user/src/geany");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("/src/a/app-1.2.3/src/lib/module/source.c",
+	                      "/src/b/app-2.2.3/src/module/source.c", NULL);
+	s = utils_strv_find_lcs(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/module/source.c");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("/src/a/app-1.2.3/src/lib/module/",
+	                      "/src/b/app-2.2.3/src/module/", NULL);
+	s = utils_strv_find_lcs(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, ".2.3/src/");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("a123b", "b123c", "c123d", NULL);
+	s = utils_strv_find_lcs(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "123");
+	g_free(s);
+	g_strfreev(data);
+
+	data = utils_strv_new("/usr/local/bin/geany", "/usr/bin/geany", "/home/user/src/geany/src/geany", NULL);
+	s = utils_strv_find_lcs(data, -1);
+	g_assert_nonnull(s);
+	g_assert_cmpstr(s, ==, "/geany");
+	g_free(s);
+	g_strfreev(data);
+}
+
+
+/* g_strv_equal is too recent */
+static gboolean strv_eq(gchar **strv1, gchar **strv2)
+{
+	while(1) {
+		gchar *s1 = *strv1++;
+		gchar *s2 = *strv2++;
+
+		if (!s1 && !s2)
+			return TRUE;
+		else if (s1 && !s2)
+			return FALSE;
+		else if (s2 && !s1)
+			return FALSE;
+		else if (!g_str_equal(s1, s2))
+			return FALSE;
+	}
+}
+
+void test_utils_strv_shorten_file_list(void)
+{
+	gchar **data, **expected, **result;
+	gchar *empty[] = { NULL };
+
+	result = utils_strv_shorten_file_list(NULL, 0);
+	expected = empty;
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(result);
+
+	data = utils_strv_new("", NULL);
+	result = utils_strv_shorten_file_list(data, -1);
+	expected = data;
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(result);
+	g_strfreev(data);
+
+	data = utils_strv_new("1", "2", "3", NULL);
+	result = utils_strv_shorten_file_list(data, -1);
+	expected = data;
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(result);
+	g_strfreev(data);
+
+	data = utils_strv_new("abc", "amn", "axy", NULL);
+	result = utils_strv_shorten_file_list(data, -1);
+	expected = data;
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(result);
+	g_strfreev(data);
+
+	data = utils_strv_new("abc", "", "axy", NULL);
+	result = utils_strv_shorten_file_list(data, -1);
+	expected = data;
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(result);
+	g_strfreev(data);
+
+	data = utils_strv_new("22", "23", "33", NULL);
+	result = utils_strv_shorten_file_list(data, 1);
+	expected = utils_strv_new("22", NULL);
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(expected);
+	g_strfreev(result);
+	result = utils_strv_shorten_file_list(data, 2);
+	expected = utils_strv_new("22", "23", NULL);
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(expected);
+	g_strfreev(result);
+	result = utils_strv_shorten_file_list(data, 3);
+	expected = utils_strv_new("22", "23", "33", NULL);
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(expected);
+	g_strfreev(result);
+	g_strfreev(data);
+
+	data = utils_strv_new("/home/user/src/geany/src/stash.c", 
+	                      "/home/user/src/geany/src/sidebar.c", 
+	                      "/home/user/src/geany/src/sidebar.h", 
+	                      "/home/user/src/geany/src/sidebar.h",
+	                      "/home/user/src/geany/src/main.c",
+	                      "/home/user/src/geany-plugins/addons/src/addons.c",
+	                      NULL);
+	result = utils_strv_shorten_file_list(data, 4);
+	expected = utils_strv_new("stash.c", "sidebar.c", "sidebar.h", "sidebar.h", NULL);
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(expected);
+	result = utils_strv_shorten_file_list(data, 5);
+	expected = utils_strv_new("stash.c", "sidebar.c", "sidebar.h", "sidebar.h", "main.c", NULL);
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(expected);
+	result = utils_strv_shorten_file_list(data, -1);
+	expected = utils_strv_new("geany/src/stash.c", "geany/src/sidebar.c",
+	                          "geany/src/sidebar.h", "geany/src/sidebar.h", "geany/src/main.c",
+	                          "geany-plugins/addons/src/addons.c",
+	                          NULL);
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(expected);
+	g_strfreev(data);
+
+	data = utils_strv_new("/home/user1/src/geany/src/stash.c", 
+	                      "/home/user2/src/geany/src/sidebar.c", 
+	                      "/home/user3/src/geany/src/sidebar.h", 
+	                      "/home/user4/src/geany/src/sidebar.h",
+	                      "/home/user5/src/geany/src/main.c",
+	                      NULL);
+	result = utils_strv_shorten_file_list(data, -1);
+	expected = utils_strv_new("user1/.../stash.c",
+	                          "user2/.../sidebar.c",
+	                          "user3/.../sidebar.h",
+	                          "user4/.../sidebar.h",
+	                          "user5/.../main.c",
+	                          NULL);
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(expected);
+	g_strfreev(result);
+	g_strfreev(data);
+
+	data = utils_strv_new("/aaa/bbb/cc/ccccc/ddddd", "/aaa/bbb/xxx/yyy/cc/ccccc/ddddd", NULL);
+	result = utils_strv_shorten_file_list(data, -1);
+	expected = utils_strv_new("cc/.../ddddd", "xxx/yyy/cc/.../ddddd", NULL);
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(expected);
+	g_strfreev(result);
+	g_strfreev(data);
+
+	/* This case shows a weakness. It would be better to elipsize "module". Instead,
+	 * nothing is elipsized as the code determines ".2.3/src/" to be the
+	 * longest common substring. Then it reduces it to directory components, so "src" remains.
+	 * This is shorter than the threshold of 5 chars and consequently not elipsized
+	 *
+	 * Plain utils_strv_find_lcs() actually finds /module/source.c,
+	 * but utils_strv_shorten_file_list() calls it without the file name part, so
+	 * ".2.3/src/" is longer than "/module/". This is illustrated in the test
+	 * test_utils_strv_find_lcs()
+	 */
+	data = utils_strv_new("/src/a/app-1.2.3/src/lib/module/source.c",
+	                      "/src/b/app-2.2.3/src/module/source.c", NULL);
+	result = utils_strv_shorten_file_list(data, -1);
+	expected = utils_strv_new("a/app-1.2.3/src/lib/module/source.c",
+	                          "b/app-2.2.3/src/module/source.c", NULL);
+	g_assert_true(strv_eq(result, expected));
+	g_strfreev(expected);
+	g_strfreev(result);
+	g_strfreev(data);
+}
+
+int main(int argc, char **argv)
+{
+	g_test_init(&argc, &argv, NULL);
+
+	UTIL_TEST_ADD("strv_join", test_utils_strv_new);
+	UTIL_TEST_ADD("strv_find_common_prefix", test_utils_strv_find_common_prefix);
+	UTIL_TEST_ADD("strv_find_lcs", test_utils_strv_find_lcs);
+	UTIL_TEST_ADD("strv_shorten_file_list", test_utils_strv_shorten_file_list);
+
+	return g_test_run();
+}


### PR DESCRIPTION
When merging #1445 we found that the results could be improved.

I promised to fix the deficient results along with proper unit tests so here we go.

Basically utils_strv_shorten_file_list() can repaired and simplified at the same time by a relatively minor change to the supprting utils_strv_find_lcs(). This is all backed up by new unit tests which tests the related functions plus (now reborn) utils_strv_new().