### PR TITLE
Windows: Do not manually realize the main window prematurely

### DIFF
--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1209,11 +1209,6 @@ gint main_lib(gint argc, gchar **argv)
 	build_menu_update(doc);
 	sidebar_update_tag_list(doc, FALSE);
 
-#ifdef G_OS_WIN32
-	/* Manually realise the main window to be able to set the position but don't show it.
-	 * We don't set the position after showing the window to avoid flickering. */
-	gtk_widget_realize(main_widgets.window);
-#endif
 	setup_window_position();
 
 	/* finally show the window */


### PR DESCRIPTION
This has been added in 9431eea24 but seems no longer necessary and actually causes problems with setting the message window height. After each start of Geany, the message window will be set a bit lower until it is not visible anymore at all.
The manual realize step was maybe necessary with older GTK2 versions but actually works contrarily on recent GTK3 builds.

Fixes #2591.