### PR TITLE
Ask whether to open new files from command-line

### DIFF
--- a/src/libmain.c
+++ b/src/libmain.c
@@ -831,7 +831,14 @@ gboolean main_handle_filename(const gchar *locale_filename)
 		if (doc)
 			document_show_tab(doc);
 		else
-			doc = document_new_file(utf8_filename, NULL, NULL);
+		{
+			gchar *msg = g_strdup_printf("%s?", _("Create a new file"));
+			if (dialogs_show_question_full(NULL,
+				GTK_STOCK_NEW, GTK_STOCK_CANCEL, msg,
+				_("Could not find file '%s'."), utf8_filename))
+				doc = document_new_file(utf8_filename, NULL, NULL);
+			g_free(msg);
+		}
 		if (doc != NULL)
 			ui_add_recent_document(doc);
 		g_free(utf8_filename);


### PR DESCRIPTION
I sometimes try to open a file from a terminal and pass the wrong path. Asking the user to confirm the new file solves this problem, they can easily press escape to cancel the new document.

Occasionally I might use a glob that turns out to be wrong too, creating many unwanted new documents. So I made cancelling a new document ignore any remaining new filenames passed to Geany.

![image](https://user-images.githubusercontent.com/1107820/67089763-58e56200-f1a0-11e9-9dd3-133a0b0ac3b7.png)
