### PR TITLE
build.h: Move GBO macros and enum to build.c

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -81,6 +81,22 @@ static RunInfo *run_info;
 static const gchar RUN_SCRIPT_CMD[] = "geany_run_script_XXXXXX.sh";
 #endif
 
+/* Order is important (see GBO_TO_GBG, GBO_TO_CMD below) */
+/* * Geany Known Build Commands.
+ * These commands are named after their default use.
+ * Only these commands can currently have keybindings.
+ **/
+typedef enum
+{
+	GEANY_GBO_COMPILE,		/* *< default compile file */
+	GEANY_GBO_BUILD,		/* *< default build file */
+	GEANY_GBO_MAKE_ALL,		/* *< default make */
+	GEANY_GBO_CUSTOM,		/* *< default make user specified target */
+	GEANY_GBO_MAKE_OBJECT,	/* *< default make object, make %e.o */
+	GEANY_GBO_EXEC,			/* *< default execute ./%e */
+	GEANY_GBO_COUNT			/* *< count of how many */
+} GeanyBuildType;
+
 /* * Convert @c GeanyBuildType to @c GeanyBuildGroup.
  *
  * This macro converts @c GeanyBuildType enum values (the "known" commands)

--- a/src/build.h
+++ b/src/build.h
@@ -94,34 +94,6 @@ typedef enum
 /* include the fixed widgets in an array indexed by groups */
 #define GBG_FIXED GEANY_GBG_COUNT
 
-/* * Convert @c GeanyBuildType to @c GeanyBuildGroup.
- *
- * This macro converts @c GeanyBuildType enum values (the "known" commands)
- * to the group they are part of.
- *
- * @param gbo the @c GeanyBuildType value.
- *
- * @return the @c GeanyBuildGroup group that @a gbo is in.
- *
- * Note this is a macro so that it can be used in static initialisers.
- **/
-#define GBO_TO_GBG(gbo) ((gbo)>GEANY_GBO_EXEC?GEANY_GBG_COUNT:((gbo)>=GEANY_GBO_EXEC?GEANY_GBG_EXEC: \
-						 ((gbo) >= GEANY_GBO_MAKE_ALL ? GEANY_GBG_NON_FT : GEANY_GBG_FT)))
-
-/* * Convert @c GeanyBuildType to command index.
- *
- * This macro converts @c GeanyBuildType enum values (the "known" commands)
- * to the index within the group.
- *
- * @param gbo the @c GeanyBuildType value.
- *
- * @return the index of the @a gbo command in its group.
- *
- * Note this is a macro so that it can be used in static initialisers.
- **/
-#define GBO_TO_CMD(gbo) ((gbo)>=GEANY_GBO_COUNT?(gbo)-GEANY_GBO_COUNT:((gbo)>=GEANY_GBO_EXEC?(gbo)-GEANY_GBO_EXEC: \
-						 ((gbo) >= GEANY_GBO_MAKE_ALL ? (gbo)-GEANY_GBO_MAKE_ALL : (gbo))))
-
 enum GeanyBuildFixedMenuItems
 {
 	GBF_NEXT_ERROR,
@@ -210,6 +182,8 @@ void build_save_menu(GKeyFile *config, gpointer ptr, GeanyBuildSource src);
 void build_set_group_count(GeanyBuildGroup grp, gint count);
 
 gchar **build_get_regex(GeanyBuildGroup grp, GeanyFiletype *ft, guint *from);
+
+gboolean build_keybinding(guint key_id);
 
 #endif /* GEANY_PRIVATE */
 

--- a/src/build.h
+++ b/src/build.h
@@ -75,22 +75,6 @@ guint build_get_group_count(const GeanyBuildGroup grp);
 
 #ifdef GEANY_PRIVATE
 
-/* Order is important (see GBO_TO_GBG, GBO_TO_CMD below) */
-/* * Geany Known Build Commands.
- * These commands are named after their default use.
- * Only these commands can currently have keybindings.
- **/
-typedef enum
-{
-	GEANY_GBO_COMPILE,		/* *< default compile file */
-	GEANY_GBO_BUILD,		/* *< default build file */
-	GEANY_GBO_MAKE_ALL,		/* *< default make */
-	GEANY_GBO_CUSTOM,		/* *< default make user specified target */
-	GEANY_GBO_MAKE_OBJECT,	/* *< default make object, make %e.o */
-	GEANY_GBO_EXEC,			/* *< default execute ./%e */
-	GEANY_GBO_COUNT			/* *< count of how many */
-} GeanyBuildType;
-
 /* include the fixed widgets in an array indexed by groups */
 #define GBG_FIXED GEANY_GBG_COUNT
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -89,7 +89,6 @@ static gboolean cb_func_search_action(guint key_id);
 static gboolean cb_func_goto_action(guint key_id);
 static gboolean cb_func_switch_action(guint key_id);
 static gboolean cb_func_clipboard_action(guint key_id);
-static gboolean cb_func_build_action(guint key_id);
 static gboolean cb_func_document_action(guint key_id);
 static gboolean cb_func_view_action(guint key_id);
 
@@ -320,7 +319,7 @@ static void init_default_kb(void)
 	ADD_KB_GROUP(GEANY_KEY_GROUP_VIEW, _("View"), cb_func_view_action);
 	ADD_KB_GROUP(GEANY_KEY_GROUP_DOCUMENT, _("Document"), cb_func_document_action);
 	ADD_KB_GROUP(GEANY_KEY_GROUP_PROJECT, _("Project"), cb_func_project_action);
-	ADD_KB_GROUP(GEANY_KEY_GROUP_BUILD, _("Build"), cb_func_build_action);
+	ADD_KB_GROUP(GEANY_KEY_GROUP_BUILD, _("Build"), build_keybinding);
 	ADD_KB_GROUP(GEANY_KEY_GROUP_TOOLS, _("Tools"), NULL);
 	ADD_KB_GROUP(GEANY_KEY_GROUP_HELP, _("Help"), NULL);
 	ADD_KB_GROUP(GEANY_KEY_GROUP_FOCUS, _("Focus"), cb_func_switch_action);
@@ -1650,61 +1649,6 @@ static void cb_func_menu_messagewindow(G_GNUC_UNUSED guint key_id)
 		ui_lookup_widget(main_widgets.window, "menu_show_messages_window1"));
 
 	gtk_check_menu_item_set_active(c, ! gtk_check_menu_item_get_active(c));
-}
-
-
-static gboolean cb_func_build_action(guint key_id)
-{
-	GtkWidget *item;
-	BuildMenuItems *menu_items;
-	GeanyDocument *doc = document_get_current();
-
-	if (doc == NULL)
-		return TRUE;
-
-	if (!gtk_widget_is_sensitive(ui_lookup_widget(main_widgets.window, "menu_build1")))
-		return TRUE;
-
-	menu_items = build_get_menu_items(doc->file_type->id);
-	/* TODO make it a table??*/
-	switch (key_id)
-	{
-		case GEANY_KEYS_BUILD_COMPILE:
-			item = menu_items->menu_item[GEANY_GBG_FT][GBO_TO_CMD(GEANY_GBO_COMPILE)];
-			break;
-		case GEANY_KEYS_BUILD_LINK:
-			item = menu_items->menu_item[GEANY_GBG_FT][GBO_TO_CMD(GEANY_GBO_BUILD)];
-			break;
-		case GEANY_KEYS_BUILD_MAKE:
-			item = menu_items->menu_item[GEANY_GBG_NON_FT][GBO_TO_CMD(GEANY_GBO_MAKE_ALL)];
-			break;
-		case GEANY_KEYS_BUILD_MAKEOWNTARGET:
-			item = menu_items->menu_item[GEANY_GBG_NON_FT][GBO_TO_CMD(GEANY_GBO_CUSTOM)];
-			break;
-		case GEANY_KEYS_BUILD_MAKEOBJECT:
-			item = menu_items->menu_item[GEANY_GBG_NON_FT][GBO_TO_CMD(GEANY_GBO_MAKE_OBJECT)];
-			break;
-		case GEANY_KEYS_BUILD_NEXTERROR:
-			item = menu_items->menu_item[GBG_FIXED][GBF_NEXT_ERROR];
-			break;
-		case GEANY_KEYS_BUILD_PREVIOUSERROR:
-			item = menu_items->menu_item[GBG_FIXED][GBF_PREV_ERROR];
-			break;
-		case GEANY_KEYS_BUILD_RUN:
-			item = menu_items->menu_item[GEANY_GBG_EXEC][GBO_TO_CMD(GEANY_GBO_EXEC)];
-			break;
-		case GEANY_KEYS_BUILD_OPTIONS:
-			item = menu_items->menu_item[GBG_FIXED][GBF_COMMANDS];
-			break;
-		default:
-			item = NULL;
-	}
-	/* Note: For Build menu items it's OK (at the moment) to assume they are in the correct
-	 * sensitive state, but some other menus don't update the sensitive status until
-	 * they are redrawn. */
-	if (item && gtk_widget_is_sensitive(item))
-		gtk_menu_item_activate(GTK_MENU_ITEM(item));
-	return TRUE;
 }
 
 


### PR DESCRIPTION
* Move build keybinding action code to build.c for better encapsulation, allowing to:
* Move the `GBO_TO_*` macros as they are now not needed outside build.c.
* Format the macros so they are a bit more readable.
* Move the GeanyBuildType enum defining `GEANY_GBO_COMPILE` etc to build.c.