### PR TITLE
Rewrite HL_N_ENTRIES macro to avoid a GCC8 false positive warning

### DIFF
--- a/src/highlightingmappings.h
+++ b/src/highlightingmappings.h
@@ -68,8 +68,16 @@ typedef struct
 #define EMPTY_KEYWORDS		((HLKeyword *) NULL)
 #define EMPTY_PROPERTIES	((HLProperty *) NULL)
 
-/* like G_N_ELEMENTS() but supports @array being NULL (for empty entries) */
-#define HL_N_ENTRIES(array) ((array != NULL) ? G_N_ELEMENTS(array) : 0)
+/* like G_N_ELEMENTS() but supports @array being NULL (for empty entries).
+ * The straightforward `((array != NULL) ? G_N_ELEMENTS(array) : 0)` is not
+ * used here because of GCC8's -Wsizeof-pointer-div which doesn't realize the
+ * result of G_N_ELEMENTS() is never actually used when `array` is NULL.
+ * This implementation gives the same result as the LHS of the division
+ * becomes 0 when `array` is NULL, but is not a case that GCC can misinterpret
+ * and warn about.
+ * An alternative solution would be using zero-sized arrays instead of NULLs,
+ * but zero-sized arrays are forbidden by ISO C */
+#define HL_N_ENTRIES(array) ((sizeof(array) * ((array) != NULL)) / sizeof((array)[0]))
 
 
 /* Abaqus */


### PR DESCRIPTION
GCC 8 introduced `-Wsizeof-pointer-div` which is enabled by `-Wall` and
warns for sizeof divisions that look like they would compute the size
of a static array but are called on something on which this doesn't
work (e.g. a pointer as LHS).  This is quite reasonable and useful, but
it fails to detect the case where the computation is guarded against
being called on problematic values, like our HL_N_ENTRIES() macro that
accepts NULLs but won't use the sizeof computation result then.

Work around this by implementing HL_N_ENTRIES() macro in a way that
cannot trigger such a warning yet yield the same result.

Example warning:
```
../../src/highlighting.c: In function ‘highlighting_init_styles’:
/usr/include/glib-2.0/glib/gmacros.h:351:42: warning: division ‘sizeof (HLKeyword * {aka struct <anonymous> *}) / sizeof (HLKeyword {aka struct <anonymous>})’ does not compute the number of array elements [-Wsizeof-pointer-div]
 #define G_N_ELEMENTS(arr)  (sizeof (arr) / sizeof ((arr)[0]))
                                          ^
../../src/highlightingmappings.h:74:48: note: in expansion of macro ‘G_N_ELEMENTS’
 #define HL_N_ENTRIES(array) ((array != NULL) ? G_N_ELEMENTS(array) : 0)
                                                ^~~~~~~~~~~~
../../src/highlighting.c:966:5: note: in expansion of macro ‘HL_N_ENTRIES’
     HL_N_ENTRIES(highlighting_keywords_##LANG_NAME)); \
     ^~~~~~~~~~~~
../../src/highlighting.c:1011:3: note: in expansion of macro ‘init_styleset_case’
   init_styleset_case(CONF);
   ^~~~~~~~~~~~~~~~~~
```

---
Another solution could be reporting a bug to GCC for it to detect our use case and avoid the warning then, but that might or might not be much meaningful, and won't fix the issue on currently affected GCC versions anyway.