### PR TITLE
OS Info Improvements

### DIFF
--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1068,6 +1068,7 @@ gint main_lib(gint argc, gchar **argv)
 	gint config_dir_result;
 	const gchar *locale;
 	gchar *utf8_configdir;
+	gchar *os_info;
 
 #if ! GLIB_CHECK_VERSION(2, 36, 0)
 	g_type_init();
@@ -1161,15 +1162,12 @@ gint main_lib(gint argc, gchar **argv)
 		gtk_major_version, gtk_minor_version, gtk_micro_version,
 		glib_major_version, glib_minor_version, glib_micro_version);
 
-#if GLIB_CHECK_VERSION(2, 64, 0)
-	gchar *os_prettyname = g_get_os_info(G_OS_INFO_KEY_PRETTY_NAME);
-	gchar *os_codename = g_get_os_info(G_OS_INFO_KEY_VERSION_CODENAME);
-	geany_debug("OS: %s (%s)",
-		os_prettyname ? os_prettyname : "Unknown",
-		os_codename ? os_codename : "Unknown");
-	g_free(os_prettyname);
-	g_free(os_codename);
-#endif
+	os_info = utils_get_os_info_string();
+	if (os_info != NULL)
+	{
+		geany_debug("OS: %s", os_info);
+		g_free(os_info);
+	}
 
 	geany_debug("System data dir: %s", app->datadir);
 	utf8_configdir = utils_get_utf8_from_locale(app->configdir);

--- a/src/utils.h
+++ b/src/utils.h
@@ -332,6 +332,8 @@ const gchar *utils_resource_dir(GeanyResourceDirType type);
 
 void utils_start_new_geany_instance(const gchar *doc_path);
 
+gchar *utils_get_os_info_string(void);
+
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS


### PR DESCRIPTION
Handles macOS and older GLibs better, as a follow-up for #2498.

Some tests so far:

- [x] Apple macOS
  - `OS: macOS`
- [x] Win7
  - `OS: Windows 7 SP17Vista SP2Vista SP1VistaXP SP3XP SP2XP SP1XP (Unknown)`
- [x] Win10 w/ Msys2 (same output for 32 and 64-bit msys2): 
  - `OS: Windows 10 2004 (Unknown)`
- [x] Debian
  - `OS: Debian GNU/Linux bullseye/sid`
- [x] Ubuntu 20.04
  - `OS: Ubuntu 20.04.1 LTS (focal)`
  - `OS: Linux Mint 20 (ulyana)`
- [x] Ubuntu 20.04 with incompatible GLib
  - `OS: Linux`

If it gets enough testing, could make 1.37, else we can leave for next release.