### PR TITLE
Remove redundant code

### DIFF
--- a/ctags/main/parse_p.h
+++ b/ctags/main/parse_p.h
@@ -45,20 +45,7 @@ typedef enum {
  * return a structure allocated using parserNew(). This structure must,
  * at minimum, set the `parser' field.
  */
-#ifdef EXTERNAL_PARSER_LIST
 extern parserDefinitionFunc EXTERNAL_PARSER_LIST;
-#else /* ! EXTERNAL_PARSER_LIST */
-extern parserDefinitionFunc PARSER_LIST;
-#ifdef HAVE_LIBXML
-extern parserDefinitionFunc XML_PARSER_LIST;
-#endif
-#ifdef HAVE_LIBYAML
-extern parserDefinitionFunc YAML_PARSER_LIST;
-#endif
-#ifdef HAVE_PACKCC
-extern parserDefinitionFunc PEG_PARSER_LIST;
-#endif
-#endif /* EXTERNAL_PARSER_LIST */
 
 extern bool doesLanguageAllowNullTag (const langType language);
 extern bool doesLanguageRequestAutomaticFQTag (const langType language);


### PR DESCRIPTION
Hello!

While chasing down these `clang` warnings I found that some code is redundant and can be safely removed:
```
main/parse.c:5007:26: warning: unused function 'FallbackParser' [-Wunused-function]
static parserDefinition *FallbackParser (void)
                         ^
main/parse.c:5040:26: warning: unused function 'CTagsParser' [-Wunused-function]
static parserDefinition *CTagsParser (void)
                         ^
main/parse.c:5355:26: warning: unused function 'CTagsSelfTestParser' [-Wunused-function]
static parserDefinition *CTagsSelfTestParser (void)
                         ^
```

This is because we explicitly define `EXTERNAL_PARSER_LIST ` in tm_parsers.h at https://github.com/geany/geany/blob/master/src/tagmanager/tm_parsers.h#L16 so guess no need to check for not defined case?

Thanks!