### PR TITLE
Switch to Python 3 for GTK doc header generation

### DIFF
--- a/m4/geany-gtkdoc-header.m4
+++ b/m4/geany-gtkdoc-header.m4
@@ -21,7 +21,7 @@ AC_DEFUN([GEANY_CHECK_GTKDOC_HEADER],
 	      [test "x$geany_enable_gtkdoc_header" != "xno"],
 	[
 		dnl python
-		AM_PATH_PYTHON([2.7], [have_python=yes], [have_python=no])
+		AM_PATH_PYTHON([3], [have_python=yes], [have_python=no])
 		dnl lxml module
 		AS_IF([test "x$have_python" = xyes],
 		      [have_python_and_lxml=yes

--- a/scripts/gen-api-gtkdoc.py
+++ b/scripts/gen-api-gtkdoc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright 2015 The Geany contributors
 #


### PR DESCRIPTION
Works for me and I have no `python` command available so it must be using `python3`