### PR TITLE
Add "Nim" to the Programming file types group

### DIFF
--- a/data/filetype_extensions.conf
+++ b/data/filetype_extensions.conf
@@ -79,7 +79,7 @@ None=*;
 
 # Note: restarting is required after editing groups
 [Groups]
-Programming=Arduino;Clojure;CUDA;Cython;Genie;Groovy;Kotlin;Scala;Swift;
+Programming=Arduino;Clojure;CUDA;Cython;Genie;Groovy;Kotlin;Nim;Scala;Swift;
 Script=Graphviz;TypeScript;
 Markup=
 Misc=JSON;


### PR DESCRIPTION
Previously Nim was grouped on the top-level menu
because the group was missing.

This improves the filetypes menu at least as long as https://github.com/geany/geany/issues/2087 is solved.