### PR TITLE
Define text color when setting dark background in find dialog

### DIFF
--- a/data/geany.css
+++ b/data/geany.css
@@ -22,6 +22,7 @@
 }
 #geany-search-entry-no-match:selected /* GTK < 3.20 */,
 #geany-search-entry-no-match selection /* GTK >= 3.20 */ {
+	color: #fff;
 	background-color: #771111;
 }
 

--- a/data/geany.gtkrc
+++ b/data/geany.gtkrc
@@ -21,6 +21,7 @@ style "geany-search-entry-no-match-style" {
 	base[NORMAL] = "#ffff66666666"
 	text[NORMAL] = "#ffffffffffff"
 	base[SELECTED] = "#777711111111"
+	text[SELECTED] = "#ffffffffffff"
 	# try and remove the entry background image on pixmap engine so that our
 	# background color is visible, and we don't end up with white text on white
 	# background (workaround for Adwaita 3.20).


### PR DESCRIPTION
Some Gtk themes define a dark foreground color for selected text, so when we
set the background to dark red, it becomes difficult to read. We must therefore
set a foreground color that will remain legible against our background.

Fixes #2332