### PR TITLE
Changed default title length from 30 to 80.

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -384,7 +384,7 @@ void ui_set_window_title(GeanyDocument *doc)
 			g_string_append(str, DOC_FILENAME(doc));
 		else
 		{
-			gchar *short_name = document_get_basename_for_display(doc, 30);
+			gchar *short_name = document_get_basename_for_display(doc, 80);
 			gchar *dirname = g_path_get_dirname(DOC_FILENAME(doc));
 
 			g_string_append(str, short_name);


### PR DESCRIPTION
Changed the default file name length in the title bar from 30 to 80. 

Fulfills: Enhancement Request - File Name in Title Bar Too Short #2334