### PR TITLE
Notebook tab menu: Move tab filenames to a button menu at end of tabs

### DIFF
--- a/src/notebook.c
+++ b/src/notebook.c
@@ -485,17 +485,17 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	menu_item = gtk_image_menu_item_new_from_stock(GTK_STOCK_CLOSE, NULL);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(notebook_tab_close_clicked_cb), doc);
-	gtk_widget_set_sensitive(GTK_WIDGET(menu_item), (doc != NULL));
+	gtk_widget_set_sensitive(menu_item, (doc != NULL));
 
 	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("Close Ot_her Documents"));
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_other_documents1_activate), doc);
-	gtk_widget_set_sensitive(GTK_WIDGET(menu_item), (doc != NULL));
+	gtk_widget_set_sensitive(menu_item, (doc != NULL));
 
 	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("Close Documents to the _Right"));
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_documents_right_activate), doc);
-	gtk_widget_set_sensitive(GTK_WIDGET(menu_item), doc != NULL && has_tabs_on_right(doc));
+	gtk_widget_set_sensitive(menu_item, doc != NULL && has_tabs_on_right(doc));
 
 	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("C_lose All"));
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -465,16 +465,13 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 
 	/* clear the old menu items */
 	gtk_container_foreach(GTK_CONTAINER(menu), (GtkCallback) gtk_widget_destroy, NULL);
-
 	ui_menu_add_document_items(GTK_MENU(menu), document_get_current(),
 		G_CALLBACK(tab_bar_menu_activate_cb));
 
 	menu_item = gtk_separator_menu_item_new();
-	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 
 	menu_item = ui_image_menu_item_new(GTK_STOCK_OPEN, _("Open in New _Window"));
-	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate",
 		G_CALLBACK(on_open_in_new_window_activate), doc);
@@ -483,32 +480,28 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 		gtk_widget_set_sensitive(menu_item, FALSE);
 
 	menu_item = gtk_separator_menu_item_new();
-	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 
 	menu_item = gtk_image_menu_item_new_from_stock(GTK_STOCK_CLOSE, NULL);
-	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(notebook_tab_close_clicked_cb), doc);
 	gtk_widget_set_sensitive(GTK_WIDGET(menu_item), (doc != NULL));
 
 	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("Close Ot_her Documents"));
-	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_other_documents1_activate), doc);
 	gtk_widget_set_sensitive(GTK_WIDGET(menu_item), (doc != NULL));
 
 	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("Close Documents to the _Right"));
-	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_documents_right_activate), doc);
 	gtk_widget_set_sensitive(GTK_WIDGET(menu_item), doc != NULL && has_tabs_on_right(doc));
 
 	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("C_lose All"));
-	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_all1_activate), NULL);
 
+	gtk_widget_show_all(menu);
 	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event->button, event->time);
 }
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -465,6 +465,11 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 		gtk_widget_destroy(menu); // recreate to update menu item sensitivity
 	menu = gtk_menu_new();
 
+	menu_item = gtk_image_menu_item_new_from_stock(GTK_STOCK_CLOSE, NULL);
+	gtk_container_add(GTK_CONTAINER(menu), menu_item);
+	g_signal_connect(menu_item, "activate", G_CALLBACK(notebook_tab_close_clicked_cb), doc);
+	gtk_widget_set_sensitive(menu_item, (doc != NULL));
+
 	menu_item = ui_image_menu_item_new(GTK_STOCK_OPEN, _("Open in New _Window"));
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate",
@@ -475,11 +480,6 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 
 	menu_item = gtk_separator_menu_item_new();
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
-
-	menu_item = gtk_image_menu_item_new_from_stock(GTK_STOCK_CLOSE, NULL);
-	gtk_container_add(GTK_CONTAINER(menu), menu_item);
-	g_signal_connect(menu_item, "activate", G_CALLBACK(notebook_tab_close_clicked_cb), doc);
-	gtk_widget_set_sensitive(menu_item, (doc != NULL));
 
 	menu_item = ui_image_menu_item_new(GTK_STOCK_CLOSE, _("Close Ot_her Documents"));
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);


### PR DESCRIPTION
The existing popup menu lists all the notebook tabs first then shows command items below. This means the command items are harder to access (user has to move mouse further). They can also get pushed off screen when there are many tabs open (see https://github.com/geany/geany/pull/2346#issuecomment-539842133). Instead, let's split up the menu for better UX.

New notebook action widget menu, left or right click ☰ button:
![image](https://user-images.githubusercontent.com/1107820/66484161-63b43e80-ea9e-11e9-9d58-b6efef850baf.png)

Commands-only tab menu:
![image](https://user-images.githubusercontent.com/1107820/66500598-b6e7ba80-eab9-11e9-8908-3fb43bed2bdb.png)

The single close item has been grouped separately and put first because:

> This will be the most common choice for anyone who disables notebook tabs.
This also groups the commands closing multiple documents separately from the other commands. Closing multiple documents is a more drastic action so should be grouped separately.