### PR TITLE
Add "Comment Blank Line(s)" option

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -2922,6 +2922,22 @@
                                   </packing>
                                 </child>
                                 <child>
+                                  <object class="GtkCheckButton" id="check_comment_blank_lines">
+                                    <property name="label" translatable="yes">Comment blank line(s)</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="tooltip_text" translatable="yes">Enable blank line(s) to also be commented</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">7</property>
+                                  </packing>
+                                </child>
+                                <child>
                                   <object class="GtkHBox" id="hbox11">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
@@ -2961,7 +2977,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
-                                    <property name="position">7</property>
+                                    <property name="position">8</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -3002,7 +3018,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
-                                    <property name="position">8</property>
+                                    <property name="position">9</property>
                                   </packing>
                                 </child>
                               </object>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2098,6 +2098,17 @@ Newline strips trailing spaces
     setting will clear a blank line, it will not set the next line
     indentation back to zero.
 
+Comment blank line(s)
+    When commenting line(s) -- Edit=>Format=>Comment Line(s) or
+    Toggle Line Commentation -- this will also add the comment tag to
+    blank line(s). This is useful for languages like Ruby, Python, etc.
+    For example, in the below code, the middle line will also be
+    prefixed with "#", if this option is set.
+
+     # puts <<EOD
+     # 
+     # EOD
+
 Line breaking column
     The editor column number to insert a newline at when Line Breaking
     is enabled for the current document.

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1270,7 +1270,7 @@ void on_menu_comment_line1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	GeanyDocument *doc = document_get_current();
 	g_return_if_fail(doc != NULL);
 
-	editor_do_comment(doc->editor, -1, FALSE, FALSE, TRUE);
+	editor_do_comment(doc->editor, -1, editor_prefs.comment_blank_lines, FALSE, TRUE);
 }
 
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -3184,7 +3184,7 @@ void editor_do_comment_toggle(GeanyEditor *editor)
 			}
 
 			/* we are still here, so the above lines were not already comments, so comment it */
-			count_commented += editor_do_comment(editor, i, FALSE, TRUE, TRUE);
+			count_commented += editor_do_comment(editor, i, editor_prefs.comment_blank_lines, TRUE, TRUE);
 		}
 		/* use multi line comment */
 		else

--- a/src/editor.h
+++ b/src/editor.h
@@ -117,6 +117,7 @@ typedef struct GeanyEditorPrefs
 	gboolean	use_tab_to_indent;	/* makes tab key indent instead of insert a tab char */
 	gboolean	smart_home_key;
 	gboolean	newline_strip;
+	gboolean	comment_blank_lines;
 	gboolean	auto_complete_symbols;
 	gboolean	auto_close_xml_tags;
 	gboolean	complete_snippets;

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -483,6 +483,7 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "pref_editor_disable_dnd", editor_prefs.disable_dnd);
 	g_key_file_set_boolean(config, PACKAGE, "pref_editor_smart_home_key", editor_prefs.smart_home_key);
 	g_key_file_set_boolean(config, PACKAGE, "pref_editor_newline_strip", editor_prefs.newline_strip);
+	g_key_file_set_boolean(config, PACKAGE, "pref_editor_comment_blank_lines", editor_prefs.comment_blank_lines);
 	g_key_file_set_integer(config, PACKAGE, "line_break_column", editor_prefs.line_break_column);
 	g_key_file_set_boolean(config, PACKAGE, "auto_continue_multiline", editor_prefs.auto_continue_multiline);
 	g_key_file_set_string(config, PACKAGE, "comment_toggle_mark", editor_prefs.comment_toggle_mark);
@@ -823,6 +824,7 @@ static void load_dialog_prefs(GKeyFile *config)
 	editor_prefs.disable_dnd = utils_get_setting_boolean(config, PACKAGE, "pref_editor_disable_dnd", FALSE);
 	editor_prefs.smart_home_key = utils_get_setting_boolean(config, PACKAGE, "pref_editor_smart_home_key", TRUE);
 	editor_prefs.newline_strip = utils_get_setting_boolean(config, PACKAGE, "pref_editor_newline_strip", FALSE);
+	editor_prefs.comment_blank_lines = utils_get_setting_boolean(config, PACKAGE, "pref_editor_comment_blank_lines", FALSE);
 	editor_prefs.line_break_column = utils_get_setting_integer(config, PACKAGE, "line_break_column", 72);
 	editor_prefs.auto_continue_multiline = utils_get_setting_boolean(config, PACKAGE, "auto_continue_multiline", TRUE);
 	editor_prefs.comment_toggle_mark = utils_get_setting_string(config, PACKAGE, "comment_toggle_mark", GEANY_TOGGLE_MARK);

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -634,6 +634,9 @@ static void prefs_init_dialog(void)
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_newline_strip");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.newline_strip);
 
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_comment_blank_lines");
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.comment_blank_lines);
+
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_indicators");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.use_indicators);
 
@@ -1105,6 +1108,9 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_newline_strip");
 		editor_prefs.newline_strip = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_comment_blank_lines");
+		editor_prefs.comment_blank_lines = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_auto_multiline");
 		editor_prefs.auto_continue_multiline = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));


### PR DESCRIPTION
In `Edit=>Preferences=>Editor.Features`, I added a checkbox "Comment blank line(s)" for issue #2239.

When this option is turned on and when commenting (`Edit=>Format=>Comment Line(s)`) or toggling comments (`Ctrl+E`), blank (empty) line(s) will also be commented.

For example, if you comment this code...

```Ruby
puts <<EOD

EOD
```

..., it will do this:

```Ruby
# puts <<EOD
# 
# EOD
```

It should work for Comment, Uncomment, Toggle, and Undo/Redo. By default, it is off/false.

If this merge is accepted, `doc/geany.html` and the screenshot in this HTML file will need to be updated.

![features](https://user-images.githubusercontent.com/16524392/76850364-3310d600-6882-11ea-94de-b3f4e38585f9.png)