### PR TITLE
build.c: enable the Next/Prev Error menu items only when there are build error messages

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -1026,6 +1026,12 @@ static void process_build_output_line(gchar *msg, gint color)
 		}
 		build_info.message_count++;
 		color = COLOR_RED;	/* error message parsed on the line */
+
+		if (build_info.message_count == 1)
+		{
+			gtk_widget_set_sensitive(build_get_menu_items(-1)->menu_item[GBG_FIXED][GBF_NEXT_ERROR], TRUE);
+			gtk_widget_set_sensitive(build_get_menu_items(-1)->menu_item[GBG_FIXED][GBF_PREV_ERROR], TRUE);
+		}
 	}
 	g_free(filename);
 

--- a/src/build.c
+++ b/src/build.c
@@ -1471,7 +1471,9 @@ void build_menu_update(GeanyDocument *doc)
 		doc = document_get_current();
 	have_path = doc != NULL && doc->file_name != NULL;
 	build_running =  build_info.pid > (GPid) 1;
-	have_errors = gtk_tree_model_iter_n_children(GTK_TREE_MODEL(msgwindow.store_compiler), NULL) > 0;
+	// note: compiler list store may have been cleared since last build
+	have_errors = build_info.message_count > 0 &&
+		gtk_tree_model_iter_n_children(GTK_TREE_MODEL(msgwindow.store_compiler), NULL) > 0;
 	for (i = 0; build_menu_specs[i].build_grp != MENU_DONE; ++i)
 	{
 		struct BuildMenuItemSpec *bs = &(build_menu_specs[i]);

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -374,10 +374,6 @@ void msgwin_compiler_add_string(gint msg_color, const gchar *msg)
 		gtk_tree_path_free(path);
 	}
 
-	/* calling build_menu_update for every build message would be overkill, TODO really should call it once when all done */
-	gtk_widget_set_sensitive(build_get_menu_items(-1)->menu_item[GBG_FIXED][GBF_NEXT_ERROR], TRUE);
-	gtk_widget_set_sensitive(build_get_menu_items(-1)->menu_item[GBG_FIXED][GBF_PREV_ERROR], TRUE);
-
 	if (utf8_msg != msg)
 		g_free(utf8_msg);
 }


### PR DESCRIPTION
~~**Merge #2268 before this pull**~~

* Whilst compiling, enable the *Next/Prev Error* menu items only when the first error is found. Before it enabled them for any compiler tab messages.
* The above has been handled in build.c rather than msgwindow.c, as it has more build-related information (and these menu items are already handled there). This allows the `GeanyBuildFixedMenuItems` enum to be moved to build.c, as it doesn't need to be exposed elsewhere - this change depends on #2268.
* Once a build command is complete, `build_menu_update` is called - this pull makes that function only enable *Next/Prev Error* menu items when there actually were error lines.