### PR TITLE
Add a meta file for funding

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,2 @@
+# These are supported funding model platforms
+liberapay: Geany


### PR DESCRIPTION
This PR adds the "funding" button on github for easy access of donators to donate via (right now) liberapay