### PR TITLE
[WIP] Build: Separate geany.conf/project non-filetype execute commands from FT execute

### DIFF
--- a/TODO
+++ b/TODO
@@ -15,7 +15,6 @@ Note: features included in brackets have lower priority.
 	  programming languages (done for C-like filetypes using
 	  filetypes.common named styles)
 	o asynchronous build commands on Windows
-	o (filetype-independent run command in build dialog & keybinding)
 	o (better custom filetype support)
 	o (custom template insertion - so user can add licenses, etc)
 	o (selectable menu of arguments to use for Make, from Make Custom)

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2652,6 +2652,8 @@ number_non_ft_menu_items          The maximum number of menu items in the      3
                                   independent build section.
 number_exec_menu_items            The maximum number of menu items in the      2           on restart
                                   execute section of the Build menu.
+number_exec_ind_menu_items        The maximum number of menu items in the      2           on restart
+                                  independent execute section.
 ================================  ===========================================  ==========  ===========
 
 Statusbar Templates

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2651,7 +2651,7 @@ number_ft_menu_items              The maximum number of menu items in the      2
 number_non_ft_menu_items          The maximum number of menu items in the      3           on restart
                                   independent build section.
 number_exec_menu_items            The maximum number of menu items in the      2           on restart
-                                  execute section of the Build menu.
+                                  filetype execute section.
 number_exec_ind_menu_items        The maximum number of menu items in the      2           on restart
                                   independent execute section.
 ================================  ===========================================  ==========  ===========
@@ -3029,24 +3029,26 @@ in to be configured. For example, if you change one of the default make
 commands to run say 'waf' you can also change the label to match.
 These settings are saved automatically when Geany is shut down.
 
-The build menu is divided into four groups of items each with different
+The build menu has four configurable groups of items each with different
 behaviors:
 
-* Filetype build commands - are configurable and depend on the filetype of the
-  current document; they capture output in the compiler tab and parse it for
+- *Filetype build commands* - these depend on the filetype of the
+  current document. They capture output in the compiler tab and parse it for
   errors.
-* Independent build commands - are configurable and mostly don't depend on the
-  filetype of the current document; they also capture output in the
-  compiler tab and parse it for errors.
-* Execute commands - are configurable and intended for executing your
-  program or other long running programs.  The output is not parsed for 
-  errors and is directed to the terminal command selected in `Tools 
-  preferences`_.
-* Fixed commands - these perform built-in actions:
+- *Independent build commands* - these (mostly) don't depend on the
+  current filetype. They also capture and parse the output.
+- *Filetype execute commands* - these depend on the current filetype 
+  and they are intended for executing your program or other long running 
+  programs.  The output is not parsed for errors and is directed to the 
+  terminal command selected in `Tools preferences`_.
+- *Independent execute commands* - as above but not dependent on the 
+  current filetype.
 
-  * Go to the next error.
-  * Go to the previous error.
-  * Show the build menu commands dialog.
+The menu also has fixed commands - these perform built-in actions:
+
+* Go to the next error.
+* Go to the previous error.
+* Show the build menu commands dialog.
 
 The maximum numbers of items in each of the configurable groups can be
 configured in `Various preferences`_. Even though the maximum number of
@@ -3087,15 +3089,18 @@ is shown in the following table:
 |              |                     |                          |                   |    Label: Make _Object        |
 |              |                     |                          |                   |    Command: make %e.o         |
 +--------------+---------------------+--------------------------+-------------------+-------------------------------+
-| Execute      | Loads From: project | Loads From:              | Loads From:       | Label: _Execute               |
-|              | file or else        | geany.conf file in       | filetypes.xxx in  | Command: ./%e                 |
-|              | filetype defined in | ~/.config/geany or else  | Geany install     |                               |
-|              | project file        | filetypes.xxx file in    |                   |                               |
-|              |                     | ~/.config/geany/filedefs | Saves To: as user |                               |
-|              | Saves To:           |                          | preferences left. |                               |
-|              | project file        | Saves To:                |                   |                               |
-|              |                     | filetypes.xxx file in    |                   |                               |
-|              |                     | ~/.config/geany/filedefs |                   |                               |
+| Filetype     | Loads From:         | Loads From:              | Loads From:       | Label: _Execute               |
+| Execute      | filetype setting    | filetypes.xxx file in    | filetypes.xxx in  | Command: ./%e                 |
+|              | stored in           | ~/.config/geany/filedefs | Geany install     |                               |
+|              | project file        |                          |                   |                               |
+|              |                     | Saves To: Same           | Saves To: as user |                               |
+|              | Saves To: Same      |                          | preferences left. |                               |
++--------------+---------------------+--------------------------+-------------------+-------------------------------+
+| Independent  | Loads From: project | Loads From:              | None              | None                          |
+| Execute      | file                | geany.conf file in       |                   |                               |
+|              |                     | ~/.config/geany          |                   |                               |
+|              | Saves To: Same      |                          |                   |                               |
+|              |                     | Saves To: Same           |                   |                               |
 +--------------+---------------------+--------------------------+-------------------+-------------------------------+
 
 The following notes on the table may reference cells by coordinate as *(group, source)*:
@@ -3116,10 +3121,9 @@ The following notes on the table may reference cells by coordinate as *(group, s
   filetype-independent commands in a filetype file, this provides the ability to
   define filetype dependent default menu items.
 
-* *(Execute, Project and Preferences)* - the project independent
-  execute and preferences independent execute commands can only be set by hand
-  editing the appropriate file, see `Preferences file format`_ and `Project file
-  format`_.
+* Independent execute - the project and preferences independent execute
+  commands can only be set by hand editing the appropriate file, see 
+  `Preferences file format`_ and `Project file format`_.
 
 Set Build Commands dialog
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -3192,7 +3196,8 @@ Keyboard shortcuts can be defined for:
 
 * the first two filetype build menu items
 * the first three independent build menu items
-* the first execute menu item 
+* the first filetype execute menu item 
+* the first independent execute menu item 
 * the fixed menu items (Next/Previous Error, Set Commands)
 
 In the keybindings configuration dialog (see `Keybinding preferences`_)

--- a/src/build.c
+++ b/src/build.c
@@ -424,7 +424,7 @@ static GeanyBuildCommand *get_next_build_cmd(GeanyDocument *doc,
 			if (psrc)
 				*psrc = src;
 			if (printbuildcmds)
-				printf("cmd[%u,%u]=%u\n", cmdgrp, cmdindex, src);
+				g_print("cmd[%u,%u]=%u below=%u; %s\n", cmdgrp, cmdindex, src, below, cmds[cmdindex].command);
 			return &(cmds[cmdindex]);
 		}
 	}

--- a/src/build.c
+++ b/src/build.c
@@ -155,7 +155,7 @@ static struct
 }
 widgets;
 
-static guint build_groups_count[GEANY_GBG_COUNT] = { 3, 4, 2 };
+static guint build_groups_count[GEANY_GBG_COUNT] = { 3, 4, 2, 2 };
 static guint build_items_count = 9;
 
 static void build_exit_cb(GPid pid, gint status, gpointer user_data);
@@ -399,15 +399,22 @@ static GeanyBuildCommand *get_next_build_cmd(GeanyDocument *doc,
 			memcpy(overloads, cs, sizeof(cs));
 			break;
 		}
-		case GEANY_GBG_EXEC: /* order proj, proj ft, pref, home ft, ft, def */
+		case GEANY_GBG_EXEC: /* order proj ft, home ft, ft, def */
 		{
 			CommandSet cs[] = {
-				{GEANY_BCS_PROJ,	exec_proj},
 				{GEANY_BCS_PROJ_FT,	ftp->projexeccmds},
-				{GEANY_BCS_PREF,	exec_pref},
 				{GEANY_BCS_FT,		ftp->homeexeccmds},
 				{GEANY_BCS_FT,		ftp->execcmds},
 				{GEANY_BCS_DEF,		exec_def},
+			};
+			memcpy(overloads, cs, sizeof(cs));
+			break;
+		}
+		case GEANY_GBG_EXEC_IND: /* order proj, pref */
+		{
+			CommandSet cs[] = {
+				{GEANY_BCS_PROJ,	exec_proj},
+				{GEANY_BCS_PREF,	exec_pref},
 			};
 			memcpy(overloads, cs, sizeof(cs));
 			break;
@@ -516,14 +523,21 @@ static GeanyBuildCommand **get_build_group_pointer(const GeanyBuildSource src, c
 				case GEANY_BCS_FT:	  return ft ? &(ft->priv->execcmds): NULL;
 				case GEANY_BCS_HOME_FT: return ft ? &(ft->priv->homeexeccmds): NULL;
 				case GEANY_BCS_PROJ_FT: return ft ? &(ft->priv->projexeccmds): NULL;
+				default: return NULL;
+			}
+			break;
+		case GEANY_GBG_EXEC_IND:
+			switch (src)
+			{
 				case GEANY_BCS_PREF:	return &(exec_pref);
 				case GEANY_BCS_PROJ:	return &(exec_proj);
 				default: return NULL;
 			}
 			break;
 		default:
-			return NULL;
+			break;
 	}
+	return NULL;
 }
 
 
@@ -1406,6 +1420,7 @@ static void create_build_menu(BuildMenuItems *build_menu_items)
 	build_menu_items->menu_item[GEANY_GBG_FT] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_FT]);
 	build_menu_items->menu_item[GEANY_GBG_NON_FT] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_NON_FT]);
 	build_menu_items->menu_item[GEANY_GBG_EXEC] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_EXEC]);
+	build_menu_items->menu_item[GEANY_GBG_EXEC_IND] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_EXEC_IND]);
 	build_menu_items->menu_item[GBG_FIXED] = g_new0(GtkWidget*, GBF_COUNT);
 
 	for (i = 0; build_menu_specs[i].build_grp != MENU_DONE; ++i)

--- a/src/build.c
+++ b/src/build.c
@@ -2709,15 +2709,6 @@ static void on_project_close(void)
 {
 	/* remove project regexen */
 	SETPTR(regex_proj, NULL);
-	
-	guint n = build_groups_count[GEANY_GBG_EXEC_IND];
-	for (guint i = 0; i < n; i++)
-	{
-		g_free(exec_proj[i].label);
-		g_free(exec_proj[i].command);
-		g_free(exec_proj[i].working_dir);
-	}
-	memset(exec_proj, 0, sizeof(GeanyBuildCommand) * n);
 }
 
 

--- a/src/build.c
+++ b/src/build.c
@@ -2233,19 +2233,13 @@ static gboolean build_read_commands(BuildDestination *dst, BuildTableData table_
 
 void build_read_project(GeanyFiletype *ft, BuildTableData build_properties)
 {
-	BuildDestination menu_dst;
+	BuildDestination menu_dst = {0};
 
 	if (ft != NULL)
 	{
 		menu_dst.dst[GEANY_GBG_FT] = &(ft->priv->projfilecmds);
 		menu_dst.dst[GEANY_GBG_EXEC] = &ft->priv->projexeccmds;
 		menu_dst.fileregexstr = &(ft->priv->projerror_regex_string);
-	}
-	else
-	{
-		menu_dst.dst[GEANY_GBG_FT] = NULL;
-		menu_dst.dst[GEANY_GBG_EXEC] = NULL;
-		menu_dst.fileregexstr = NULL;
 	}
 	menu_dst.dst[GEANY_GBG_NON_FT] = &non_ft_proj;
 	menu_dst.dst[GEANY_GBG_EXEC_IND] = &exec_proj;
@@ -2263,7 +2257,6 @@ static void show_build_commands_dialog(void)
 	const gchar *title = _("Set Build Commands");
 	gint response;
 	BuildTableData table_data;
-	BuildDestination prefdsts;
 
 	if (doc != NULL)
 		ft = doc->file_type;
@@ -2278,19 +2271,13 @@ static void show_build_commands_dialog(void)
 	/* run modally to prevent user changing idx filetype */
 	response = gtk_dialog_run(GTK_DIALOG(dialog));
 
+	BuildDestination prefdsts = {0};
 	prefdsts.dst[GEANY_GBG_NON_FT] = &non_ft_pref;
-	prefdsts.dst[GEANY_GBG_EXEC_IND] = NULL;
 	if (ft != NULL)
 	{
 		prefdsts.dst[GEANY_GBG_FT] = &(ft->priv->homefilecmds);
 		prefdsts.fileregexstr = &(ft->priv->homeerror_regex_string);
 		prefdsts.dst[GEANY_GBG_EXEC] = &(ft->priv->homeexeccmds);
-	}
-	else
-	{
-		prefdsts.dst[GEANY_GBG_FT] = NULL;
-		prefdsts.fileregexstr = NULL;
-		prefdsts.dst[GEANY_GBG_EXEC] = NULL;
 	}
 	prefdsts.nonfileregexstr = &regex_pref;
 	if (build_read_commands(&prefdsts, table_data, response) && ft != NULL)

--- a/src/build.c
+++ b/src/build.c
@@ -1298,7 +1298,7 @@ static void on_build_menu_item(GtkWidget *w, gpointer user_data)
 		}
 		return;
 	}
-	else if (grp == GEANY_GBG_EXEC)
+	else if (grp == GEANY_GBG_EXEC || grp == GEANY_GBG_EXEC_IND)
 	{
 		GPid *pid = get_run_pid(grp, cmd);
 		if (*pid > (GPid) 1)
@@ -1333,6 +1333,7 @@ static void on_build_menu_item(GtkWidget *w, gpointer user_data)
 #define MENU_FT_REST	 (GEANY_GBG_COUNT + GEANY_GBG_FT)
 #define MENU_NON_FT_REST (GEANY_GBG_COUNT + GEANY_GBG_NON_FT)
 #define MENU_EXEC_REST   (GEANY_GBG_COUNT + GEANY_GBG_EXEC)
+#define MENU_EXEC_IND_REST (GEANY_GBG_COUNT + GEANY_GBG_EXEC_IND)
 /* the separator */
 #define MENU_SEPARATOR   (2*GEANY_GBG_COUNT)
 /* the fixed items */
@@ -1378,6 +1379,12 @@ static struct BuildMenuItemSpec {
 		GBO_TO_CMD(GEANY_GBO_EXEC), NULL, on_build_menu_item},
 	{NULL, -1, MENU_EXEC_REST,
 		GBO_TO_CMD(GEANY_GBO_EXEC) + 1, NULL, on_build_menu_item},
+	{NULL, -1, MENU_SEPARATOR,
+		GBF_SEP_5, NULL, NULL},
+	{GTK_STOCK_EXECUTE, GEANY_KEYS_BUILD_RUNINDEPENDENT, GEANY_GBG_EXEC_IND,
+		0, NULL, on_build_menu_item},
+	{NULL, -1, MENU_EXEC_IND_REST,
+		1, NULL, on_build_menu_item},
 	{NULL, -1, MENU_SEPARATOR,
 		GBF_SEP_4, NULL, NULL},
 	{GTK_STOCK_PREFERENCES, GEANY_KEYS_BUILD_OPTIONS, MENU_COMMANDS,
@@ -2699,6 +2706,15 @@ static void on_project_close(void)
 {
 	/* remove project regexen */
 	SETPTR(regex_proj, NULL);
+	
+	guint n = build_groups_count[GEANY_GBG_EXEC_IND];
+	for (guint i = 0; i < n; i++)
+	{
+		g_free(exec_proj[i].label);
+		g_free(exec_proj[i].command);
+		g_free(exec_proj[i].working_dir);
+	}
+	memset(exec_proj, 0, sizeof(GeanyBuildCommand) * n);
 }
 
 
@@ -2843,10 +2859,8 @@ gboolean build_keybinding(guint key_id)
 			item = menu_items->menu_item[GEANY_GBG_EXEC][GBO_TO_CMD(GEANY_GBO_EXEC)];
 			break;
 		case GEANY_KEYS_BUILD_RUNINDEPENDENT:
-		{
-			build_run_cmd(doc, GEANY_GBG_EXEC_IND, 0);
-			return TRUE;
-		}
+			item = menu_items->menu_item[GEANY_GBG_EXEC_IND][0];
+			break;
 		case GEANY_KEYS_BUILD_OPTIONS:
 			item = menu_items->menu_item[GBG_FIXED][GBF_COMMANDS];
 			break;

--- a/src/build.c
+++ b/src/build.c
@@ -2239,7 +2239,7 @@ void build_read_project(GeanyFiletype *ft, BuildTableData build_properties)
 		menu_dst.fileregexstr = NULL;
 	}
 	menu_dst.dst[GEANY_GBG_NON_FT] = &non_ft_proj;
-	menu_dst.dst[GEANY_GBG_EXEC] = &exec_proj;
+	menu_dst.dst[GEANY_GBG_EXEC_IND] = &exec_proj;
 	menu_dst.nonfileregexstr = &regex_proj;
 
 	build_read_commands(&menu_dst, build_properties, GTK_RESPONSE_ACCEPT);
@@ -2315,7 +2315,7 @@ static const gchar *build_grp_name = "build-menu";
  * where gg = FT, NF, EX for the command group
  *       nn = 2 digit command number
  *       xx = LB for label, CM for command and WD for working dir */
-static const gchar *groups[GEANY_GBG_COUNT] = { "FT", "NF", "EX" };
+static const gchar *groups[GEANY_GBG_COUNT] = { "FT", "NF", "EX", "EX" };
 static const gchar *fixedkey="xx_xx_xx";
 
 #define set_key_grp(key, grp) (key[prefixlen + 0] = grp[0], key[prefixlen + 1] = grp[1])
@@ -2417,12 +2417,12 @@ void build_load_menu(GKeyFile *config, GeanyBuildSource src, gpointer p)
 				break;
 			case GEANY_BCS_PREF:
 				build_load_menu_grp(config, &non_ft_pref, GEANY_GBG_NON_FT, NULL, FALSE);
-				build_load_menu_grp(config, &exec_pref, GEANY_GBG_EXEC, NULL, FALSE);
+				build_load_menu_grp(config, &exec_pref, GEANY_GBG_EXEC_IND, NULL, FALSE);
 				SETPTR(regex_pref, g_key_file_get_string(config, build_grp_name, "error_regex", NULL));
 				break;
 			case GEANY_BCS_PROJ:
 				build_load_menu_grp(config, &non_ft_proj, GEANY_GBG_NON_FT, NULL, FALSE);
-				build_load_menu_grp(config, &exec_proj, GEANY_GBG_EXEC, NULL, FALSE);
+				build_load_menu_grp(config, &exec_proj, GEANY_GBG_EXEC_IND, NULL, FALSE);
 				SETPTR(regex_proj, g_key_file_get_string(config, build_grp_name, "error_regex", NULL));
 				pj = (GeanyProject*)p;
 				if (p == NULL)
@@ -2507,7 +2507,7 @@ void build_load_menu(GKeyFile *config, GeanyBuildSource src, gpointer p)
 			if (!EMPTY(value))
 			{
 				if (exec_proj == NULL)
-					exec_proj = g_new0(GeanyBuildCommand, build_groups_count[GEANY_GBG_EXEC]);
+					exec_proj = g_new0(GeanyBuildCommand, build_groups_count[GEANY_GBG_EXEC_IND]);
 				if (! exec_proj[GBO_TO_CMD(GEANY_GBO_EXEC)].exists)
 				{
 					exec_proj[GBO_TO_CMD(GEANY_GBO_EXEC)].exists = TRUE;
@@ -2624,7 +2624,7 @@ void build_save_menu(GKeyFile *config, gpointer ptr, GeanyBuildSource src)
 			break;
 		case GEANY_BCS_PREF:
 			build_save_menu_grp(config, non_ft_pref, GEANY_GBG_NON_FT, NULL);
-			build_save_menu_grp(config, exec_pref, GEANY_GBG_EXEC, NULL);
+			build_save_menu_grp(config, exec_pref, GEANY_GBG_EXEC_IND, NULL);
 			if (!EMPTY(regex_pref))
 				g_key_file_set_string(config, build_grp_name, "error_regex", regex_pref);
 			else
@@ -2633,7 +2633,7 @@ void build_save_menu(GKeyFile *config, gpointer ptr, GeanyBuildSource src)
 		case GEANY_BCS_PROJ:
 			pj = (GeanyProject*)ptr;
 			build_save_menu_grp(config, non_ft_proj, GEANY_GBG_NON_FT, NULL);
-			build_save_menu_grp(config, exec_proj, GEANY_GBG_EXEC, NULL);
+			build_save_menu_grp(config, exec_proj, GEANY_GBG_EXEC_IND, NULL);
 			if (!EMPTY(regex_proj))
 				g_key_file_set_string(config, build_grp_name, "error_regex", regex_proj);
 			else

--- a/src/build.c
+++ b/src/build.c
@@ -2238,11 +2238,13 @@ void build_read_project(GeanyFiletype *ft, BuildTableData build_properties)
 	if (ft != NULL)
 	{
 		menu_dst.dst[GEANY_GBG_FT] = &(ft->priv->projfilecmds);
+		menu_dst.dst[GEANY_GBG_EXEC] = &ft->priv->projexeccmds;
 		menu_dst.fileregexstr = &(ft->priv->projerror_regex_string);
 	}
 	else
 	{
 		menu_dst.dst[GEANY_GBG_FT] = NULL;
+		menu_dst.dst[GEANY_GBG_EXEC] = NULL;
 		menu_dst.fileregexstr = NULL;
 	}
 	menu_dst.dst[GEANY_GBG_NON_FT] = &non_ft_proj;
@@ -2277,6 +2279,7 @@ static void show_build_commands_dialog(void)
 	response = gtk_dialog_run(GTK_DIALOG(dialog));
 
 	prefdsts.dst[GEANY_GBG_NON_FT] = &non_ft_pref;
+	prefdsts.dst[GEANY_GBG_EXEC_IND] = NULL;
 	if (ft != NULL)
 	{
 		prefdsts.dst[GEANY_GBG_FT] = &(ft->priv->homefilecmds);

--- a/src/build.h
+++ b/src/build.h
@@ -88,6 +88,7 @@ enum GeanyBuildFixedMenuItems
 	GBF_SEP_2,
 	GBF_SEP_3,
 	GBF_SEP_4,
+	GBF_SEP_5,
 	GBF_COUNT
 };
 

--- a/src/build.h
+++ b/src/build.h
@@ -36,6 +36,7 @@ typedef enum
 	GEANY_GBG_FT,		/**< filetype items */
 	GEANY_GBG_NON_FT,	/**< non filetype items.*/
 	GEANY_GBG_EXEC,		/**< execute items */
+	GEANY_GBG_EXEC_IND,	/**< independent execute items */
 	GEANY_GBG_COUNT		/**< count of groups. */
 } GeanyBuildGroup;
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -704,6 +704,8 @@ static void init_default_kb(void)
 		0, 0, "build_previouserror", _("Previous error"), NULL);
 	add_kb(group, GEANY_KEYS_BUILD_RUN, NULL,
 		GDK_F5, 0, "build_run", _("Run"), NULL);
+	add_kb(group, GEANY_KEYS_BUILD_RUNINDEPENDENT, NULL,
+		GDK_F5, GDK_SHIFT_MASK, "build_run_ind", _("_Independent Run"), NULL);
 	add_kb(group, GEANY_KEYS_BUILD_OPTIONS, NULL,
 		0, 0, "build_options", _("Build options"), NULL);
 

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -273,8 +273,9 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_FORMAT_SENDTOCMD8,				/**< Keybinding. */
 	GEANY_KEYS_FORMAT_SENDTOCMD9,				/**< Keybinding. */
 	GEANY_KEYS_EDITOR_DELETELINETOBEGINNING,	/**< Keybinding. */
-	GEANY_KEYS_DOCUMENT_STRIPTRAILINGSPACES,	/**< Keybinding.
-												 * @since 1.34 (API 238) */
+	GEANY_KEYS_DOCUMENT_STRIPTRAILINGSPACES,	/**< Keybinding. */
+	GEANY_KEYS_BUILD_RUNINDEPENDENT,			/**< Keybinding.
+												 * @since 1.34 (API 239) */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -117,6 +117,7 @@ static struct
 	gint number_ft_menu_items;
 	gint number_non_ft_menu_items;
 	gint number_exec_menu_items;
+	gint number_exec_ind_menu_items;
 }
 build_menu_prefs;
 
@@ -284,6 +285,8 @@ static void init_pref_groups(void)
 		"number_non_ft_menu_items", 0);
 	stash_group_add_integer(group, &build_menu_prefs.number_exec_menu_items,
 		"number_exec_menu_items", 0);
+	stash_group_add_integer(group, &build_menu_prefs.number_exec_ind_menu_items,
+		"number_exec_ind_menu_items", 0);
 }
 
 
@@ -1000,6 +1003,7 @@ static void load_dialog_prefs(GKeyFile *config)
 	build_set_group_count(GEANY_GBG_FT, build_menu_prefs.number_ft_menu_items);
 	build_set_group_count(GEANY_GBG_NON_FT, build_menu_prefs.number_non_ft_menu_items);
 	build_set_group_count(GEANY_GBG_EXEC, build_menu_prefs.number_exec_menu_items);
+	build_set_group_count(GEANY_GBG_EXEC_IND, build_menu_prefs.number_exec_ind_menu_items);
 	build_load_menu(config, GEANY_BCS_PREF, NULL);
 }
 

--- a/src/project.c
+++ b/src/project.c
@@ -443,6 +443,7 @@ static void destroy_project(gboolean open_default)
 	/* remove project non filetype build menu items */
 	build_remove_menu_item(GEANY_BCS_PROJ, GEANY_GBG_NON_FT, -1);
 	build_remove_menu_item(GEANY_BCS_PROJ, GEANY_GBG_EXEC, -1);
+	build_remove_menu_item(GEANY_BCS_PROJ, GEANY_GBG_EXEC_IND, -1);
 
 	g_free(app->project->name);
 	g_free(app->project->description);


### PR DESCRIPTION
Depends on #2301, that should be merged first. (Could be worked around if necessary).

Currently the user can manually edit `geany.conf` or the project `.conf` to add filetype-independent execute commands which silently override the filetype execute ones. It's not really explained in the manual (but Lex says it's in the Wiki page), my guess is it's not used much. Example:
```conf
[build-menu]
EX_00_LB=_Explore
EX_00_CM=explorer
EX_00_WD=
```

This pull creates a new group of build commands - independent execute commands. These appear in the build menu after the filetype execute commands.
This is more flexible for the user and allows for adding GUI configurability to the 'Set Build Commands' dialog (which I can do in another pull).
This adds a keybinding for the first filetype-independent execute command, which defaults to Shift+F5.

The commands are still read from the same keys in the keyfiles.