### PR TITLE
Prefs dialog: Disable overridden pref widgets when project is open

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -4606,11 +4606,37 @@
                       </object>
                     </child>
                     <child type="label">
-                      <object class="GtkLabel" id="label19">
+                      <object class="GtkHBox" id="hbox6">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">&lt;b&gt;Saving files&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="tooltip_text" translatable="yes">These preferences can be overridden when a project is open</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkLabel" id="label19">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Saving files&lt;/b&gt;</property>
+                            <property name="use_markup">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkImage" id="image7">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="stock">gtk-info</property>
+                            <property name="icon-size">1</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -803,6 +803,15 @@ static void prefs_init_dialog(void)
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), vc->cursor_blinks);
 	}
 #endif
+	// note some widgets are only *optionally* overridden, don't include them
+	const gchar *proj_overrides[] = {
+		"vbox6"
+	};
+	for (guint i = 0; i < G_N_ELEMENTS(proj_overrides); i++)
+	{
+		GtkWidget *w = ui_lookup_widget(ui_widgets.prefs_dialog, proj_overrides[i]);
+		gtk_widget_set_sensitive(w, !app->project);
+	}
 }
 
 


### PR DESCRIPTION
Fixes #1363.

Similar to #1750, this disables pref widgets that are overridden by an open project. (It doesn't disable the frame label). Instead of editing a translatable label, this adds an info image next to the frame/widget label. A tooltip is set to show when the mouse is over the label or the image. This doesn't try to change the tooltip for disabled widgets, I didn't find a way to implement that easily and cleanly.

![image](https://user-images.githubusercontent.com/1107820/65428866-103ec100-de0d-11e9-91b1-dc038082b1ee.png)

This approach can also be used to indicate which prefs are overridden by document-specific settings.

ATM this only affects the 'Saving files' prefs, but I can add the others.
