### PR TITLE
Include <unistd.h> for pathconf()

### DIFF
--- a/src/tagmanager/tm_source_file.c
+++ b/src/tagmanager/tm_source_file.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include <glib/gstdio.h>
 #ifdef G_OS_WIN32
 # define VC_EXTRALEAN


### PR DESCRIPTION
The `get_path_max()` function uses `pathconf()` in case `PATH_MAX` is not defined, and for that `<unistd.h>` is needed.