### PR TITLE
Add option to hide project close/save warning when opening new project

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2542,6 +2542,8 @@ msgwin_messages_visible           Whether to show the Messages tab in the      t
                                   Messages Window
 msgwin_scribble_visible           Whether to show the Scribble tab in the      true        immediately
                                   Messages Window
+warn_on_project_close             Whether to show a warning when opening       true        immediately
+                                  a project while one is already open.
 **``terminal`` group**
 send_selection_unsafe             By default, Geany strips any trailing        false       immediately
                                   newline characters from the current

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 240
+#define GEANY_API_VERSION 241
 
 /* hack to have a different ABI when built with different GTK major versions
  * because loading plugins linked to a different one leads to crashes.

--- a/src/project.c
+++ b/src/project.c
@@ -661,7 +661,8 @@ gboolean project_ask_close(void)
 {
 	if (app->project != NULL)
 	{
-		if (dialogs_show_question_full(NULL, GTK_STOCK_CLOSE, GTK_STOCK_CANCEL,
+		if (!interface_prefs.warn_on_project_close ||
+			dialogs_show_question_full(NULL, GTK_STOCK_CLOSE, GTK_STOCK_CANCEL,
 			_("Do you want to close it before proceeding?"),
 			_("The '%s' project is open."), app->project->name))
 		{

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2352,6 +2352,8 @@ void ui_init_prefs(void)
 		"msgwin_messages_visible", TRUE);
 	stash_group_add_boolean(group, &interface_prefs.msgwin_scribble_visible,
 		"msgwin_scribble_visible", TRUE);
+	stash_group_add_boolean(group, &interface_prefs.warn_on_project_close,
+		"warn_on_project_close", TRUE);
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -69,6 +69,8 @@ typedef struct GeanyInterfacePrefs
 	gboolean		compiler_tab_autoscroll;
 	gint			msgwin_orientation;			/**< orientation of the message window */
 	gint 			symbols_sort_mode;			/**< symbol list sorting mode */
+	/** whether to show a warning when closing a project to open a new one */
+	gboolean		warn_on_project_close;
 }
 GeanyInterfacePrefs;
 


### PR DESCRIPTION
This adds an option to hide the warning when opening a project while one is already open.  (The default is to retain the warning.)  Since projects autosave when closed, no work is lost and the project can just be reopened if needed.  Depending on how the user manages project files, reopening the previous project can take less time than responding to the dialog.