### PR TITLE
Context menu update

### DIFF
--- a/src/notebook.c
+++ b/src/notebook.c
@@ -457,25 +457,25 @@ static void on_close_documents_right_activate(GtkMenuItem *menuitem, GeanyDocume
 
 static void on_copy_filename_to_clipboard_activate(GtkMenuItem *menuitem, GeanyDocument *doc)
 {
-        g_return_if_fail(doc->is_valid);
+		g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_basename(doc->real_path), -1);
+		gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_basename(doc->real_path), -1);
 }
 
 
 static void on_copy_file_path_to_clipboard_activate(GtkMenuItem *menuitem, GeanyDocument *doc)
 {
-        g_return_if_fail(doc->is_valid);
+		g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), doc->real_path, -1);
+		gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), doc->real_path, -1);
 }
 
 
 static void on_copy_file_dir_to_clipboard_activate(GtkMenuItem *menuitem, GeanyDocument *doc)
 {
-        g_return_if_fail(doc->is_valid);
+		g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_dirname(doc->real_path), -1);
+		gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_dirname(doc->real_path), -1);
 }
 
 
@@ -537,32 +537,32 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 
-        menu_item = ui_image_menu_item_new(GTK_STOCK_PASTE, _("Copy filename to clipboard"));
-        gtk_widget_show(menu_item);
-        gtk_container_add(GTK_CONTAINER(menu), menu_item);
-        g_signal_connect(menu_item, "activate",
-                G_CALLBACK(on_copy_filename_to_clipboard_activate), doc);
-        /* disable if not on disk */
-        if (doc == NULL || !doc->real_path)
-                gtk_widget_set_sensitive(menu_item, FALSE);
+		menu_item = ui_image_menu_item_new(GTK_STOCK_PASTE, _("Copy filename to clipboard"));
+		gtk_widget_show(menu_item);
+		gtk_container_add(GTK_CONTAINER(menu), menu_item);
+		g_signal_connect(menu_item, "activate",
+				G_CALLBACK(on_copy_filename_to_clipboard_activate), doc);
+		/* disable if not on disk */
+		if (doc == NULL || !doc->real_path)
+				gtk_widget_set_sensitive(menu_item, FALSE);
 
-        menu_item = ui_image_menu_item_new(GTK_STOCK_PASTE, _("Copy file path to clipboard"));
-        gtk_widget_show(menu_item);
-        gtk_container_add(GTK_CONTAINER(menu), menu_item);
-        g_signal_connect(menu_item, "activate",
-                G_CALLBACK(on_copy_file_path_to_clipboard_activate), doc);
-        /* disable if not on disk */
-        if (doc == NULL || !doc->real_path)
-                gtk_widget_set_sensitive(menu_item, FALSE);
+		menu_item = ui_image_menu_item_new(GTK_STOCK_PASTE, _("Copy file path to clipboard"));
+		gtk_widget_show(menu_item);
+		gtk_container_add(GTK_CONTAINER(menu), menu_item);
+		g_signal_connect(menu_item, "activate",
+				G_CALLBACK(on_copy_file_path_to_clipboard_activate), doc);
+		/* disable if not on disk */
+		if (doc == NULL || !doc->real_path)
+				gtk_widget_set_sensitive(menu_item, FALSE);
 
-        menu_item = ui_image_menu_item_new(GTK_STOCK_PASTE, _("Copy file directory to clipboard"));
-        gtk_widget_show(menu_item);
-        gtk_container_add(GTK_CONTAINER(menu), menu_item);
-        g_signal_connect(menu_item, "activate",
-                G_CALLBACK(on_copy_file_dir_to_clipboard_activate), doc);
-        /* disable if not on disk */
-        if (doc == NULL || !doc->real_path)
-                gtk_widget_set_sensitive(menu_item, FALSE);
+		menu_item = ui_image_menu_item_new(GTK_STOCK_PASTE, _("Copy file directory to clipboard"));
+		gtk_widget_show(menu_item);
+		gtk_container_add(GTK_CONTAINER(menu), menu_item);
+		g_signal_connect(menu_item, "activate",
+				G_CALLBACK(on_copy_file_dir_to_clipboard_activate), doc);
+		/* disable if not on disk */
+		if (doc == NULL || !doc->real_path)
+				gtk_widget_set_sensitive(menu_item, FALSE);
 
 	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event->button, event->time);
 }

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -467,7 +467,7 @@ static void on_copy_file_path_to_clipboard_activate(GtkMenuItem *menuitem, Geany
 {
         g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_dirname(doc->real_path))
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), doc->real_path)
 }
 
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -463,6 +463,14 @@ static void on_copy_filename_to_clipboard_activate(GtkMenuItem *menuitem, GeanyD
 }
 
 
+static void on_copy_file_path_to_clipboard_activate(GtkMenuItem *menuitem, GeanyDocument *doc)
+{
+        g_return_if_fail(doc->is_valid);
+
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_dirname(doc->real_path))
+}
+
+
 static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 {
 	GtkWidget *menu_item;

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -513,6 +513,33 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 
+        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("To clipboard filename"));
+        gtk_widget_show(menu_item);
+        gtk_container_add(GTK_CONTAINER(menu), menu_item);
+        g_signal_connect(menu_item, "activate",
+                G_CALLBACK(on_to_clipboard_filename), doc);
+        /* disable if not on disk */
+        if (doc == NULL || !doc->real_path)
+                gtk_widget_set_sensitive(menu_item, FALSE);
+
+        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("To clipboard full file path."));
+        gtk_widget_show(menu_item);
+        gtk_container_add(GTK_CONTAINER(menu), menu_item);
+        g_signal_connect(menu_item, "activate",
+                G_CALLBACK(on_to_clipboard_full_file_path), doc);
+        /* disable if not on disk */
+        if (doc == NULL || !doc->real_path)
+                gtk_widget_set_sensitive(menu_item, FALSE);
+
+        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("To clipboard file directory"));
+        gtk_widget_show(menu_item);
+        gtk_container_add(GTK_CONTAINER(menu), menu_item);
+        g_signal_connect(menu_item, "activate",
+                G_CALLBACK(on_to_clipboard_file_dir), doc);
+        /* disable if not on disk */
+        if (doc == NULL || !doc->real_path)
+                gtk_widget_set_sensitive(menu_item, FALSE);
+
 
 	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event->button, event->time);
 }

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -513,33 +513,32 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 
-        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("To clipboard filename"));
+        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("Copy filename to clipboard"));
         gtk_widget_show(menu_item);
         gtk_container_add(GTK_CONTAINER(menu), menu_item);
         g_signal_connect(menu_item, "activate",
-                G_CALLBACK(on_to_clipboard_filename), doc);
+                G_CALLBACK(on_copy_filename_to_clipboard_activate), doc);
         /* disable if not on disk */
         if (doc == NULL || !doc->real_path)
                 gtk_widget_set_sensitive(menu_item, FALSE);
 
-        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("To clipboard full file path."));
+        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("Copy file path to clipboard"));
         gtk_widget_show(menu_item);
         gtk_container_add(GTK_CONTAINER(menu), menu_item);
         g_signal_connect(menu_item, "activate",
-                G_CALLBACK(on_to_clipboard_full_file_path), doc);
+                G_CALLBACK(on_copy_file_path_to_clipboard_activate), doc);
         /* disable if not on disk */
         if (doc == NULL || !doc->real_path)
                 gtk_widget_set_sensitive(menu_item, FALSE);
 
-        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("To clipboard file directory"));
+        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("Copy file directory to clipboard"));
         gtk_widget_show(menu_item);
         gtk_container_add(GTK_CONTAINER(menu), menu_item);
         g_signal_connect(menu_item, "activate",
-                G_CALLBACK(on_to_clipboard_file_dir), doc);
+                G_CALLBACK(on_copy_file_dir_to_clipboard_activate), doc);
         /* disable if not on disk */
         if (doc == NULL || !doc->real_path)
                 gtk_widget_set_sensitive(menu_item, FALSE);
-
 
 	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event->button, event->time);
 }

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -509,6 +509,11 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_all1_activate), NULL);
 
+	menu_item = gtk_separator_menu_item_new();
+	gtk_widget_show(menu_item);
+	gtk_container_add(GTK_CONTAINER(menu), menu_item);
+
+
 	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, event->button, event->time);
 }
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -455,6 +455,15 @@ static void on_close_documents_right_activate(GtkMenuItem *menuitem, GeanyDocume
 }
 
 
+static void on_copy_filename_to_clipboard_activate(GtkMenuItem *menuitem, GeanyDocument *doc)
+{
+        g_return_if_fail(doc->is_valid);
+
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_basename(doc->file_name))
+
+}
+
+
 static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 {
 	GtkWidget *menu_item;

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -471,6 +471,14 @@ static void on_copy_file_path_to_clipboard_activate(GtkMenuItem *menuitem, Geany
 }
 
 
+static void on_copy_file_dir_to_clipboard_activate(GtkMenuItem *menuitem, GeanyDocument *doc)
+{
+        g_return_if_fail(doc->is_valid);
+
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_dirname(doc->real_path))
+}
+
+
 static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 {
 	GtkWidget *menu_item;

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -459,7 +459,7 @@ static void on_copy_filename_to_clipboard_activate(GtkMenuItem *menuitem, GeanyD
 {
         g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_basename(doc->real_path), -1)
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_basename(doc->real_path), -1);
 }
 
 
@@ -467,7 +467,7 @@ static void on_copy_file_path_to_clipboard_activate(GtkMenuItem *menuitem, Geany
 {
         g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), doc->real_path, -1)
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), doc->real_path, -1);
 }
 
 
@@ -475,7 +475,7 @@ static void on_copy_file_dir_to_clipboard_activate(GtkMenuItem *menuitem, GeanyD
 {
         g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_dirname(doc->real_path), -1)
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_dirname(doc->real_path), -1);
 }
 
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -459,8 +459,7 @@ static void on_copy_filename_to_clipboard_activate(GtkMenuItem *menuitem, GeanyD
 {
         g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_basename(doc->file_name))
-
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_basename(doc->real_path))
 }
 
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -459,7 +459,7 @@ static void on_copy_filename_to_clipboard_activate(GtkMenuItem *menuitem, GeanyD
 {
         g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_basename(doc->real_path))
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_basename(doc->real_path), -1)
 }
 
 
@@ -467,7 +467,7 @@ static void on_copy_file_path_to_clipboard_activate(GtkMenuItem *menuitem, Geany
 {
         g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), doc->real_path)
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), doc->real_path, -1)
 }
 
 
@@ -475,7 +475,7 @@ static void on_copy_file_dir_to_clipboard_activate(GtkMenuItem *menuitem, GeanyD
 {
         g_return_if_fail(doc->is_valid);
 
-        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_dirname(doc->real_path))
+        gtk_clipboard_set_text(gtk_clipboard_get(GDK_NONE), g_path_get_dirname(doc->real_path), -1)
 }
 
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -537,7 +537,7 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	gtk_widget_show(menu_item);
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 
-        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("Copy filename to clipboard"));
+        menu_item = ui_image_menu_item_new(GTK_STOCK_PASTE, _("Copy filename to clipboard"));
         gtk_widget_show(menu_item);
         gtk_container_add(GTK_CONTAINER(menu), menu_item);
         g_signal_connect(menu_item, "activate",
@@ -546,7 +546,7 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
         if (doc == NULL || !doc->real_path)
                 gtk_widget_set_sensitive(menu_item, FALSE);
 
-        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("Copy file path to clipboard"));
+        menu_item = ui_image_menu_item_new(GTK_STOCK_PASTE, _("Copy file path to clipboard"));
         gtk_widget_show(menu_item);
         gtk_container_add(GTK_CONTAINER(menu), menu_item);
         g_signal_connect(menu_item, "activate",
@@ -555,7 +555,7 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
         if (doc == NULL || !doc->real_path)
                 gtk_widget_set_sensitive(menu_item, FALSE);
 
-        menu_item = ui_image_menu_item_new(GTK_STOCK_COPY, _("Copy file directory to clipboard"));
+        menu_item = ui_image_menu_item_new(GTK_STOCK_PASTE, _("Copy file directory to clipboard"));
         gtk_widget_show(menu_item);
         gtk_container_add(GTK_CONTAINER(menu), menu_item);
         g_signal_connect(menu_item, "activate",


### PR DESCRIPTION
This patch adds to the context menu that pops up when the user issues a right-click on the Notebook tab a few additional actions.

- Copy filename to clipboard
- Copy file path to clipboard
- Copy file directory to clipboard

This is a feature that already exists in Notepad++ (and I think Atom) and often times when using Geany I miss it. The closest thing I am able to replicate currently in Geany 1.36 (Poliff) is to going to File -> Properties and manually dragging and highlighting the selections. Of course I use a laptop 99.9% with no trackpad (only a trackpoint) of the time so it's not only far too much mouse movement but inaccurate.