### PR TITLE
g_print and g_printerr handlers: don't add a newline

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -86,10 +86,10 @@ static void handler_print(const gchar *msg)
 
 static void handler_printerr(const gchar *msg)
 {
-	fprintf(stderr, "%s\n", msg);
+	fprintf(stderr, "%s", msg);
 	if (G_LIKELY(log_buffer != NULL))
 	{
-		g_string_append_printf(log_buffer, "%s\n", msg);
+		g_string_append_printf(log_buffer, "%s", msg);
 		update_dialog();
 	}
 }

--- a/src/log.c
+++ b/src/log.c
@@ -75,10 +75,10 @@ void geany_debug(gchar const *format, ...)
 
 static void handler_print(const gchar *msg)
 {
-	printf("%s\n", msg);
+	printf("%s", msg);
 	if (G_LIKELY(log_buffer != NULL))
 	{
-		g_string_append_printf(log_buffer, "%s\n", msg);
+		g_string_append_printf(log_buffer, "%s", msg);
 		update_dialog();
 	}
 }

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -723,7 +723,7 @@ void plugin_set_document_data(struct GeanyPlugin *plugin, struct GeanyDocument *
  * void on_document_save(GObject *unused, GeanyDocument *doc, GeanyPlugin *plugin)
  * {
  *     const gchar *some_data = plugin_get_document_data(plugin, doc, "my-data");
- *     g_print("my-data: %s", some_data);
+ *     g_print("my-data: %s\n", some_data);
  * }
  *
  * gboolean plugin_init(GeanyPlugin *plugin, gpointer unused)

--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -549,7 +549,7 @@ static gchar *pre_process_file(const gchar *cmd, const gchar *inf)
 
 	g_file_get_contents(tmp_errfile, &errors, NULL, NULL);
 	if (errors && *errors)
-		g_printerr("%s", errors);
+		g_printerr("%s\n", errors);
 	g_free(errors);
 	g_unlink(tmp_errfile);
 	g_free(tmp_errfile);

--- a/src/utils.c
+++ b/src/utils.c
@@ -2377,13 +2377,13 @@ void utils_start_new_geany_instance(const gchar *doc_path)
 
 		if (!utils_spawn_async(NULL, (gchar**) argv, NULL, 0, NULL, NULL, NULL, &err))
 		{
-			g_printerr("Unable to open new window: %s", err->message);
+			g_printerr("Unable to open new window: %s\n", err->message);
 			g_error_free(err);
 		}
 		g_free(exec_path);
 	}
 	else
-		g_printerr("Unable to find 'geany'");
+		g_printerr("Unable to find 'geany'\n");
 }
 
 


### PR DESCRIPTION
The GLib docs say the caller should usually include newline: "Typically, `format` should end with its own new-line character":
https://developer.gnome.org/glib/stable/glib-Warnings-and-Assertions.html#g-print

* Not adding a newline is more flexible as the caller can conditionally print part of a line, then the remaining part and a newline.
* Almost all the uses of g_print and g_printerr in geany and geany-plugins already include a newline at the end of `format`. Printing two newlines is annoying.
* This adds a newline for the remaining cases in geany.
* I have a pull ready for geany-plugins [here](https://github.com/geany/geany-plugins/pull/906). Only needed to change one line.