### PR TITLE
Do not convert filename when opening files from command line on Windows

### DIFF
--- a/src/libmain.c
+++ b/src/libmain.c
@@ -886,10 +886,6 @@ static void open_cl_files(gint argc, gchar **argv)
 			continue;
 		}
 
-#ifdef G_OS_WIN32
-		/* It seems argv elements are encoded in CP1252 on a German Windows */
-		SETPTR(filename, g_locale_to_utf8(filename, -1, NULL, NULL, NULL));
-#endif
 		if (filename && ! main_handle_filename(filename))
 		{
 			const gchar *msg = _("Could not find file '%s'.");


### PR DESCRIPTION
It's unclear why the previous was added (by me) 12 years ago.
Maybe the code in main_handle_filename() or after has been
changed/improved so that it works now or the previous test case for
opening files from the command line was wrong.
This happens only when starting a new instance of Geany from command
line. Opening files in a running instance works fine with and without
this change.

Closes #2652.