### PR TITLE
Set a default widget name on all GtkBuilder widgets.

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2491,6 +2491,11 @@ void ui_init_builder(void)
 			g_warning("Unable to get name from GtkBuilder object");
 			continue;
 		}
+		else
+		{
+			/* Set a default name for use from CSS by name */
+			gtk_widget_set_name(widget, name);
+		}
 
 		toplevel = ui_get_top_parent(widget);
 		if (toplevel)


### PR DESCRIPTION
Allows selecting individual widgets in Gtk CSS using `#name` selector.

For example the snippet [from my comment](https://github.com/geany/geany/issues/2468#issuecomment-610695277) on #2468 could be made to apply to just the document notebook like:

```css
notebook#notebook1 > header.left > tabs > tab {
	padding: 0px 12px 0px 12px;
}
```

Tested with Gtk Inspector.