### PR TITLE
Add option to prevent reloading projects that are already loaded

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2614,6 +2614,9 @@ save_config_on_file_change        Automatically save Geany's configuration     t
 extract_filetype_regex            Regex to extract filetype name from file     See link    immediately
                                   via capture group one.
                                   See `ft_regex`_ for default.
+**``projects`` group**
+reload_already_open               When a project that is already loaded        false        immediately
+                                  is opened again, whether to reload it.
 **``search`` group**
 find_selection_type               See `Find selection`_.                       0           immediately
 replace_and_find_by_default       Set ``Replace & Find`` button as default so  true        immediately

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -271,6 +271,12 @@ static void init_pref_groups(void)
 		"allow_always_save", FALSE);
 
 	group = stash_group_new(PACKAGE);
+	configuration_add_various_pref_group(group, "projects");
+
+	stash_group_add_boolean(group, &project_prefs.project_reload_already_open,
+		"reload_already_open", FALSE);
+
+	group = stash_group_new(PACKAGE);
 	configuration_add_various_pref_group(group, "search");
 
 	stash_group_add_integer(group, (gint*)&search_prefs.find_selection_type,
@@ -449,6 +455,7 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_load_session", prefs.load_session);
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_project_session", project_prefs.project_session);
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_project_file_in_basedir", project_prefs.project_file_in_basedir);
+	g_key_file_set_boolean(config, PACKAGE, "pref_main_project_reload_already_open", project_prefs.project_reload_already_open);
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_save_winpos", prefs.save_winpos);
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_save_wingeom", prefs.save_wingeom);
 	g_key_file_set_boolean(config, PACKAGE, "pref_main_confirm_exit", prefs.confirm_exit);
@@ -807,6 +814,7 @@ static void load_dialog_prefs(GKeyFile *config)
 	prefs.suppress_status_messages = utils_get_setting_boolean(config, PACKAGE, "pref_main_suppress_status_messages", FALSE);
 	prefs.load_session = utils_get_setting_boolean(config, PACKAGE, "pref_main_load_session", TRUE);
 	project_prefs.project_session = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_session", TRUE);
+	project_prefs.project_reload_already_open = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_reload_already_open", FALSE);
 	project_prefs.project_file_in_basedir = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_file_in_basedir", FALSE);
 	prefs.save_winpos = utils_get_setting_boolean(config, PACKAGE, "pref_main_save_winpos", TRUE);
 	prefs.save_wingeom = utils_get_setting_boolean(config, PACKAGE, "pref_main_save_wingeom", prefs.save_winpos);

--- a/src/project.h
+++ b/src/project.h
@@ -57,6 +57,7 @@ typedef struct ProjectPrefs
 	gchar *session_file;
 	gboolean project_session;
 	gboolean project_file_in_basedir;
+	gboolean project_reload_already_open;
 } ProjectPrefs;
 
 extern ProjectPrefs project_prefs;


### PR DESCRIPTION
This PR adds an option (projects.reload_already_open) to control whether Geany reloads projects that are already loaded.

* The real paths are compared so symlinked files are also caught.
* This affects files opened from both the command line and UI. 
* The default is false, which prevents projects from being reloaded.  Although this is a change from the current behavior:
  - Review of existing plugins indicates minimal, if any, negative effect.
  - The most noticeable difference will be a reduction of warning popups.  Another effect is that undo history will not be lost by an unnecessary reload, which potentially prevents data loss.
  - The option can be enabled by those who really want it.
* When a project is not reloaded, a message is sent to the status window to notify the user.