### PR TITLE
Move "Send Selection to" from Edit/Format to Edit

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -6925,30 +6925,24 @@
                                     <signal name="activate" handler="on_smart_line_indent1_activate" swapped="no"/>
                                   </object>
                                 </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuItem" id="send_selection_to2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">_Send Selection</property>
+                            <property name="use_underline">True</property>
+                            <child type="submenu">
+                              <object class="GtkMenu" id="send_selection_to2_menu">
+                                <property name="can_focus">False</property>
                                 <child>
-                                  <object class="GtkSeparatorMenuItem" id="separator37">
-                                    <property name="visible">True</property>
+                                  <object class="GtkMenuItem" id="invisible13">
                                     <property name="can_focus">False</property>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkMenuItem" id="send_selection_to2">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">_Send Selection to</property>
+                                    <property name="label" translatable="yes">invisible</property>
                                     <property name="use_underline">True</property>
-                                    <child type="submenu">
-                                      <object class="GtkMenu" id="send_selection_to2_menu">
-                                        <property name="can_focus">False</property>
-                                        <child>
-                                          <object class="GtkMenuItem" id="invisible13">
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">invisible</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
                                   </object>
                                 </child>
                               </object>

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -6933,7 +6933,7 @@
                           <object class="GtkMenuItem" id="send_selection_to2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">_Send Selection</property>
+                            <property name="label" translatable="yes">Send Selecti_on</property>
                             <property name="use_underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="send_selection_to2_menu">

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -835,10 +835,10 @@ Sending text through custom commands
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can define several custom commands in Geany and send the current
-selection to one of these commands using the *Edit->Format->Send
-Selection to* menu or keybindings. The output of the command will be
-used to replace the current selection. This makes it possible to use
-text formatting tools with Geany in a general way.
+selection to one of these commands using the *Edit->Send Selection*
+menu or keybindings. The output of the command will be used to replace
+the current selection. This makes it possible to use text formatting
+tools with Geany in a general way.
 
 The selected text will be sent to the standard input of the executed
 command, so the command should be able to read from it and it should
@@ -849,7 +849,7 @@ output.
 
 If there is no selection, the whole current line is used instead.
 
-To add a custom command, use the *Send Selection to->Set Custom
+To add a custom command, use the *Send Selection->Set Custom
 Commands* menu item. Click on *Add* to get a new item and type the
 command. You can also specify some command line options. Empty
 commands are not saved.


### PR DESCRIPTION
I've been using Geany for years and never knew this feature exists.  I saw it mentioned in a comment, but didn't find it.  I did find "Send Selection to Terminal", but it was grayed out.  So I thought maybe that was what I was looking for, but couldn't use it for whatever reason.  (I thought this might be like the plugins that no longer compile.)  So I forgot about it.  Then I saw this feature mentioned someplace else in a different context.  So I went searching again, and still didn't find it.  So I asked the internet, and finally found out where it is.

Two levels of nested menus seems like a bit too much.  So this PR is to make the "Send Selection to" feature easier to find and use.  It's renamed to "Send Selection" and moved from Edit/Format to Edit menu.