### PR TITLE
Add option to disable zooming (via the scroll wheel)

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2523,6 +2523,8 @@ indent_hard_tab_width             The size of a tab character. Don't change    8
 editor_ime_interaction            Input method editor (IME)'s candidate        0           to new
                                   window behaviour. May be 0 (windowed) or                 documents
                                   1 (inline)
+zoom_disable_scrollwheel          Disable zooming the editor view with         false       immediately
+                                  the scroll wheel.
 **``interface`` group**
 show_symbol_list_expanders        Whether to show or hide the small            true        to new
                                   expander icons on the symbol list                        documents

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -445,6 +445,13 @@ static void on_hide_toolbar1_activate(GtkMenuItem *menuitem, gpointer user_data)
 }
 
 
+static gboolean on_zoom_disable_scrollwheel_timeout(G_GNUC_UNUSED gpointer user_data)
+{
+	editor_prefs.zoom_disable_scrollwheel = TRUE;
+	return FALSE;
+}
+
+
 /* zoom in from menu bar and popup menu */
 void on_zoom_in1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
@@ -452,7 +459,14 @@ void on_zoom_in1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 	g_return_if_fail(doc != NULL);
 
-	sci_zoom_in(doc->editor->sci);
+	if (editor_prefs.zoom_disable_scrollwheel)
+	{
+		editor_prefs.zoom_disable_scrollwheel = FALSE;
+		sci_zoom_in(doc->editor->sci);
+		g_timeout_add (250, on_zoom_disable_scrollwheel_timeout, NULL);
+	}
+	else
+		sci_zoom_in(doc->editor->sci);
 }
 
 
@@ -463,7 +477,14 @@ void on_zoom_out1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 	g_return_if_fail(doc != NULL);
 
-	sci_zoom_out(doc->editor->sci);
+	if (editor_prefs.zoom_disable_scrollwheel)
+	{
+		editor_prefs.zoom_disable_scrollwheel = FALSE;
+		sci_zoom_out(doc->editor->sci);
+		g_timeout_add (250, on_zoom_disable_scrollwheel_timeout, NULL);
+	}
+	else
+		sci_zoom_out(doc->editor->sci);
 }
 
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -445,30 +445,22 @@ static void on_hide_toolbar1_activate(GtkMenuItem *menuitem, gpointer user_data)
 }
 
 
-/* re-disable scrollwheel zoom after using keybindings */
-static gboolean on_zoom_disable_scrollwheel_timeout(G_GNUC_UNUSED gpointer user_data)
-{
-	editor_prefs.zoom_disable_scrollwheel = TRUE;
-	return FALSE;
-}
-
-
 /* zoom in from menu bar and popup menu */
 void on_zoom_in1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();
+	gboolean zoom_disable_restore;
 
 	g_return_if_fail(doc != NULL);
 
-	if (editor_prefs.zoom_disable_scrollwheel)
-	{
-		/* Need to temporarily enable zoom to allow keybindings to work */
-		editor_prefs.zoom_disable_scrollwheel = FALSE;
-		sci_zoom_in(doc->editor->sci);
-		g_timeout_add (250, on_zoom_disable_scrollwheel_timeout, NULL);
-	}
-	else
-		sci_zoom_in(doc->editor->sci);
+	/* Need to temporarily enable zoom to allow keybindings to work */
+	zoom_disable_restore = editor_prefs.zoom_disable_scrollwheel;
+	editor_prefs.zoom_disable_scrollwheel = FALSE;
+
+	sci_zoom_in(doc->editor->sci);
+
+	/* Restore previous setting */
+	editor_prefs.zoom_disable_scrollwheel = zoom_disable_restore;
 }
 
 
@@ -476,36 +468,36 @@ void on_zoom_in1_activate(GtkMenuItem *menuitem, gpointer user_data)
 void on_zoom_out1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();
+	gboolean zoom_disable_restore;
 
 	g_return_if_fail(doc != NULL);
 
-	if (editor_prefs.zoom_disable_scrollwheel)
-	{
-		/* Need to temporarily enable zoom to allow keybindings to work */
-		editor_prefs.zoom_disable_scrollwheel = FALSE;
-		sci_zoom_out(doc->editor->sci);
-		g_timeout_add (250, on_zoom_disable_scrollwheel_timeout, NULL);
-	}
-	else
-		sci_zoom_out(doc->editor->sci);
+	/* Need to temporarily enable zoom to allow keybindings to work */
+	zoom_disable_restore = editor_prefs.zoom_disable_scrollwheel;
+	editor_prefs.zoom_disable_scrollwheel = FALSE;
+
+	sci_zoom_out(doc->editor->sci);
+
+	/* Restore previous setting */
+	editor_prefs.zoom_disable_scrollwheel = zoom_disable_restore;
 }
 
 
 void on_normal_size1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();
+	gboolean zoom_disable_restore;
 
 	g_return_if_fail(doc != NULL);
 
-	if (editor_prefs.zoom_disable_scrollwheel)
-	{
-		/* Need to temporarily enable zoom to allow keybindings to work */
-		editor_prefs.zoom_disable_scrollwheel = FALSE;
-		sci_zoom_off(doc->editor->sci);
-		g_timeout_add (250, on_zoom_disable_scrollwheel_timeout, NULL);
-	}
-	else
-		sci_zoom_off(doc->editor->sci);
+	/* Need to temporarily enable zoom to allow keybindings to work */
+	zoom_disable_restore = editor_prefs.zoom_disable_scrollwheel;
+	editor_prefs.zoom_disable_scrollwheel = FALSE;
+
+	sci_zoom_off(doc->editor->sci);
+
+	/* Restore previous setting */
+	editor_prefs.zoom_disable_scrollwheel = zoom_disable_restore;
 }
 
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -445,6 +445,7 @@ static void on_hide_toolbar1_activate(GtkMenuItem *menuitem, gpointer user_data)
 }
 
 
+/* re-disable scrollwheel zoom after using keybindings */
 static gboolean on_zoom_disable_scrollwheel_timeout(G_GNUC_UNUSED gpointer user_data)
 {
 	editor_prefs.zoom_disable_scrollwheel = TRUE;
@@ -461,6 +462,7 @@ void on_zoom_in1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 	if (editor_prefs.zoom_disable_scrollwheel)
 	{
+		/* Need to temporarily enable zoom to allow keybindings to work */
 		editor_prefs.zoom_disable_scrollwheel = FALSE;
 		sci_zoom_in(doc->editor->sci);
 		g_timeout_add (250, on_zoom_disable_scrollwheel_timeout, NULL);
@@ -479,6 +481,7 @@ void on_zoom_out1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 	if (editor_prefs.zoom_disable_scrollwheel)
 	{
+		/* Need to temporarily enable zoom to allow keybindings to work */
 		editor_prefs.zoom_disable_scrollwheel = FALSE;
 		sci_zoom_out(doc->editor->sci);
 		g_timeout_add (250, on_zoom_disable_scrollwheel_timeout, NULL);
@@ -494,7 +497,15 @@ void on_normal_size1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 	g_return_if_fail(doc != NULL);
 
-	sci_zoom_off(doc->editor->sci);
+	if (editor_prefs.zoom_disable_scrollwheel)
+	{
+		/* Need to temporarily enable zoom to allow keybindings to work */
+		editor_prefs.zoom_disable_scrollwheel = FALSE;
+		sci_zoom_off(doc->editor->sci);
+		g_timeout_add (250, on_zoom_disable_scrollwheel_timeout, NULL);
+	}
+	else
+		sci_zoom_off(doc->editor->sci);
 }
 
 

--- a/src/editor.c
+++ b/src/editor.c
@@ -1198,7 +1198,16 @@ static gboolean on_editor_notify(G_GNUC_UNUSED GObject *object, GeanyEditor *edi
 			if (editor_prefs.zoom_disable_scrollwheel)
 				sci_zoom_off(editor->sci);
 			else
+			{
+				int curr_size = SSM(sci, SCI_STYLEGETSIZEFRACTIONAL, STYLE_DEFAULT, STYLE_DEFAULT);
+				int curr_zoom = SSM(sci, SCI_GETZOOM, 0, 0);
+				++curr_zoom;
+				if (curr_size + curr_zoom*SC_FONT_SIZE_MULTIPLIER <= 2*SC_FONT_SIZE_MULTIPLIER)
+				{
+					SSM(sci, SCI_SETZOOM, curr_zoom, curr_zoom);
+				}
 				update_margins(sci);
+			}
 			break;
 	}
 	/* we always return FALSE here to let plugins handle the event too */

--- a/src/editor.c
+++ b/src/editor.c
@@ -1195,7 +1195,10 @@ static gboolean on_editor_notify(G_GNUC_UNUSED GObject *object, GeanyEditor *edi
 			break;
 
 		case SCN_ZOOM:
-			update_margins(sci);
+			if (editor_prefs.zoom_disable_scrollwheel)
+				sci_zoom_off(editor->sci);
+			else
+				update_margins(sci);
 			break;
 	}
 	/* we always return FALSE here to let plugins handle the event too */

--- a/src/editor.h
+++ b/src/editor.h
@@ -138,6 +138,7 @@ typedef struct GeanyEditorPrefs
 	gint		autocompletion_update_freq;
 	gint		scroll_lines_around_cursor;
 	gint		ime_interaction; /* input method editor's candidate window behaviour */
+	gboolean	zoom_disable_scrollwheel;
 }
 GeanyEditorPrefs;
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -247,6 +247,8 @@ static void init_pref_groups(void)
 		"indent_hard_tab_width", 8);
 	stash_group_add_integer(group, &editor_prefs.ime_interaction,
 		"editor_ime_interaction", SC_IME_WINDOWED);
+	stash_group_add_boolean(group, &editor_prefs.zoom_disable_scrollwheel,
+		"zoom_disable_scrollwheel", FALSE);
 
 	group = stash_group_new(PACKAGE);
 	configuration_add_various_pref_group(group, "files");

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -365,13 +365,25 @@ gboolean sci_is_modified(ScintillaObject *sci)
 
 void sci_zoom_in(ScintillaObject *sci)
 {
-	SSM(sci, SCI_ZOOMIN, 0, 0);
+	// SCI_ZOOMIN is limited to 20, SCI_SETZOOM is unlimited
+	int curr_zoom = SSM(sci, SCI_GETZOOM, 0, 0);
+	++curr_zoom;
+	SSM(sci, SCI_SETZOOM, curr_zoom, curr_zoom);
 }
 
 
 void sci_zoom_out(ScintillaObject *sci)
 {
-	SSM(sci, SCI_ZOOMOUT, 0, 0);
+	int curr_size = SSM(sci, SCI_STYLEGETSIZEFRACTIONAL, STYLE_DEFAULT, STYLE_DEFAULT);
+	int curr_zoom = SSM(sci, SCI_GETZOOM, 0, 0);
+
+	// SCI_ZOOMOUT is limited to -10, SCI_SETZOOM is unlimited.
+	// Minimum font size is 2pt.  Number of zoom levels depends on base font size.
+	if (curr_size + curr_zoom*SC_FONT_SIZE_MULTIPLIER > 2*SC_FONT_SIZE_MULTIPLIER)
+	{
+		--curr_zoom;
+		SSM(sci, SCI_SETZOOM, curr_zoom, curr_zoom);
+	}
 }
 
 

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -374,16 +374,13 @@ void sci_zoom_in(ScintillaObject *sci)
 
 void sci_zoom_out(ScintillaObject *sci)
 {
-	int curr_size = SSM(sci, SCI_STYLEGETSIZEFRACTIONAL, STYLE_DEFAULT, STYLE_DEFAULT);
-	int curr_zoom = SSM(sci, SCI_GETZOOM, 0, 0);
-
 	// SCI_ZOOMOUT is limited to -10, SCI_SETZOOM is unlimited.
-	// Minimum font size is 2pt.  Number of zoom levels depends on base font size.
-	if (curr_size + curr_zoom*SC_FONT_SIZE_MULTIPLIER > 2*SC_FONT_SIZE_MULTIPLIER)
-	{
-		--curr_zoom;
-		SSM(sci, SCI_SETZOOM, curr_zoom, curr_zoom);
-	}
+	int curr_zoom = SSM(sci, SCI_GETZOOM, 0, 0);
+	--curr_zoom;
+	SSM(sci, SCI_SETZOOM, curr_zoom, curr_zoom);
+
+	// Minimum font size is 2pt, but it is not necessary to check here
+	// because it is checked in on_editor_notify() in editor.c.
 }
 
 


### PR DESCRIPTION
This PR adds an option to disable zooming via the scroll wheel.   Zooming via the keybindings is still possible when this option is enabled.

I have the editor font sent to a comfortable size.  Many shortcuts consist of combining the Control key with others.  And of course, the touchpad is used for moving the cursor.  So very frequently (multiple times per day), I accidentally engage the scrolling function of the touchpad while the control key is pressed.  This causes the editor view to zoom, which is disruptive.

The zoom range of the keybindings is also expanded.  Resolves #2750.

* Range of zoom in via scroll wheel is unaffected (up to +20).  (Cannot be changed because controlled by Scintilla.)
* Zoom in via keybinding is "unlimited".  (But everyone stops zooming eventually.)
* Zoom out (both keybinding and scroll wheel) is stopped when the font size reaches 2pt (limited by scintilla).  Current behavior is to zoom out to -10 even when the font size doesn't change.  So for a base font size of 10pt, the current behavior has the last three zoom levels (-8, -9, -10) set at 2pt.  This PR stops at -8.  But if the base font size is 16pt, zoom out with this PR continues to -14.