### PR TITLE
Add option to use status window to warn about unwritable project files

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2544,6 +2544,10 @@ msgwin_scribble_visible           Whether to show the Scribble tab in the      t
                                   Messages Window
 warn_on_project_close             Whether to show a warning when opening       true        immediately
                                   a project while one is already open.
+warn_on_project_unwritable        Whether to show a popup warning when         true        immediately
+                                  opening a read-only project file.
+                                  When disabled, the warning will be sent
+                                  to the status window instead.
 **``terminal`` group**
 send_selection_unsafe             By default, Geany strips any trailing        false       immediately
                                   newline characters from the current

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2354,6 +2354,8 @@ void ui_init_prefs(void)
 		"msgwin_scribble_visible", TRUE);
 	stash_group_add_boolean(group, &interface_prefs.warn_on_project_close,
 		"warn_on_project_close", TRUE);
+	stash_group_add_boolean(group, &interface_prefs.warn_on_project_unwritable,
+		"warn_on_project_unwritable", TRUE);
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -71,6 +71,8 @@ typedef struct GeanyInterfacePrefs
 	gint 			symbols_sort_mode;			/**< symbol list sorting mode */
 	/** whether to show a warning when closing a project to open a new one */
 	gboolean		warn_on_project_close;
+	/** whether to show a warning when the project file is unwritable */
+	gboolean		warn_on_project_unwritable;
 }
 GeanyInterfacePrefs;
 


### PR DESCRIPTION
This PR adds an option that moves the warning from a popup to the status window when a project file is unwritable.  Potentially addresses #2863.