### PR TITLE
Add Rust and libvte mention in README

### DIFF
--- a/README
+++ b/README
@@ -22,9 +22,9 @@ The basic features of Geany are:
 - auto completion of XML and HTML tags
 - call tips
 - folding
-- many supported filetypes like C, Java, PHP, HTML, Python, Perl, Pascal
+- many supported filetypes like C, Java, PHP, HTML, Python, Perl, Pascal, Rust
 - symbol lists
-- embedded terminal emulation
+- embedded terminal emulation (needs libvte)
 - extensibility through plugins
 
 


### PR DESCRIPTION
Hi,

I think it is important to mention in the README that libvte needs to be installed for terminal emulation to work.
This PR is just a suggestion.

Maybe, when Geany starts, it could also display a message in the "Status" window if it is not able to create the terminal, and then instruct how to fix it, eg: "libvte needs to be installed for terminal emulation to work. Install it using ..."

I also added Rust to the list of supported filetypes.

What do you think?