### PR TITLE
Don't use volatile

### DIFF
--- a/src/stash.c
+++ b/src/stash.c
@@ -88,7 +88,7 @@
 #define TYPE_COMBO_BOX_ENTRY get_combo_box_entry_type()
 static GType get_combo_box_entry_type(void)
 {
-	static volatile gsize type = 0;
+	static gsize type = 0;
 	if (g_once_init_enter(&type))
 	{
 		GType g_type = g_type_register_static_simple(GTK_TYPE_COMBO_BOX, "dummy-combo-box-entry",


### PR DESCRIPTION
Hello!

This fixes following clang warning:
```
stash.c:92:6: warning: passing 'typeof (*(&type)) *' (aka 'volatile unsigned long *') to parameter of type 'gsize *' (aka 'unsigned long *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        if (g_once_init_enter(&type))
            ^~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gthread.h:260:7: note: expanded from macro 'g_once_init_enter'
    (!g_atomic_pointer_get (location) &&                             \
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gatomic.h:117:38: note: expanded from macro 'g_atomic_pointer_get'
    __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
                                     ^~~~~~~~~~~~~~~~~
1 warning generated.
```
Thanks!