### PR TITLE
Set ctrl-shift-v to properties to stop it crashing VTE

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -345,7 +345,7 @@ static void init_default_kb(void)
 		GDK_KEY_s, GDK_SHIFT_MASK | GEANY_PRIMARY_MOD_MASK, "menu_saveall", _("Save all"),
 		"menu_save_all1");
 	add_kb(group, GEANY_KEYS_FILE_PROPERTIES, NULL,
-		0, 0, "file_properties", _("Properties"), "properties1");
+		GDK_KEY_v, GDK_SHIFT_MASK | GEANY_PRIMARY_MOD_MASK, "file_properties", _("Properties"), "properties1");
 	add_kb(group, GEANY_KEYS_FILE_PRINT, NULL,
 		GDK_KEY_p, GEANY_PRIMARY_MOD_MASK, "menu_print", _("Print"), "print1");
 	add_kb(group, GEANY_KEYS_FILE_CLOSE, NULL,


### PR DESCRIPTION
Some VTE versions crash if paste happens with focus outside the window, bind the accelerator to something innocuous in Geany to override it outside the VTE window.