### PR TITLE
Show OS info in debug messages

### DIFF
--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1160,6 +1160,17 @@ gint main_lib(gint argc, gchar **argv)
 	geany_debug(geany_lib_versions,
 		gtk_major_version, gtk_minor_version, gtk_micro_version,
 		glib_major_version, glib_minor_version, glib_micro_version);
+
+#if GLIB_CHECK_VERSION(2, 64, 0)
+	gchar *os_prettyname = g_get_os_info(G_OS_INFO_KEY_PRETTY_NAME);
+	gchar *os_codename = g_get_os_info(G_OS_INFO_KEY_VERSION_CODENAME);
+	geany_debug("OS: %s (%s)",
+		os_prettyname ? os_prettyname : "Unknown",
+		os_codename ? os_codename : "Unknown");
+	g_free(os_prettyname);
+	g_free(os_codename);
+#endif
+
 	geany_debug("System data dir: %s", app->datadir);
 	utf8_configdir = utils_get_utf8_from_locale(app->configdir);
 	geany_debug("User config dir: %s", utf8_configdir);


### PR DESCRIPTION
This PR conditionally uses newer GLib API to get information about the OS and to print it in with the existing debug messages. I don't really have a preference on the formatting of the info, this PR is tested against own-built Geany on Ubuntu 20.04.

Example:

```
$ /opt/geany/bin/geany -v -c /tmp/cfg0
Geany-INFO: 23:57:45.734: Using alternate configuration directory
Geany-INFO: 23:57:45.785: Geany 1.37 (git >= ea649d802), en_CA.UTF-8
Geany-INFO: 23:57:45.785: GTK 3.24.18, GLib 2.64.2
Geany-INFO: 23:57:45.785: OS Information:
Geany-INFO: 23:57:45.785:   Name       : Ubuntu (ubuntu/focal)
Geany-INFO: 23:57:45.785:   Pretty Name: Ubuntu 20.04 LTS
Geany-INFO: 23:57:45.785:   Version    : 20.04 LTS (Focal Fossa) (20.04)
Geany-INFO: 23:57:45.785: System data dir: /opt/geany/share/geany
Geany-INFO: 23:57:45.785: User config dir: /tmp/cfg0
```