### PR TITLE
Split geany.conf into geany.conf (preferences) and session.conf (recent files and VTE session)

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -1225,6 +1225,7 @@ gboolean configuration_load(void)
 		geany_debug("No user session file found, trying to use configuration file.");
 		session_filename = PREFERENCES_FILE;
 	}
+	g_free(session_file);
 	gboolean sess_loaded = read_config_file(session_filename, SESSION);
 	return prefs_loaded && sess_loaded;
 }

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -685,7 +685,7 @@ void configuration_save(void)
 	 * it is probably not very efficient to write both files every time
 	 * could be more selective about which file is saved when */
 	write_config_file(PREFERENCES_FILE, PREFERENCES);
-	write_config_file("session.conf", SESSION);
+	write_config_file(SESSION_FILE, SESSION);
 }
 
 static void load_recent_files(GKeyFile *config, GQueue *queue, const gchar *key)
@@ -1146,7 +1146,7 @@ void configuration_save_default_session(void)
 
 void configuration_clear_default_session(void)
 {
-	gchar *configfile = g_build_filename(app->configdir, PREFERENCES_FILE, NULL);
+	gchar *configfile = g_build_filename(app->configdir, SESSION_FILE, NULL);
 	gchar *data;
 	GKeyFile *config = g_key_file_new();
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -1217,7 +1217,15 @@ gboolean read_config_file(gchar const *filename, ConfigPayload payload)
 gboolean configuration_load(void)
 {
 	gboolean prefs_loaded = read_config_file(PREFERENCES_FILE, PREFERENCES);
-	gboolean sess_loaded = read_config_file(SESSION_FILE, SESSION);
+	/* backwards-compatibility: try to read session from preferences if session file doesn't exist */
+	gchar *session_filename = SESSION_FILE;
+	gchar *session_file = g_build_filename(app->configdir, session_filename, NULL);
+	if (! g_file_test(session_file, G_FILE_TEST_IS_REGULAR))
+	{
+		geany_debug("No user session file found, trying to use configuration file.");
+		session_filename = PREFERENCES_FILE;
+	}
+	gboolean sess_loaded = read_config_file(session_filename, SESSION);
 	return prefs_loaded && sess_loaded;
 }
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -67,7 +67,7 @@
 #endif
 
 /* define the configuration filenames */
-#define PREFERENCES_FILE				"geany.conf"
+#define PREFS_FILE						"geany.conf"
 #define SESSION_FILE					"session.conf"
 
 /* some default settings which are used at the very first start of Geany to fill
@@ -633,7 +633,7 @@ static void save_ui_prefs(GKeyFile *config)
 
 typedef enum ConfigPayload
 {
-	PREFERENCES,
+	PREFS,
 	SESSION
 }
 ConfigPayload;
@@ -648,7 +648,7 @@ void write_config_file(gchar const *filename, ConfigPayload payload)
 
 	switch (payload)
 	{
-		case PREFERENCES:
+		case PREFS:
 			/* this signal can be used e.g. to prepare any settings before Stash code reads them below */
 			g_signal_emit_by_name(geany_object, "save-settings", config);
 			save_dialog_prefs(config);
@@ -683,7 +683,7 @@ void configuration_save(void)
 	/* save all configuration files
 	 * it is probably not very efficient to write both files every time
 	 * could be more selective about which file is saved when */
-	write_config_file(PREFERENCES_FILE, PREFERENCES);
+	write_config_file(PREFS_FILE, PREFS);
 	write_config_file(SESSION_FILE, SESSION);
 }
 
@@ -1124,7 +1124,7 @@ static void load_ui_prefs(GKeyFile *config)
  */
 void configuration_save_default_session(void)
 {
-	gchar *configfile = g_build_filename(app->configdir, PREFERENCES_FILE, NULL);
+	gchar *configfile = g_build_filename(app->configdir, PREFS_FILE, NULL);
 	gchar *data;
 	GKeyFile *config = g_key_file_new();
 
@@ -1196,7 +1196,7 @@ gboolean read_config_file(gchar const *filename, ConfigPayload payload)
 
 	switch (payload)
 	{
-		case PREFERENCES:
+		case PREFS:
 			load_dialog_prefs(config);
 			load_ui_prefs(config);
 			project_load_prefs(config);
@@ -1215,14 +1215,14 @@ gboolean read_config_file(gchar const *filename, ConfigPayload payload)
 
 gboolean configuration_load(void)
 {
-	gboolean prefs_loaded = read_config_file(PREFERENCES_FILE, PREFERENCES);
+	gboolean prefs_loaded = read_config_file(PREFS_FILE, PREFS);
 	/* backwards-compatibility: try to read session from preferences if session file doesn't exist */
 	gchar *session_filename = SESSION_FILE;
 	gchar *session_file = g_build_filename(app->configdir, session_filename, NULL);
 	if (! g_file_test(session_file, G_FILE_TEST_IS_REGULAR))
 	{
 		geany_debug("No user session file found, trying to use configuration file.");
-		session_filename = PREFERENCES_FILE;
+		session_filename = PREFS_FILE;
 	}
 	g_free(session_file);
 	gboolean sess_loaded = read_config_file(session_filename, SESSION);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -682,7 +682,7 @@ void write_config_file(gchar const *filename, ConfigPayload payload)
 void configuration_save(void)
 {
 	/* save all configuration files
-	 * it is probably not very efficient to write all 3 files every time
+	 * it is probably not very efficient to write both files every time
 	 * could be more selective about which file is saved when */
 	write_config_file(PREFERENCES_FILE, PREFERENCES);
 	write_config_file("session.conf", SESSION);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -646,12 +646,11 @@ void write_config_file(gchar const *filename, ConfigPayload payload)
 
 	g_key_file_load_from_file(config, configfile, G_KEY_FILE_NONE, NULL);
 
-	/* this signal can be used e.g. to prepare any settings before Stash code reads them below */
-	g_signal_emit_by_name(geany_object, "save-settings", config);
-
 	switch (payload)
 	{
 		case PREFERENCES:
+			/* this signal can be used e.g. to prepare any settings before Stash code reads them below */
+			g_signal_emit_by_name(geany_object, "save-settings", config);
 			save_dialog_prefs(config);
 			save_ui_prefs(config);
 			project_save_prefs(config);	/* save project filename, etc. */
@@ -1201,13 +1200,13 @@ gboolean read_config_file(gchar const *filename, ConfigPayload payload)
 			load_dialog_prefs(config);
 			load_ui_prefs(config);
 			project_load_prefs(config);
+			/* this signal can be used e.g. to delay building UI elements until settings have been read */
+			g_signal_emit_by_name(geany_object, "load-settings", config);
 			break;
 		case SESSION:
 			configuration_load_session_files(config, TRUE);
 			break;
 	}
-	/* this signal can be used e.g. to delay building UI elements until settings have been read */
-	g_signal_emit_by_name(geany_object, "load-settings", config);
 
 	g_key_file_free(config);
 	return TRUE;


### PR DESCRIPTION
Related to  #1763.

## New behaviour

Preferences are written to and read from `geany.conf` (like before), whereas "session data" is written to and read from `session.conf`.

For the sake of backwards compatibility, if `session.conf` does not exist, the data is read from `geany.conf` instead. 

## Implementation

I introduced an `enum` in `src/keyfile.c` called `ConfigPayload` which determines whether to read/write preference-data or session-data. 

The strings `"geany.conf"` and `"session.conf"` are now defined as preprocessor macros `PREFERENCES_FILE` and `SESSION_FILE`, respectively.

## Matters of taste
- The old recent files are not cleared from `geany.conf`
- The string `"geany.conf"` still appears in `src/keybindings.c` and `src/libmain.c`, so changing the `PREFERENCES_FILE` macro in `src/keyfile.c` is not enough to rename this file.