### PR TITLE
Add microseconds to timestamp in debug log messages

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -137,7 +137,7 @@ static void handler_log(const gchar *domain, GLogLevelFlags level, const gchar *
 #endif
 	}
 
-	time_str = utils_get_current_time_string();
+	time_str = utils_get_current_time_string(TRUE);
 
 	g_string_append_printf(log_buffer, "%s: %s %s: %s\n", time_str, domain,
 		get_log_prefix(level), msg);

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -494,7 +494,7 @@ void msgwin_status_add_string(const gchar *string)
 	gchar *statusmsg, *time_str;
 
 	/* add a timestamp to status messages */
-	time_str = utils_get_current_time_string();
+	time_str = utils_get_current_time_string(FALSE);
 	statusmsg = g_strconcat(time_str, ": ", string, NULL);
 	g_free(time_str);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1012,16 +1012,17 @@ gint utils_parse_color_to_bgr(const gchar *spec)
 }
 
 
-/* Returns: newly allocated string with the current time formatted HH:MM:SS. */
-gchar *utils_get_current_time_string(void)
+/* Returns: newly allocated string with the current time formatted HH:MM:SS.
+ * If "include_microseconds" is TRUE, microseconds are appended.
+ *
+ * The returned string should be freed with g_free(). */
+gchar *utils_get_current_time_string(gboolean include_microseconds)
 {
-	const time_t tp = time(NULL);
-	const struct tm *tmval = localtime(&tp);
-	gchar *result = g_malloc0(9);
-
-	strftime(result, 9, "%H:%M:%S", tmval);
-	result[8] = '\0';
-	return result;
+	GDateTime *now = g_date_time_new_now_local();
+	const gchar *format = include_microseconds ? "%H:%M:%S.%f" : "%H:%M:%S";
+	gchar *time_string = g_date_time_format(now, format);
+	g_date_time_unref(now);
+	return time_string;
 }
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -287,7 +287,7 @@ gint utils_color_to_bgr(const GdkColor *color);
 
 gint utils_parse_color_to_bgr(const gchar *spec);
 
-gchar *utils_get_current_time_string(void);
+gchar *utils_get_current_time_string(gboolean include_microseconds);
 
 GIOChannel *utils_set_up_io_channel(gint fd, GIOCondition cond, gboolean nblock,
 									GIOFunc func, gpointer data);


### PR DESCRIPTION
This could help to debug the reported slow startup times but is also useful in general.
Starting Geany from the command line with `--verbose` already logs milliseconds. But most users (and maybe developers) usually don't do this.

Thanks to GLib, we don't need to do much for it and it actually simplifies the existing code.

Tested on ArchLinux and Windows 7.