### PR TITLE
Improve caching for SCI_TEXTHEIGHT

### DIFF
--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -174,6 +174,7 @@ void				sci_scroll_columns			(ScintillaObject *sci, gint columns);
 gint				sci_search_next				(ScintillaObject *sci, gint flags, const gchar *text);
 gint				sci_search_prev				(ScintillaObject *sci, gint flags, const gchar *text);
 void				sci_marker_delete_all		(ScintillaObject *sci, gint marker);
+gint				sci_text_height_cached		(ScintillaObject *sci, const gint line);
 void				sci_set_symbol_margin		(ScintillaObject *sci, gboolean set);
 void				sci_set_codepage			(ScintillaObject *sci, gint cp);
 void				sci_clear_cmdkey			(ScintillaObject *sci, gint key);

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1960,7 +1960,7 @@ static void goto_popup_position_func(GtkMenu *menu, gint *x, gint *y, gboolean *
 		gint pos_x = SSM(sci, SCI_POINTXFROMPOSITION, 0, pos);
 		gint pos_y = SSM(sci, SCI_POINTYFROMPOSITION, 0, pos);
 
-		line_height = SSM(sci, SCI_TEXTHEIGHT, line, 0);
+		line_height = sci_text_height_cached(sci, line);
 
 		gdk_window_get_origin(window, x, y);
 		*x += pos_x;


### PR DESCRIPTION
This improves caching introduced in https://github.com/geany/geany/pull/2747 and discussed in https://github.com/geany/geany/issues/2883, https://github.com/geany/geany/issues/2649
This change reduce CPU usage on window activate/deactivate by caching up to 128 elements from all SCI_TEXTHEIGHT calls.