### PR TITLE
Use "encoding" keyword argument for lxml's tostring()

### DIFF
--- a/scripts/gen-api-gtkdoc.py
+++ b/scripts/gen-api-gtkdoc.py
@@ -106,7 +106,7 @@ class DoxygenProcess(object):
         from lxml.etree import tostring
         from itertools import chain
         parts = ([node.text] +
-                 list(chain(*([c.text, tostring(c).decode("utf-8"), c.tail] for c in node.getchildren()))) +
+                 list(chain(*([c.text, tostring(c, encoding='unicode'), c.tail] for c in node.getchildren()))) +
                  [node.tail])
         # filter removes possible Nones in texts and tails
         return "".join(filter(None, parts))
@@ -121,9 +121,9 @@ class DoxygenProcess(object):
                 # <sp/> tags must be replaced with spaces, then just use the text
                 h = l.find("highlight")
                 if h is not None:
-                    html = tostring(h).decode("utf-8")
+                    html = tostring(h, encoding='unicode')
                     html = html.replace("<sp/>", " ")
-                    arr.append("  " + tostring(etree.HTML(html), method="text").decode("utf-8"))
+                    arr.append("  " + tostring(etree.HTML(html), method="text", encoding='unicode'))
         arr.append("]|")
         return "\n".join(arr)
 


### PR DESCRIPTION
Newer versions of libxml2 (used by lxml) crash in tostring() when no encoding argument is present. Passing "unicode" as encoding makes tostring() returning already a Python unicode string, so we don't need to decode it anymore.

On Debian Sid where libxml2 2.9.12 is included, the following error occurs without the change:
```
/usr/bin/python3 ../scripts/gen-api-gtkdoc.py xml -d . -o geany-gtkdoc.h \
		--sci-output geany-sciwrappers-gtkdoc.h
Traceback (most recent call last):
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 460, in <module>
    sys.exit(main(sys.argv))
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 389, in main
    e = DoxyStruct.from_compounddef(n0)
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 321, in from_compounddef
    e.add_member(p)
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 233, in add_member
    proc.process_element(xml.find("detaileddescription"))
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 136, in process_element
    s = self.__process_element(xml)
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 163, in __process_element
    s += self.__process_element(n) + "\n"
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 167, in __process_element
    ss = self.at.cb(n.get("kind"), self.__process_element(n))
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 163, in __process_element
    s += self.__process_element(n) + "\n"
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 170, in __process_element
    s += self.get_program_listing(n)
  File "/build/geany-1.37.1-1+20210903gitb7bd5fa/doc/../scripts/gen-api-gtkdoc.py", line 126, in get_program_listing
    arr.append("  " + tostring(etree.HTML(html), method="text").decode("utf-8"))
  File "src/lxml/etree.pyx", line 3437, in lxml.etree.tostring
  File "src/lxml/serializer.pxi", line 103, in lxml.etree._tostring
  File "src/lxml/serializer.pxi", line 75, in lxml.etree._textToString
UnicodeEncodeError: 'ascii' codec can't encode character '\xe1' in position 130970: ordinal not in range(128)
```

I'm not completely sure why this happens with libxml 2.9.12 (2.9.10 works fine), the XML contents which are processed here should be plain ASCII. Anyway, it might not be bad to set the encoding anyways.

To reproduce, start a Docker container with a Debian Sid image, like: `docker run --rm -it debian:sid` and within the container execute:
```bash
apt-get update && apt-get install --no-install-recommends -y git intltool libtool build-essential libgtk-3-dev  python3-docutils rst2pdf doxygen python3-lxml nano
git clone https://github.com/geany/geany
cd geany
./autogen.sh
make -C doc
```