### PR TITLE
add comment_single configuration for kotlin

### DIFF
--- a/data/filedefs/filetypes.Kotlin.conf
+++ b/data/filedefs/filetypes.Kotlin.conf
@@ -16,6 +16,7 @@ lexer_filetype=C
 tag_parser=C
 extension=kt
 mime_type=text/x-kotlin
+comment_single=//
 
 [build-menu]
 FT_00_LB=_Compile


### PR DESCRIPTION
Configuration file for Kotlin was missing `comment_single` configuration. Therefore, the Toggle line comentation feature (Ctrl+E) was not working by default for Kotlin files.