### PR TITLE
Try and find ldconfig on Ubuntu even with weird sudo configurations

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,7 +198,7 @@ fix-ubuntu-libdir:
 	if test "$(DESTDIR)$(libdir)" = /usr/local/lib && \
 	   LANG=C ldd "$(DESTDIR)$(bindir)/geany" | grep -q 'libgeany.*not found' \
 	; then \
-		ldconfig "$(DESTDIR)$(libdir)"; \
+		PATH="\$PATH:/sbin" ldconfig "$(DESTDIR)$(libdir)"; \
 	fi
 
 install-exec-hook: fix-ubuntu-libdir


### PR DESCRIPTION
Not tested yet, but this might fix the problem from a user on the ML (https://lists.geany.org/pipermail/users/2020-November/011427.html) as suggester by @elextr 

Could someone with Ubuntu test this, esp. if they reproduce the issue?