### PR TITLE
R outline improved for environments and R6 classes, = sign added as well

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -545,8 +545,10 @@ static void add_top_level_items(GeanyDocument *doc)
 		case GEANY_FILETYPES_R:
 		{
 			tag_list_add_groups(tag_store,
+                &(tv_iters.tag_other), _("Libraries"), ICON_NAMESPACE,
+                &(tv_iters.tag_class), _("Classes"), ICON_CLASS,
 				&(tv_iters.tag_function), _("Functions"), ICON_METHOD,
-				&(tv_iters.tag_other), _("Other"), ICON_NONE,
+				
 				NULL);
 			break;
 		}

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -418,6 +418,7 @@ static TMParserMapEntry map_VERILOG[] = {
 };
 
 static TMParserMapEntry map_R[] = {
+    {'c', tm_tag_class_t},
 	{'f', tm_tag_function_t},
 	{'l', tm_tag_other_t},
 	{'s', tm_tag_other_t},


### PR DESCRIPTION
Dear Reviewer of this pull request. The suggested pull request improves the outline facilitities for R using geany. First it is now possible also to use the = sign as the assignment operator for functions, secondly I added support for R6Class(es), environments (new.env) and a generic RxClass which can be used as well for outline creation. The latter allows for instance to write workaround code like 
RxClass = proto 
# and then 
obj=RxClass()
th
Best regards,
Detlef Groth