### PR TITLE
Fix shell script generation in build.c

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -1169,7 +1169,7 @@ static gchar *build_create_shellscript(const gchar *working_dir, const gchar *cm
 	if (!g_file_set_contents(fname, str, -1, error))
 		success = FALSE;
 	g_free(str);
-#ifdef __APPLE__
+
 	if (success && g_chmod(fname, 0777) != 0)
 	{
 		if (error)
@@ -1181,7 +1181,6 @@ static gchar *build_create_shellscript(const gchar *working_dir, const gchar *cm
 		}
 		success = FALSE;
 	}
-#endif
 
 	if (!success)
 	{


### PR DESCRIPTION
(On my system) the "run" build commands didn't work (the opened term said the run script was not executable). For some reason the code here only made the run script executable on apple platforms. I removed this limitation to have the file chmod'ed on all unixoid platforms.

Works on my machine.

I'm very new to patches and PRs and such, lmk if i'm doing this wrong :)

Cheers