### PR TITLE
Make GTK3 build the default, and GTK2 build optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ dist: trusty
 compiler:
   - gcc
 env:
-  - GTK3=no BINRELOC=no
-  - GTK3=yes BINRELOC=no
-  - GTK3=no BINRELOC=yes
-  - GTK3=yes BINRELOC=yes
-  - GTK3=no MINGW=yes
-  - GTK3=yes MINGW=yes
+  - GTK2=no BINRELOC=no
+  - GTK2=yes BINRELOC=no
+  - GTK2=no BINRELOC=yes
+  - GTK2=yes BINRELOC=yes
+  - GTK2=no MINGW=yes
+  - GTK2=yes MINGW=yes
 before_install:
   - sudo apt-get update -qq
 install:
@@ -29,11 +29,11 @@ script:
   - NOCONFIGURE=1 ./autogen.sh
   - >
     if [ -n "$MINGW" ]; then
-      arg=-2; [ "$GTK3" = yes ] && arg=-3;
+      arg=-3; [ "$GTK2" = yes ] && arg=-2;
       unset CC CXX;
       sh ./scripts/cross-build-mingw.sh $arg;
     else
-      CONFIGURE_FLAGS="--enable-gtk3=$GTK3 --enable-binreloc=$BINRELOC";
+      CONFIGURE_FLAGS="--enable-gtk2=$GTK2 --enable-binreloc=$BINRELOC";
       mkdir _build                        &&
       cd _build                           &&
       { ../configure $CONFIGURE_FLAGS || { cat config.log; exit 1; } ; } &&

--- a/configure.ac
+++ b/configure.ac
@@ -72,26 +72,23 @@ GEANY_CHECK_REVISION([dnl force debug mode for a VCS working copy
 					  CFLAGS="-g -DGEANY_DEBUG $CFLAGS"])
 
 # GTK version check
-AC_ARG_ENABLE([gtk3],
-		[AS_HELP_STRING([--enable-gtk3],
-						[compile against GTK3 [default=auto]])],
-		[enable_gtk3=$enableval],
-		[enable_gtk3=auto])
+AC_ARG_ENABLE([gtk2],
+		[AS_HELP_STRING([--enable-gtk2],
+						[compile against deprecated GTK2 [default=no]])],
+		[enable_gtk2=$enableval],
+		[enable_gtk2=no])
 
 gtk2_package=gtk+-2.0
 gtk2_min_version=2.24
 gtk3_package=gtk+-3.0
 gtk3_min_version=3.0
 
-PKG_CHECK_EXISTS([$gtk2_package >= $gtk2_min_version], [have_gtk2=yes], [have_gtk2=no])
-PKG_CHECK_EXISTS([$gtk3_package >= $gtk3_min_version], [have_gtk3=yes], [have_gtk3=no])
-AS_IF([test "x$enable_gtk3" = xyes || (test "x$enable_gtk3" != xno &&
-									   test "x$have_gtk3" = xyes &&
-									   test "x$have_gtk2" = xno)],
-	  [gtk_package=$gtk3_package
-	   gtk_min_version=$gtk3_min_version],
-	  [gtk_package=$gtk2_package
-	   gtk_min_version=$gtk2_min_version])
+AS_IF([test "x$enable_gtk2" = "xyes"],
+	[gtk_package=$gtk2_package
+	 gtk_min_version=$gtk2_min_version],
+	[gtk_package=$gtk3_package
+	 gtk_min_version=$gtk3_min_version])
+
 AM_CONDITIONAL([GTK3], [test "x$gtk_package" = "x$gtk3_package"])
 
 # GTK/GLib/GIO checks


### PR DESCRIPTION
As discussed in #2602, make GTK+3 the default of the build system, leading up to the eventual removal of GTK+2 support.

The `--enable-gtk3` configuration option is replaced with `--enable-gtk2`. If `--enable-gtk2` is specified, the GTK+2 development libraries/headers must be available via `pkg-config` or else configuration will fail. If `--enable-gtk2` is _not_ specified, the GTK+3 development libraries/headers must be available or else configuration will fail. It intentionally does not fall back to GTK+2 automatically.