### PR TITLE
Add keybindings to switch focus between Editor and VTE/sidebar/message window

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -624,21 +624,21 @@ static void init_default_kb(void)
 	add_kb(group, GEANY_KEYS_FOCUS_MESSAGE_WINDOW, NULL,
 		0, 0, "switch_msgwin_status", _("Switch to Message Window"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_STATUS, NULL,
-		0, 0, "switch_msgwin_status", _("Switch to Message Window - Status"), NULL);
+		0, 0, "switch_msgwin_status", _("Switch to Message Window: Status"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_COMPILER, NULL,
-		0, 0, "switch_msgwin_status_compiler", _("Switch to Message Window - Compiler"), NULL);
+		0, 0, "switch_msgwin_status_compiler", _("Switch to Message Window: Compiler"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_MESSAGES, NULL,
-		0, 0, "switch_msgwin_status_messages", _("Switch to Message Window - Messages"), NULL);
+		0, 0, "switch_msgwin_status_messages", _("Switch to Message Window: Messages"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_SCRIBBLE, NULL,
-		GDK_KEY_F6, 0, "switch_msgwin_status_scribble", _("Switch to Message Window - Scribble"), NULL);
+		GDK_KEY_F6, 0, "switch_msgwin_status_scribble", _("Switch to Message Window: Scribble"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_VTE, NULL,
 		GDK_KEY_F4, 0, "switch_vte", _("Switch to VTE"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_SIDEBAR, NULL,
 		0, 0, "switch_sidebar", _("Switch to Sidebar"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_SIDEBAR_SYMBOL_LIST, NULL,
-		0, 0, "switch_sidebar_symbol_list", _("Switch to Sidebar - Symbols"), NULL);
+		0, 0, "switch_sidebar_symbol_list", _("Switch to Sidebar: Symbols"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_SIDEBAR_DOCUMENT_LIST, NULL,
-		0, 0, "switch_sidebar_doc_list", _("Switch to Sidebar - Documents"), NULL);
+		0, 0, "switch_sidebar_doc_list", _("Switch to Sidebar: Documents"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_TOGGLE_EDITOR_VTE, NULL,
 		0, 0, "switch_editor_vte", _("Switch between Editor and VTE"), NULL);
 	add_kb(group, GEANY_KEYS_FOCUS_TOGGLE_EDITOR_SIDEBAR, NULL,

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1772,7 +1772,8 @@ static void focus_toggle_editor_vte(void)
 	widget = find_focus_widget(widget);
 	if (gtk_widget_has_focus(widget))
 	{
-      if (previous_page_num >= 0) {
+		if (previous_page_num >= 0 && page_num == MSG_VTE)
+		{
 			gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), previous_page_num);
 		}
 		keybindings_send_command(GEANY_KEY_GROUP_FOCUS, GEANY_KEYS_FOCUS_EDITOR);

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -277,6 +277,10 @@ enum GeanyKeyBindingID
 												 * @since 1.34 (API 238) */
 	GEANY_KEYS_FILE_RELOAD_ALL,					/**< Keybinding.
 												 * @since 1.38 (API 240) */
+	GEANY_KEYS_FOCUS_STATUS,						/**< Keybinding. */
+	GEANY_KEYS_FOCUS_TOGGLE_EDITOR_VTE,			/**< Keybinding. */
+	GEANY_KEYS_FOCUS_TOGGLE_EDITOR_SIDEBAR,	/**< Keybinding. */
+	GEANY_KEYS_FOCUS_TOGGLE_EDITOR_MSGWIN,		/**< Keybinding. */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 


### PR DESCRIPTION
This PR adds keybindings to switch focus between:

* Editor and VTE (Resolves #2847)
* Editor and Sidebar (Resolves #2914)
* Editor and Message Window

It also adds a keybinding to switch focus to the status tab (every other msgwin tab has a keybinding).  Existing keybindings to change focus are unchanged, for those who prefer them.

This PR cannot be put in a plugin because the VTE grabs focus and won't let it go except for shortcuts in the focus group.  There is an option to make the VTE not override shortcuts, but then it becomes unusable because it doesn't respond to expected VTE shortcuts.

I understand there is currently a string freeze, so this PR won't get much attention for a while.