### PR TITLE
Added 3 More Keybindings

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -495,6 +495,12 @@ static void init_default_kb(void)
 		0, 0, "edit_sendtocmd8", _("Send to Custom Command 8"), NULL);
 	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD9, NULL,
 		0, 0, "edit_sendtocmd9", _("Send to Custom Command 9"), NULL);
+	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD10, NULL,
+		0, 0, "edit_sendtocmd10", _("Send to Custom Command 10"), NULL);
+	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD11, NULL,
+		0, 0, "edit_sendtocmd11", _("Send to Custom Command 11"), NULL);
+	add_kb(group, GEANY_KEYS_FORMAT_SENDTOCMD12, NULL,
+		0, 0, "edit_sendtocmd12", _("Send to Custom Command 12"), NULL);
 	/* may fit better in editor group */
 	add_kb(group, GEANY_KEYS_FORMAT_SENDTOVTE, NULL,
 		0, 0, "edit_sendtovte", _("_Send Selection to Terminal"), "send_selection_to_vte1");

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -275,6 +275,9 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_EDITOR_DELETELINETOBEGINNING,	/**< Keybinding. */
 	GEANY_KEYS_DOCUMENT_STRIPTRAILINGSPACES,	/**< Keybinding.
 												 * @since 1.34 (API 238) */
+	GEANY_KEYS_FORMAT_SENDTOCMD10,				/**< Keybinding. */
+	GEANY_KEYS_FORMAT_SENDTOCMD11,				/**< Keybinding. */
+	GEANY_KEYS_FORMAT_SENDTOCMD12,				/**< Keybinding. */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -558,6 +558,9 @@ static void cc_insert_custom_command_items(GtkMenu *me, const gchar *label, cons
 		case 6: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD7; break;
 		case 7: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD8; break;
 		case 8: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD9; break;
+		case 9: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD10; break;
+		case 10: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD11; break;
+		case 11: key_idx = GEANY_KEYS_FORMAT_SENDTOCMD12; break;
 	}
 
 	item = gtk_menu_item_new_with_label(label);


### PR DESCRIPTION
Added 3 more keybindings for "Send Selection To".

I am obviously missing something. The keybindings are recognized (i.e. I can add more "Sent Selection To" commands and the keybinding will be shown in the menus of "Edit→Format→Send Selection to") and I can run the commands by manually going to "Edit→Format→Send Selection to" and clicking the desired command. However, pressing the keyboard shortcut for these new "Edit→Format→Send Selection to" commands will not run the assigned commands. Perhaps, somebody can point me in the correct direction.