### PR TITLE
scintilla: Add more MIME types for copy/paste

### DIFF
--- a/scintilla/gtk/ScintillaGTK.cxx
+++ b/scintilla/gtk/ScintillaGTK.cxx
@@ -138,14 +138,18 @@ GdkAtom ScintillaGTK::atomDROPFILES_DND = nullptr;
 
 static const GtkTargetEntry clipboardCopyTargets[] = {
 	{ (gchar *) "UTF8_STRING", 0, TARGET_UTF8_STRING },
+	{ (gchar *) "text/plain;charset=utf-8", 0, TARGET_UTF8_STRING },
 	{ (gchar *) "STRING", 0, TARGET_STRING },
+	{ (gchar *) "text/plain", 0, TARGET_STRING },
 };
 static const gint nClipboardCopyTargets = ELEMENTS(clipboardCopyTargets);
 
 static const GtkTargetEntry clipboardPasteTargets[] = {
 	{ (gchar *) "text/uri-list", 0, TARGET_URI },
 	{ (gchar *) "UTF8_STRING", 0, TARGET_UTF8_STRING },
+	{ (gchar *) "text/plain;charset=utf-8", 0, TARGET_UTF8_STRING },
 	{ (gchar *) "STRING", 0, TARGET_STRING },
+	{ (gchar *) "text/plain", 0, TARGET_STRING },
 };
 static const gint nClipboardPasteTargets = ELEMENTS(clipboardPasteTargets);
 


### PR DESCRIPTION
This fixes copying/pasting text from Geany to some applications under
Wayland. Examples: kitty (terminal emulator), Qt-based applications.