### PR TITLE
Find in Files: Put extra options after generated --include options

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -1565,16 +1565,6 @@ static GString *get_grep_options(void)
 	else
 		g_string_append_c(gstr, 'E');
 
-	if (settings.fif_use_extra_options)
-	{
-		g_strstrip(settings.fif_extra_options);
-
-		if (*settings.fif_extra_options != 0)
-		{
-			g_string_append_c(gstr, ' ');
-			g_string_append(gstr, settings.fif_extra_options);
-		}
-	}
 	g_strstrip(settings.fif_files);
 	if (settings.fif_files_mode != FILES_MODE_ALL && *settings.fif_files)
 	{
@@ -1587,6 +1577,16 @@ static GString *get_grep_options(void)
 		utils_string_replace_all(tmp, " ", " --include=");
 		g_string_append(gstr, tmp->str);
 		g_string_free(tmp, TRUE);
+	}
+	if (settings.fif_use_extra_options)
+	{
+		g_strstrip(settings.fif_extra_options);
+
+		if (*settings.fif_extra_options != 0)
+		{
+			g_string_append_c(gstr, ' ');
+			g_string_append(gstr, settings.fif_extra_options);
+		}
 	}
 	return gstr;
 }


### PR DESCRIPTION
This fixes #2321, allowing --exclude to override --include.