### PR TITLE
Use Python interpreter detected by autotools for geany-gtkdoc.h

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -133,7 +133,7 @@ Doxyfile-gi.stamp: Doxyfile-gi Doxyfile.stamp $(doxygen_dependencies)
 	$(AM_V_GEN)$(DOXYGEN) Doxyfile-gi && echo "" > $@
 
 geany-gtkdoc.h: Doxyfile-gi.stamp $(top_srcdir)/scripts/gen-api-gtkdoc.py
-	$(AM_V_GEN)$(top_srcdir)/scripts/gen-api-gtkdoc.py xml -d $(builddir) -o $@ \
+	$(AM_V_GEN)$(PYTHON) $(top_srcdir)/scripts/gen-api-gtkdoc.py xml -d $(builddir) -o $@ \
 			--sci-output geany-sciwrappers-gtkdoc.h
 
 geany-sciwrappers-gtkdoc.h: geany-gtkdoc.h


### PR DESCRIPTION
This should work fine on systems with only Python3, only Python2 and
also with both versions installed and do not rely on just being "python"
available in $PATH.