### PR TITLE
Make the search marker translucency configurable

### DIFF
--- a/data/filedefs/filetypes.common
+++ b/data/filedefs/filetypes.common
@@ -42,6 +42,9 @@ marker_mark=marker_mark
 # translucency for the line marker(first argument) and the search marker (second argument)
 marker_translucency=256;256
 
+# translucency (0-255) for the search marker's outline (first argument) and background (second argument)
+marker_search_translucency=50;60
+
 # colour of the caret(the blinking cursor), only first and third argument is interpreted
 # set the third argument to true to change the caret into a block caret
 caret=caret

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -106,7 +106,7 @@ Requirements
 You will need the GTK (>= 2.24) libraries and their dependencies
 (Pango, GLib and ATK). Your distro should provide packages for these,
 usually installed by default. For Windows, you can download an installer
-from the website which bundles these libraries.
+from the website which bundles these libraries.marker_mark
 
 
 Binary packages
@@ -4622,6 +4622,14 @@ marker_search
     Only the second argument is interpreted.
 
     *Example:* ``marker_search=0x000000;0xb8f4b8;false;false``
+
+marker_search_translucency
+    Translucency for the search marker's outline (first argument) and
+    background (second argument). Values between 0 and 255 are accepted.
+
+    Only the first and second arguments are interpreted.
+
+    *Example:* ``marker_search_translucency=127;64``
 
 marker_mark
     The style for a marked line (e.g when using the "Toggle Marker" keybinding

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -106,7 +106,7 @@ Requirements
 You will need the GTK (>= 2.24) libraries and their dependencies
 (Pango, GLib and ATK). Your distro should provide packages for these,
 usually installed by default. For Windows, you can download an installer
-from the website which bundles these libraries.marker_mark
+from the website which bundles these libraries.
 
 
 Binary packages

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -665,7 +665,7 @@ static void styleset_common(ScintillaObject *sci, guint ft_id)
 	 * cursor positions. */
 	SSM(sci, SCI_INDICSETSTYLE, GEANY_INDICATOR_SNIPPET, INDIC_DOTBOX);
 	SSM(sci, SCI_INDICSETALPHA, GEANY_INDICATOR_SNIPPET, 60);
-	
+
 	/* define marker symbols
 	 * 0 -> line marker */
 	SSM(sci, SCI_MARKERDEFINE, 0, SC_MARK_SHORTARROW);

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -91,6 +91,7 @@ enum	/* Geany common styling */
 	GCS_TRANSLUCENCY,
 	GCS_MARKER_LINE,
 	GCS_MARKER_SEARCH,
+	GCS_MARKER_SEARCH_TRANSLUCENCY,
 	GCS_MARKER_MARK,
 	GCS_MARKER_TRANSLUCENCY,
 	GCS_LINE_HEIGHT,
@@ -574,6 +575,8 @@ static void styleset_common_init(GKeyFile *config, GKeyFile *config_home)
 		256, 256, &common_style_set.styling[GCS_TRANSLUCENCY]);
 	get_keyfile_int(config, config_home, "styling", "marker_translucency",
 		256, 256, &common_style_set.styling[GCS_MARKER_TRANSLUCENCY]);
+	get_keyfile_int(config, config_home, "styling", "marker_search_translucency",
+		50, 60, &common_style_set.styling[GCS_MARKER_SEARCH_TRANSLUCENCY]);
 	get_keyfile_int(config, config_home, "styling", "line_height",
 		0, 0, &common_style_set.styling[GCS_LINE_HEIGHT]);
 
@@ -655,13 +658,14 @@ static void styleset_common(ScintillaObject *sci, guint ft_id)
 	SSM(sci, SCI_INDICSETSTYLE, GEANY_INDICATOR_SEARCH, INDIC_ROUNDBOX);
 	SSM(sci, SCI_INDICSETFORE, GEANY_INDICATOR_SEARCH,
 		invert(common_style_set.styling[GCS_MARKER_SEARCH].background));
-	SSM(sci, SCI_INDICSETALPHA, GEANY_INDICATOR_SEARCH, 60);
+	SSM(sci, SCI_INDICSETALPHA, GEANY_INDICATOR_SEARCH, common_style_set.styling[GCS_MARKER_SEARCH_TRANSLUCENCY].background);
+	SSM(sci, SCI_INDICSETOUTLINEALPHA, GEANY_INDICATOR_SEARCH, common_style_set.styling[GCS_MARKER_SEARCH_TRANSLUCENCY].foreground);
 
 	/* Snippet cursor indicator, when inserting snippets with multiple
 	 * cursor positions. */
 	SSM(sci, SCI_INDICSETSTYLE, GEANY_INDICATOR_SNIPPET, INDIC_DOTBOX);
 	SSM(sci, SCI_INDICSETALPHA, GEANY_INDICATOR_SNIPPET, 60);
-
+	
 	/* define marker symbols
 	 * 0 -> line marker */
 	SSM(sci, SCI_MARKERDEFINE, 0, SC_MARK_SHORTARROW);


### PR DESCRIPTION
Search marker is too translucent, barely visible with my theme. Currently, translucency is hardwired at 60. This pull request makes the search marker translucency configurable.

This patch is tested and working. Solved my problem beautifully.