### PR TITLE
Filter symbols in the Symbol List (new feature)

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8245,17 +8245,48 @@
                     <signal name="switch-page" handler="on_tv_notebook_switch_page" swapped="no"/>
                     <signal name="switch-page" handler="on_tv_notebook_switch_page_after" after="yes" swapped="no"/>
                     <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow2">
+                      <object class="GtkVBox" id="vbox46">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">automatic</property>
-                        <property name="vscrollbar_policy">automatic</property>
+                        <property name="can_focus">False</property>
                         <child>
-                          <object class="GtkTreeView" id="treeview2">
+                          <object class="GtkEntry" id="entry_tagfilter">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="enable_search">False</property>
+                            <property name="tooltip_text" translatable="yes">Filter the Symbol List</property>
+                            <property name="invisible_char">•</property>
+                            <property name="secondary_icon_stock">gtk-clear</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="secondary_icon_activatable">True</property>
+                            <property name="primary_icon_sensitive">True</property>
+                            <property name="secondary_icon_sensitive">True</property>
+                            <signal name="changed" handler="on_entry_tagfilter_changed" swapped="no"/>
+                            <signal name="icon-press" handler="on_entry_tagfilter_icon_press" swapped="no"/>
                           </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScrolledWindow" id="scrolledwindow2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="hscrollbar_policy">automatic</property>
+                            <property name="vscrollbar_policy">automatic</property>
+                            <child>
+                              <object class="GtkTreeView" id="treeview2">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="enable_search">False</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
                     </child>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -401,6 +401,20 @@ void on_toolbutton_search_clicked(GtkAction *action, gpointer user_data)
 }
 
 
+void on_entry_tagfilter_changed(GtkAction *action, gpointer user_data)
+{
+	GeanyDocument *doc = document_get_current();
+	sidebar_update_tag_list(doc, TRUE);
+}
+
+
+void on_entry_tagfilter_icon_press(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event, gpointer user_data)
+{
+	if (event->button.button == 1)
+		gtk_entry_set_text(entry, "");
+}
+
+
 /* hides toolbar from toolbar popup menu */
 static void on_hide_toolbar1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
@@ -462,7 +476,7 @@ static void on_notebook1_switch_page_after(GtkNotebook *notebook, gpointer page,
 		ui_update_popup_reundo_items(doc);
 		ui_document_show_hide(doc); /* update the document menu */
 		build_menu_update(doc);
-		sidebar_update_tag_list(doc, FALSE);
+		sidebar_update_tag_list(doc, TRUE);
 		document_highlight_tags(doc);
 
 		document_check_disk_status(doc, TRUE);

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -72,6 +72,10 @@ void on_toolbar_search_entry_changed(GtkAction *action, const gchar *text, gpoin
 
 void on_toolbar_search_entry_activate(GtkAction *action, const gchar *text, gpointer user_data);
 
+void on_entry_tagfilter_changed(GtkAction *action, gpointer user_data);
+
+void on_entry_tagfilter_icon_press(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event, gpointer user_data);
+
 void on_toggle_case1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_find_usage1_activate(GtkMenuItem *menuitem, gpointer user_data);

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -308,12 +308,21 @@ static gint compare_symbol_lines(gconstpointer a, gconstpointer b)
 static GList *get_tag_list(GeanyDocument *doc, TMTagType tag_types)
 {
 	GList *tag_names = NULL;
-	guint i;
+	guint i, j;
+
+	GtkEntry  *tfentry = NULL; // entry_tagfilter
+	gchar    **tfarray = NULL; // Array of the Tag Filter
+	guint      tfarlen = 0;    // Length of the tfarray
+	gboolean   tfapres = TRUE; // Result of the Tag Filter Applying
 
 	g_return_val_if_fail(doc, NULL);
 
 	if (! doc->tm_file || ! doc->tm_file->tags_array)
 		return NULL;
+
+	tfentry = GTK_ENTRY(ui_lookup_widget(main_widgets.window, "entry_tagfilter"));
+	tfarray = g_strsplit_set(gtk_entry_get_text(tfentry), " ", -1);
+	tfarlen = g_strv_length(tfarray);
 
 	for (i = 0; i < doc->tm_file->tags_array->len; ++i)
 	{
@@ -324,10 +333,25 @@ static GList *get_tag_list(GeanyDocument *doc, TMTagType tag_types)
 
 		if (tag->type & tag_types)
 		{
-			tag_names = g_list_prepend(tag_names, tag);
+			tfapres = TRUE;
+			for (j = 0; j < tfarlen; j++)
+			{
+				if (tfarray[j][0] != '\0')
+				{
+					if (g_strrstr(tag->name, tfarray[j]) == NULL)
+					{
+						tfapres = FALSE;
+						break;
+					}
+				}
+			}
+			if (tfapres) tag_names = g_list_prepend(tag_names, tag);
 		}
 	}
 	tag_names = g_list_sort(tag_names, compare_symbol_lines);
+	
+	g_strfreev(tfarray);
+	
 	return tag_names;
 }
 


### PR DESCRIPTION
It adds an entry field at the top of the symbol list to filter this list.

The text of the entry field divides into parts with a space symbol. A symbol of the symbol list (tag) must contain each of these parts to be shown in the filtered list. Filtering applies immediately during changing the text of the entry field.