### PR TITLE
Remove geany.glade from POTFILES.skip

### DIFF
--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -2,8 +2,6 @@
 
 # geany.desktop.in will be translated
 geany.desktop.in
-# generated src/interface.c will be translated
-geany.glade
 # no need to translate these files
 plugins/demoplugin.c
 plugins/demoproxy.c


### PR DESCRIPTION
This file is no longer compiled to `src/interface.c`, has moved, and is in fact now translated.

I'll merge this after the CI runs.