### PR TITLE
Added filename support to status bar template

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -304,6 +304,8 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 				g_string_append_printf(stats_str, "%d",
 					sci_get_style_at(doc->editor->sci, pos));
 				break;
+			case 'N':
+				g_string_append(stats_str, DOC_FILENAME(doc));
 			default:
 				g_string_append_len(stats_str, expos, 1);
 		}


### PR DESCRIPTION
Using '%N' in template to display current document filename on status bar