### PR TITLE
Messages tab: Show Find Usage matches in bold

### DIFF
--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -440,11 +440,33 @@ void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *
  * @param string    Message to be added.
  *
  * @see msgwin_msg_add()
- *
  * @since 1.34 (API 236)
  **/
 GEANY_API_SYMBOL
 void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const gchar *string)
+{
+	gchar *tmp = g_markup_escape_text(string, -1);
+	
+	msgwin_msg_add_markup(msg_color, line, doc, tmp);
+	g_free(tmp);
+}
+
+
+/* *
+ * Adds a new message in the messages tab treeview in the messages window.
+ *
+ * If @a line and @a doc are set, clicking on this line jumps into the
+ * file which is specified by @a doc into the line specified with @a line.
+ *
+ * @param msg_color A color to be used for the text. It must be an element of #MsgColors.
+ * @param line      The document's line where the message belongs to. Set to @c -1 to ignore.
+ * @param doc       @nullable The document. Set to @c NULL to ignore.
+ * @param markup    Marked up text to be added.
+ *
+ * @see msgwin_msg_add_string()
+ * @since ???
+ **/
+void msgwin_msg_add_markup(gint msg_color, gint line, GeanyDocument *doc, const gchar *markup)
 {
 	GtkTreeIter iter;
 	const GdkColor *color = get_color(msg_color);
@@ -458,14 +480,12 @@ void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const 
 	/* work around a strange problem when adding very long lines(greater than 4000 bytes)
 	 * cut the string to a maximum of 1024 bytes and discard the rest */
 	/* TODO: find the real cause for the display problem / if it is GtkTreeView file a bug report */
-	len = strlen(string);
+	len = strlen(markup);
 	if (len > 1024)
-		tmp = g_strndup(string, 1024);
+		tmp = g_strndup(markup, 1024);
 	else
-		tmp = g_strdup(string);
+		tmp = g_strdup(markup);
 	
-	SETPTR(tmp, g_markup_escape_text(tmp, -1));
-
 	if (! g_utf8_validate(tmp, -1, NULL))
 		utf8_msg = utils_get_utf8_from_locale(tmp);
 	else

--- a/src/msgwindow.h
+++ b/src/msgwindow.h
@@ -59,7 +59,8 @@ void msgwin_compiler_add_string(gint msg_color, const gchar *msg);
 
 void msgwin_msg_add(gint msg_color, gint line, GeanyDocument *doc, const gchar *format, ...)
 			G_GNUC_PRINTF (4, 5);
-void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const char *msg);
+void msgwin_msg_add_string(gint msg_color, gint line, GeanyDocument *doc, const gchar *string);
+void msgwin_msg_add_markup(gint msg_color, gint line, GeanyDocument *doc, const gchar *markup);
 
 void msgwin_clear_tab(gint tabnum);
 

--- a/src/search.c
+++ b/src/search.c
@@ -2145,10 +2145,9 @@ gint search_find_text(ScintillaObject *sci, GeanyFindFlags flags, struct Sci_Tex
 
 static gint find_document_usage(GeanyDocument *doc, const gchar *search_text, GeanyFindFlags flags)
 {
-	gchar *buffer, *short_file_name;
+	gchar *short_file_name;
 	struct Sci_TextToFind ttf;
 	gint count = 0;
-	gint prev_line = -1;
 	GSList *match, *matches;
 
 	g_return_val_if_fail(DOC_VALID(doc), 0);
@@ -2164,17 +2163,14 @@ static gint find_document_usage(GeanyDocument *doc, const gchar *search_text, Ge
 	{
 		GeanyMatchInfo *info = match->data;
 		gint line = sci_get_line_from_position(doc->editor->sci, info->start);
-
-		if (line != prev_line)
-		{
-			buffer = sci_get_line(doc->editor->sci, line);
-			msgwin_msg_add(COLOR_BLACK, line + 1, doc,
-				"%s:%d: %s", short_file_name, line + 1, g_strstrip(buffer));
-			g_free(buffer);
-			prev_line = line;
-		}
+		gchar *buffer = sci_get_line(doc->editor->sci, line);
+		gchar *markup = g_markup_printf_escaped("<u>%s:%d:</u> %s",
+			short_file_name, line + 1, g_strstrip(buffer));
+			
+		g_free(buffer);
+		msgwin_msg_add_markup(COLOR_BLACK, line + 1, doc, markup);
+		g_free(markup);
 		count++;
-
 		geany_match_info_free(info);
 	}
 	g_slist_free(matches);


### PR DESCRIPTION
* Add function msgwin_msg_add_markup()
* Underline Find Usage filename and line

Screenshot of regex match:
![image](https://user-images.githubusercontent.com/1107820/66309938-cffa3b00-e902-11e9-864b-2f8e7c73788d.png)
