### PR TITLE
Correct the backport of UniqueStringSet::Save to Scintilla 3.x.

### DIFF
--- a/scintilla/src/UniqueString.cxx
+++ b/scintilla/src/UniqueString.cxx
@@ -43,7 +43,7 @@ const char *UniqueStringSet::Save(const char *text) {
 		return nullptr;
 
 	for (const UniqueString &us : strings) {
-		if (text == us.get()) {
+		if (strcmp(us.get(), text) == 0) {
 			return us.get();
 		}
 	}


### PR DESCRIPTION
(String comparison was intended, not identity.)
Fixes #2883.
To minimize conflict with PR #2867, this does not touch the `scintilla_changes.patch` / `update-scintilla.sh` setup. When the time comes, #2867 will obsolete this change.
All the best!