### PR TITLE
Rearrange struct members to remove padding bytes

### DIFF
--- a/src/highlightingmappings.h
+++ b/src/highlightingmappings.h
@@ -33,7 +33,7 @@ G_BEGIN_DECLS
 /* contains all filtypes informations in the form of:
  *  - highlighting_lexer_LANG:		the SCI lexer
  *  - highlighting_styles_LANG:		SCI style/named style mappings.  The first
- * 									item is also used for the default style.
+ *									item is also used for the default style.
  *  - highlighting_keywords_LANG:	keywords ID/name mappings
  *  - highlighting_properties_LANG:	default SCI properties and their value
  * where LANG is the lang part from GEANY_FILETYPE_LANG
@@ -46,15 +46,15 @@ G_BEGIN_DECLS
 
 typedef struct
 {
-	guint		 style;		/* SCI style */
 	const gchar	*name;		/* style name in the filetypes.* file */
+	guint		 style;		/* SCI style */
 	gboolean	 fill_eol;	/* whether to set EOLFILLED flag to this style */
 } HLStyle;
 
 typedef struct
 {
-	guint		 id;	/* SCI keyword ID */
 	const gchar	*key;	/* keywords entry name in the filetypes.* file */
+	guint		 id;	/* SCI keyword ID */
 	gboolean	 merge;	/* whether to merge with session types */
 } HLKeyword;
 
@@ -76,23 +76,23 @@ typedef struct
 #define highlighting_lexer_ABAQUS			SCLEX_ABAQUS
 static const HLStyle highlighting_styles_ABAQUS[] =
 {
-	{ SCE_ABAQUS_DEFAULT,		"default",		FALSE },
-	{ SCE_ABAQUS_COMMENT,		"comment",		FALSE },
-	{ SCE_ABAQUS_NUMBER,		"number",		FALSE },
-	{ SCE_ABAQUS_STRING,		"string",		FALSE },
-	{ SCE_ABAQUS_OPERATOR,		"operator",		FALSE },
-	{ SCE_ABAQUS_PROCESSOR,		"processor",		FALSE },
-	{ SCE_ABAQUS_STARCOMMAND,	"starcommand",		FALSE },
-	{ SCE_ABAQUS_ARGUMENT,		"argument",		FALSE }
+	{ "default",			SCE_ABAQUS_DEFAULT,			FALSE },
+	{ "comment",			SCE_ABAQUS_COMMENT,			FALSE },
+	{ "number",				SCE_ABAQUS_NUMBER,			FALSE },
+	{ "string",				SCE_ABAQUS_STRING,			FALSE },
+	{ "operator",			SCE_ABAQUS_OPERATOR,		FALSE },
+	{ "processor",			SCE_ABAQUS_PROCESSOR,		FALSE },
+	{ "starcommand",		SCE_ABAQUS_STARCOMMAND,		FALSE },
+	{ "argument",			SCE_ABAQUS_ARGUMENT,		FALSE }
 };
 static const HLKeyword highlighting_keywords_ABAQUS[] =
 {
-	{ 0, "processors", FALSE },
-	{ 1, "commands", FALSE },
-	{ 2, "slashommands", FALSE },
-	{ 3, "starcommands", FALSE },
-	{ 4, "arguments", FALSE },
-	{ 5, "functions", FALSE }
+	{ "processors",			0,		FALSE },
+	{ "commands",			1,		FALSE },
+	{ "slashommands",		2,		FALSE },
+	{ "starcommands",		3,		FALSE },
+	{ "arguments",			4,		FALSE },
+	{ "functions",			5,		FALSE }
 };
 #define highlighting_properties_ABAQUS		EMPTY_PROPERTIES
 
@@ -101,22 +101,22 @@ static const HLKeyword highlighting_keywords_ABAQUS[] =
 #define highlighting_lexer_ADA			SCLEX_ADA
 static const HLStyle highlighting_styles_ADA[] =
 {
-	{ SCE_ADA_DEFAULT,		"default",		FALSE },
-	{ SCE_ADA_WORD,			"word",			FALSE },
-	{ SCE_ADA_IDENTIFIER,	"identifier",	FALSE },
-	{ SCE_ADA_NUMBER,		"number",		FALSE },
-	{ SCE_ADA_DELIMITER,	"delimiter",	FALSE },
-	{ SCE_ADA_CHARACTER,	"character",	FALSE },
-	{ SCE_ADA_CHARACTEREOL,	"charactereol",	FALSE },
-	{ SCE_ADA_STRING,		"string",		FALSE },
-	{ SCE_ADA_STRINGEOL,	"stringeol",	FALSE },
-	{ SCE_ADA_LABEL,		"label",		FALSE },
-	{ SCE_ADA_COMMENTLINE,	"commentline",	FALSE },
-	{ SCE_ADA_ILLEGAL,		"illegal",		FALSE }
+	{ "default",		SCE_ADA_DEFAULT,			FALSE },
+	{ "word",			SCE_ADA_WORD,				FALSE },
+	{ "identifier",		SCE_ADA_IDENTIFIER,			FALSE },
+	{ "number",			SCE_ADA_NUMBER,				FALSE },
+	{ "delimiter",		SCE_ADA_DELIMITER,			FALSE },
+	{ "character",		SCE_ADA_CHARACTER,			FALSE },
+	{ "charactereol",	SCE_ADA_CHARACTEREOL,		FALSE },
+	{ "string",			SCE_ADA_STRING,				FALSE },
+	{ "stringeol",		SCE_ADA_STRINGEOL,			FALSE },
+	{ "label",			SCE_ADA_LABEL,				FALSE },
+	{ "commentline",	SCE_ADA_COMMENTLINE,		FALSE },
+	{ "illegal",		SCE_ADA_ILLEGAL,			FALSE }
 };
 static const HLKeyword highlighting_keywords_ADA[] =
 {
-	{ 0, "primary",	FALSE }
+	{ "primary", 0,	FALSE }
 };
 #define highlighting_properties_ADA		EMPTY_PROPERTIES
 
@@ -126,9 +126,9 @@ static const HLKeyword highlighting_keywords_ADA[] =
 #define highlighting_styles_AS		highlighting_styles_C
 static const HLKeyword highlighting_keywords_AS[] =
 {
-	{ 0, "primary",		FALSE },
-	{ 1, "secondary",	FALSE },
-	{ 3, "classes",		FALSE }
+	{ "primary",		0,	FALSE },
+	{ "secondary",		1,	FALSE },
+	{ "classes",		3,	FALSE }
 };
 #define highlighting_properties_AS	highlighting_properties_C
 
@@ -137,30 +137,30 @@ static const HLKeyword highlighting_keywords_AS[] =
 #define highlighting_lexer_ASM			SCLEX_ASM
 static const HLStyle highlighting_styles_ASM[] =
 {
-	{ SCE_ASM_DEFAULT,			"default",				FALSE },
-	{ SCE_ASM_COMMENT,			"comment",				FALSE },
-	{ SCE_ASM_NUMBER,			"number",				FALSE },
-	{ SCE_ASM_STRING,			"string",				FALSE },
-	{ SCE_ASM_OPERATOR,			"operator",				FALSE },
-	{ SCE_ASM_IDENTIFIER,		"identifier",			FALSE },
-	{ SCE_ASM_CPUINSTRUCTION,	"cpuinstruction",		FALSE },
-	{ SCE_ASM_MATHINSTRUCTION,	"mathinstruction",		FALSE },
-	{ SCE_ASM_REGISTER,			"register",				FALSE },
-	{ SCE_ASM_DIRECTIVE,		"directive",			FALSE },
-	{ SCE_ASM_DIRECTIVEOPERAND,	"directiveoperand",		FALSE },
-	{ SCE_ASM_COMMENTBLOCK,		"commentblock",			FALSE },
-	{ SCE_ASM_CHARACTER,		"character",			FALSE },
-	{ SCE_ASM_STRINGEOL,		"stringeol",			FALSE },
-	{ SCE_ASM_EXTINSTRUCTION,	"extinstruction",		FALSE },
-	{ SCE_ASM_COMMENTDIRECTIVE,	"commentdirective",		FALSE }
+	{ "default",			SCE_ASM_DEFAULT,			FALSE },
+	{ "comment",			SCE_ASM_COMMENT,			FALSE },
+	{ "number",				SCE_ASM_NUMBER,				FALSE },
+	{ "string",				SCE_ASM_STRING,				FALSE },
+	{ "operator",			SCE_ASM_OPERATOR,			FALSE },
+	{ "identifier",			SCE_ASM_IDENTIFIER,			FALSE },
+	{ "cpuinstruction",		SCE_ASM_CPUINSTRUCTION,		FALSE },
+	{ "mathinstruction",	SCE_ASM_MATHINSTRUCTION,	FALSE },
+	{ "register",			SCE_ASM_REGISTER,			FALSE },
+	{ "directive",			SCE_ASM_DIRECTIVE,			FALSE },
+	{ "directiveoperand",	SCE_ASM_DIRECTIVEOPERAND,	FALSE },
+	{ "commentblock",		SCE_ASM_COMMENTBLOCK,		FALSE },
+	{ "character",			SCE_ASM_CHARACTER,			FALSE },
+	{ "stringeol",			SCE_ASM_STRINGEOL,			FALSE },
+	{ "extinstruction",		SCE_ASM_EXTINSTRUCTION,		FALSE },
+	{ "commentdirective",	SCE_ASM_COMMENTDIRECTIVE,	FALSE }
 };
 static const HLKeyword highlighting_keywords_ASM[] =
 {
-	{ 0, "instructions",	FALSE },
-	/*{ 1, "instructions",	FALSE },*/
-	{ 2, "registers",		FALSE },
-	{ 3, "directives",		FALSE }
-	/*{ 5, "instructions",	FALSE }*/
+	{ "instructions",	0,	FALSE },
+	/*{ "instructions",	1,	FALSE },*/
+	{ "registers",		2,	FALSE },
+	{ "directives",		3,	FALSE }
+	/*{ "instructions",	5,	FALSE }*/
 };
 #define highlighting_properties_ASM		EMPTY_PROPERTIES
 
@@ -169,36 +169,36 @@ static const HLKeyword highlighting_keywords_ASM[] =
 #define highlighting_lexer_BASIC		SCLEX_FREEBASIC
 static const HLStyle highlighting_styles_BASIC[] =
 {
-	{ SCE_B_DEFAULT,		"default",			FALSE },
-	{ SCE_B_COMMENT,		"comment",			FALSE },
-	{ SCE_B_COMMENTBLOCK,	"commentblock",		FALSE },
-	{ SCE_B_DOCLINE,		"docline",			FALSE },
-	{ SCE_B_DOCBLOCK,		"docblock",			FALSE },
-	{ SCE_B_DOCKEYWORD,		"dockeyword",		FALSE },
-	{ SCE_B_NUMBER,			"number",			FALSE },
-	{ SCE_B_KEYWORD,		"word",				FALSE },
-	{ SCE_B_STRING,			"string",			FALSE },
-	{ SCE_B_PREPROCESSOR,	"preprocessor",		FALSE },
-	{ SCE_B_OPERATOR,		"operator",			FALSE },
-	{ SCE_B_IDENTIFIER,		"identifier",		FALSE },
-	{ SCE_B_DATE,			"date",				FALSE },
-	{ SCE_B_STRINGEOL,		"stringeol",		FALSE },
-	{ SCE_B_KEYWORD2,		"word2",			FALSE },
-	{ SCE_B_KEYWORD3,		"word3",			FALSE },
-	{ SCE_B_KEYWORD4,		"word4",			FALSE },
-	{ SCE_B_CONSTANT,		"constant",			FALSE },
-	{ SCE_B_ASM,			"asm",				FALSE },
-	{ SCE_B_LABEL,			"label",			FALSE },
-	{ SCE_B_ERROR,			"error",			FALSE },
-	{ SCE_B_HEXNUMBER,		"hexnumber",		FALSE },
-	{ SCE_B_BINNUMBER,		"binnumber",		FALSE }
+	{ "default",		SCE_B_DEFAULT,			FALSE },
+	{ "comment",		SCE_B_COMMENT,			FALSE },
+	{ "commentblock",	SCE_B_COMMENTBLOCK,		FALSE },
+	{ "docline",		SCE_B_DOCLINE,			FALSE },
+	{ "docblock",		SCE_B_DOCBLOCK,			FALSE },
+	{ "dockeyword",		SCE_B_DOCKEYWORD,		FALSE },
+	{ "number",			SCE_B_NUMBER,			FALSE },
+	{ "word",			SCE_B_KEYWORD,			FALSE },
+	{ "string",			SCE_B_STRING,			FALSE },
+	{ "preprocessor",	SCE_B_PREPROCESSOR,		FALSE },
+	{ "operator",		SCE_B_OPERATOR,			FALSE },
+	{ "identifier",		SCE_B_IDENTIFIER,		FALSE },
+	{ "date",			SCE_B_DATE,				FALSE },
+	{ "stringeol",		SCE_B_STRINGEOL,		FALSE },
+	{ "word2",			SCE_B_KEYWORD2,			FALSE },
+	{ "word3",			SCE_B_KEYWORD3,			FALSE },
+	{ "word4",			SCE_B_KEYWORD4,			FALSE },
+	{ "constant",		SCE_B_CONSTANT,			FALSE },
+	{ "asm",			SCE_B_ASM,				FALSE },
+	{ "label",			SCE_B_LABEL,			FALSE },
+	{ "error",			SCE_B_ERROR,			FALSE },
+	{ "hexnumber",		SCE_B_HEXNUMBER,		FALSE },
+	{ "binnumber",		SCE_B_BINNUMBER,		FALSE }
 };
 static const HLKeyword highlighting_keywords_BASIC[] =
 {
-	{ 0, "keywords",		FALSE },
-	{ 1, "preprocessor",	FALSE },
-	{ 2, "user1",			FALSE },
-	{ 3, "user2",			FALSE }
+	{ "keywords",		0,	FALSE },
+	{ "preprocessor",	1,	FALSE },
+	{ "user1",			2,	FALSE },
+	{ "user2",			3,	FALSE }
 };
 #define highlighting_properties_BASIC	EMPTY_PROPERTIES
 
@@ -207,19 +207,19 @@ static const HLKeyword highlighting_keywords_BASIC[] =
 #define highlighting_lexer_BATCH		SCLEX_BATCH
 static const HLStyle highlighting_styles_BATCH[] =
 {
-	{ SCE_BAT_DEFAULT,		"default",		FALSE },
-	{ SCE_BAT_COMMENT,		"comment",		FALSE },
-	{ SCE_BAT_LABEL,		"label",		FALSE },
-	{ SCE_BAT_WORD,			"word",			FALSE },
-	{ SCE_BAT_HIDE,			"hide",			FALSE },
-	{ SCE_BAT_COMMAND,		"command",		FALSE },
-	{ SCE_BAT_IDENTIFIER,	"identifier",	FALSE },
-	{ SCE_BAT_OPERATOR,		"operator",		FALSE }
+	{ "default",		SCE_BAT_DEFAULT,		FALSE },
+	{ "comment",		SCE_BAT_COMMENT,		FALSE },
+	{ "label",			SCE_BAT_LABEL,			FALSE },
+	{ "word",			SCE_BAT_WORD,			FALSE },
+	{ "hide",			SCE_BAT_HIDE,			FALSE },
+	{ "command",		SCE_BAT_COMMAND,		FALSE },
+	{ "identifier",		SCE_BAT_IDENTIFIER,		FALSE },
+	{ "operator",		SCE_BAT_OPERATOR,		FALSE }
 };
 static const HLKeyword highlighting_keywords_BATCH[] =
 {
-	{ 0, "keywords",			FALSE },
-	{ 1, "keywords_optional",	FALSE }
+	{ "keywords",			0,	FALSE },
+	{ "keywords_optional",	1,	FALSE }
 };
 #define highlighting_properties_BATCH	EMPTY_PROPERTIES
 
@@ -229,43 +229,43 @@ static const HLKeyword highlighting_keywords_BATCH[] =
 #define highlighting_lexer_C		SCLEX_CPP
 static const HLStyle highlighting_styles_C[] =
 {
-	{ SCE_C_DEFAULT,				"default",					FALSE },
-	{ SCE_C_COMMENT,				"comment",					FALSE },
-	{ SCE_C_COMMENTLINE,			"commentline",				FALSE },
-	{ SCE_C_COMMENTDOC,				"commentdoc",				FALSE },
-	{ SCE_C_PREPROCESSORCOMMENT,	"preprocessorcomment",		FALSE },
-	{ SCE_C_PREPROCESSORCOMMENTDOC,	"preprocessorcommentdoc",	FALSE },
-	{ SCE_C_NUMBER,					"number",					FALSE },
-	{ SCE_C_WORD,					"word",						FALSE },
-	{ SCE_C_WORD2,					"word2",					FALSE },
-	{ SCE_C_STRING,					"string",					FALSE },
-	{ SCE_C_STRINGRAW,				"stringraw",				FALSE },
-	{ SCE_C_CHARACTER,				"character",				FALSE },
-	{ SCE_C_USERLITERAL,			"userliteral",				FALSE },
-	{ SCE_C_UUID,					"uuid",						FALSE },
-	{ SCE_C_PREPROCESSOR,			"preprocessor",				FALSE },
-	{ SCE_C_OPERATOR,				"operator",					FALSE },
-	{ SCE_C_IDENTIFIER,				"identifier",				FALSE },
-	{ SCE_C_STRINGEOL,				"stringeol",				FALSE },
-	{ SCE_C_VERBATIM,				"verbatim",					FALSE },
+	{ "default",				SCE_C_DEFAULT,					FALSE },
+	{ "comment",				SCE_C_COMMENT,					FALSE },
+	{ "commentline",			SCE_C_COMMENTLINE,				FALSE },
+	{ "commentdoc",				SCE_C_COMMENTDOC,				FALSE },
+	{ "preprocessorcomment",	SCE_C_PREPROCESSORCOMMENT,		FALSE },
+	{ "preprocessorcommentdoc",	SCE_C_PREPROCESSORCOMMENTDOC,	FALSE },
+	{ "number",					SCE_C_NUMBER,					FALSE },
+	{ "word",					SCE_C_WORD,						FALSE },
+	{ "word2",					SCE_C_WORD2,					FALSE },
+	{ "string",					SCE_C_STRING,					FALSE },
+	{ "stringraw",				SCE_C_STRINGRAW,				FALSE },
+	{ "character",				SCE_C_CHARACTER,				FALSE },
+	{ "userliteral",			SCE_C_USERLITERAL,				FALSE },
+	{ "uuid",					SCE_C_UUID,						FALSE },
+	{ "preprocessor",			SCE_C_PREPROCESSOR,				FALSE },
+	{ "operator",				SCE_C_OPERATOR,					FALSE },
+	{ "identifier",				SCE_C_IDENTIFIER,				FALSE },
+	{ "stringeol",				SCE_C_STRINGEOL,				FALSE },
+	{ "verbatim",				SCE_C_VERBATIM,					FALSE },
 	/* triple verbatims use the same style */
-	{ SCE_C_TRIPLEVERBATIM,			"verbatim",					FALSE },
-	{ SCE_C_REGEX,					"regex",					FALSE },
-	{ SCE_C_HASHQUOTEDSTRING,		"hashquotedstring",			FALSE },
-	{ SCE_C_COMMENTLINEDOC,			"commentlinedoc",			FALSE },
-	{ SCE_C_COMMENTDOCKEYWORD,		"commentdockeyword",		FALSE },
-	{ SCE_C_COMMENTDOCKEYWORDERROR,	"commentdockeyworderror",	FALSE },
+	{ "verbatim",				SCE_C_TRIPLEVERBATIM,			FALSE },
+	{ "regex",					SCE_C_REGEX,					FALSE },
+	{ "hashquotedstring",		SCE_C_HASHQUOTEDSTRING,			FALSE },
+	{ "commentlinedoc",			SCE_C_COMMENTLINEDOC,			FALSE },
+	{ "commentdockeyword",		SCE_C_COMMENTDOCKEYWORD,		FALSE },
+	{ "commentdockeyworderror",	SCE_C_COMMENTDOCKEYWORDERROR,	FALSE },
 	/* used for local structs and typedefs */
-	{ SCE_C_GLOBALCLASS,			"globalclass",				FALSE },
-	{ SCE_C_TASKMARKER,				"taskmarker",				FALSE },
-	{ SCE_C_ESCAPESEQUENCE,			"escapesequence",			FALSE }
+	{ "globalclass",			SCE_C_GLOBALCLASS,				FALSE },
+	{ "taskmarker",				SCE_C_TASKMARKER,				FALSE },
+	{ "escapesequence",			SCE_C_ESCAPESEQUENCE,			FALSE }
 };
 static const HLKeyword highlighting_keywords_C[] =
 {
-	{ 0, "primary",		FALSE },
+	{ "primary",	0,	FALSE },
 	/* SCI_SETKEYWORDS = 1 - secondary + global tags file types, see below */
-	{ 1, "secondary",	TRUE },
-	{ 2, "docComment",	FALSE }
+	{ "secondary",	1,	TRUE },
+	{ "docComment", 2,	FALSE }
 	/* SCI_SETKEYWORDS = 3 is for current session types - see document_highlight_tags() */
 };
 static const HLProperty highlighting_properties_C[] =
@@ -278,27 +278,27 @@ static const HLProperty highlighting_properties_C[] =
 #define highlighting_lexer_CAML			SCLEX_CAML
 static const HLStyle highlighting_styles_CAML[] =
 {
-	{ SCE_CAML_DEFAULT,		"default",		FALSE },
-	{ SCE_CAML_COMMENT,		"comment",		FALSE },
-	{ SCE_CAML_COMMENT1,	"comment1",		FALSE },
-	{ SCE_CAML_COMMENT2,	"comment2",		FALSE },
-	{ SCE_CAML_COMMENT3,	"comment3",		FALSE },
-	{ SCE_CAML_NUMBER,		"number",		FALSE },
-	{ SCE_CAML_KEYWORD,		"keyword",		FALSE },
-	{ SCE_CAML_KEYWORD2,	"keyword2",		FALSE },
-	{ SCE_CAML_KEYWORD3,	"keyword3",		FALSE },
-	{ SCE_CAML_STRING,		"string",		FALSE },
-	{ SCE_CAML_CHAR,		"char",			FALSE },
-	{ SCE_CAML_OPERATOR,	"operator",		FALSE },
-	{ SCE_CAML_IDENTIFIER,	"identifier",	FALSE },
-	{ SCE_CAML_TAGNAME,		"tagname",		FALSE },
-	{ SCE_CAML_LINENUM,		"linenum",		FALSE },
-	{ SCE_CAML_WHITE,		"white",		FALSE }
+	{ "default",		SCE_CAML_DEFAULT,			FALSE },
+	{ "comment",		SCE_CAML_COMMENT,			FALSE },
+	{ "comment1",		SCE_CAML_COMMENT1,			FALSE },
+	{ "comment2",		SCE_CAML_COMMENT2,			FALSE },
+	{ "comment3",		SCE_CAML_COMMENT3,			FALSE },
+	{ "number",			SCE_CAML_NUMBER,			FALSE },
+	{ "keyword",		SCE_CAML_KEYWORD,			FALSE },
+	{ "keyword2",		SCE_CAML_KEYWORD2,			FALSE },
+	{ "keyword3",		SCE_CAML_KEYWORD3,			FALSE },
+	{ "string",			SCE_CAML_STRING,			FALSE },
+	{ "char",			SCE_CAML_CHAR,				FALSE },
+	{ "operator",		SCE_CAML_OPERATOR,			FALSE },
+	{ "identifier",		SCE_CAML_IDENTIFIER,		FALSE },
+	{ "tagname",		SCE_CAML_TAGNAME,			FALSE },
+	{ "linenum",		SCE_CAML_LINENUM,			FALSE },
+	{ "white",			SCE_CAML_WHITE,				FALSE }
 };
 static const HLKeyword highlighting_keywords_CAML[] =
 {
-	{ 0, "keywords",			FALSE },
-	{ 1, "keywords_optional",	FALSE }
+	{ "keywords",			0,	FALSE },
+	{ "keywords_optional",	1,	FALSE }
 };
 #define highlighting_properties_CAML	EMPTY_PROPERTIES
 
@@ -307,27 +307,27 @@ static const HLKeyword highlighting_keywords_CAML[] =
 #define highlighting_lexer_CMAKE		SCLEX_CMAKE
 static const HLStyle highlighting_styles_CMAKE[] =
 {
-	{ SCE_CMAKE_DEFAULT,		"default",		FALSE },
-	{ SCE_CMAKE_COMMENT,		"comment",		FALSE },
-	{ SCE_CMAKE_STRINGDQ,		"stringdq",		FALSE },
-	{ SCE_CMAKE_STRINGLQ,		"stringlq",		FALSE },
-	{ SCE_CMAKE_STRINGRQ,		"stringrq",		FALSE },
-	{ SCE_CMAKE_COMMANDS,		"command",		FALSE },
-	{ SCE_CMAKE_PARAMETERS,		"parameters",	FALSE },
-	{ SCE_CMAKE_VARIABLE,		"variable",		FALSE },
-	{ SCE_CMAKE_USERDEFINED,	"userdefined",	FALSE },
-	{ SCE_CMAKE_WHILEDEF,		"whiledef",		FALSE },
-	{ SCE_CMAKE_FOREACHDEF,		"foreachdef",	FALSE },
-	{ SCE_CMAKE_IFDEFINEDEF,	"ifdefinedef",	FALSE },
-	{ SCE_CMAKE_MACRODEF,		"macrodef",		FALSE },
-	{ SCE_CMAKE_STRINGVAR,		"stringvar",	FALSE },
-	{ SCE_CMAKE_NUMBER,			"number",		FALSE }
+	{ "default",		SCE_CMAKE_DEFAULT,			FALSE },
+	{ "comment",		SCE_CMAKE_COMMENT,			FALSE },
+	{ "stringdq",		SCE_CMAKE_STRINGDQ,			FALSE },
+	{ "stringlq",		SCE_CMAKE_STRINGLQ,			FALSE },
+	{ "stringrq",		SCE_CMAKE_STRINGRQ,			FALSE },
+	{ "command",		SCE_CMAKE_COMMANDS,			FALSE },
+	{ "parameters",		SCE_CMAKE_PARAMETERS,		FALSE },
+	{ "variable",		SCE_CMAKE_VARIABLE,			FALSE },
+	{ "userdefined",	SCE_CMAKE_USERDEFINED,		FALSE },
+	{ "whiledef",		SCE_CMAKE_WHILEDEF,			FALSE },
+	{ "foreachdef",		SCE_CMAKE_FOREACHDEF,		FALSE },
+	{ "ifdefinedef",	SCE_CMAKE_IFDEFINEDEF,		FALSE },
+	{ "macrodef",		SCE_CMAKE_MACRODEF,			FALSE },
+	{ "stringvar",		SCE_CMAKE_STRINGVAR,		FALSE },
+	{ "number",			SCE_CMAKE_NUMBER,			FALSE }
 };
 static const HLKeyword highlighting_keywords_CMAKE[] =
 {
-	{ 0, "commands",	FALSE },
-	{ 1, "parameters",	FALSE },
-	{ 2, "userdefined",	FALSE }
+	{ "commands",		0,	FALSE },
+	{ "parameters",		1,	FALSE },
+	{ "userdefined",	2,	FALSE }
 };
 #define highlighting_properties_CMAKE	EMPTY_PROPERTIES
 
@@ -335,28 +335,28 @@ static const HLKeyword highlighting_keywords_CMAKE[] =
 #define highlighting_lexer_COFFEESCRIPT		SCLEX_COFFEESCRIPT
 static const HLStyle highlighting_styles_COFFEESCRIPT[] =
 {
-	{ SCE_COFFEESCRIPT_DEFAULT,					"default",				FALSE },
-	{ SCE_COFFEESCRIPT_COMMENTLINE,				"commentline",			FALSE },
-	{ SCE_COFFEESCRIPT_NUMBER,					"number",				FALSE },
-	{ SCE_COFFEESCRIPT_WORD,					"word",					FALSE },
-	{ SCE_COFFEESCRIPT_STRING,					"string",				FALSE },
-	{ SCE_COFFEESCRIPT_CHARACTER,				"character",			FALSE },
-	{ SCE_COFFEESCRIPT_OPERATOR,				"operator",				FALSE },
-	{ SCE_COFFEESCRIPT_IDENTIFIER,				"identifier",			FALSE },
-	{ SCE_COFFEESCRIPT_STRINGEOL,				"stringeol",			FALSE },
-	{ SCE_COFFEESCRIPT_REGEX,					"regex",				FALSE },
-	{ SCE_COFFEESCRIPT_WORD2,					"word2",				FALSE },
-	{ SCE_COFFEESCRIPT_GLOBALCLASS,				"globalclass",			FALSE },
-	{ SCE_COFFEESCRIPT_COMMENTBLOCK,			"commentblock",			FALSE },
-	{ SCE_COFFEESCRIPT_VERBOSE_REGEX,			"verbose_regex",		FALSE },
-	{ SCE_COFFEESCRIPT_VERBOSE_REGEX_COMMENT,	"verbose_regex_comment",FALSE },
-	{ SCE_COFFEESCRIPT_INSTANCEPROPERTY,		"instanceproperty",		FALSE }
+	{ "default",				SCE_COFFEESCRIPT_DEFAULT,				FALSE },
+	{ "commentline",			SCE_COFFEESCRIPT_COMMENTLINE,			FALSE },
+	{ "number",					SCE_COFFEESCRIPT_NUMBER,				FALSE },
+	{ "word",					SCE_COFFEESCRIPT_WORD,					FALSE },
+	{ "string",					SCE_COFFEESCRIPT_STRING,				FALSE },
+	{ "character",				SCE_COFFEESCRIPT_CHARACTER,				FALSE },
+	{ "operator",				SCE_COFFEESCRIPT_OPERATOR,				FALSE },
+	{ "identifier",				SCE_COFFEESCRIPT_IDENTIFIER,			FALSE },
+	{ "stringeol",				SCE_COFFEESCRIPT_STRINGEOL,				FALSE },
+	{ "regex",					SCE_COFFEESCRIPT_REGEX,					FALSE },
+	{ "word2",					SCE_COFFEESCRIPT_WORD2,					FALSE },
+	{ "globalclass",			SCE_COFFEESCRIPT_GLOBALCLASS,			FALSE },
+	{ "commentblock",			SCE_COFFEESCRIPT_COMMENTBLOCK,			FALSE },
+	{ "verbose_regex",			SCE_COFFEESCRIPT_VERBOSE_REGEX,			FALSE },
+	{ "verbose_regex_comment",	SCE_COFFEESCRIPT_VERBOSE_REGEX_COMMENT,	FALSE },
+	{ "instanceproperty",		SCE_COFFEESCRIPT_INSTANCEPROPERTY,		FALSE }
 };
 static const HLKeyword highlighting_keywords_COFFEESCRIPT[] =
 {
-	{ 0, "primary",		FALSE },
-	{ 1, "secondary",	FALSE },
-	{ 3, "globalclass",	FALSE }
+	{ "primary",		0,	FALSE },
+	{ "secondary",		1,	FALSE },
+	{ "globalclass",	3,	FALSE }
 };
 #define highlighting_properties_COFFEESCRIPT	EMPTY_PROPERTIES
 
@@ -365,41 +365,41 @@ static const HLKeyword highlighting_keywords_COFFEESCRIPT[] =
 #define highlighting_lexer_CSS			SCLEX_CSS
 static const HLStyle highlighting_styles_CSS[] =
 {
-	{ SCE_CSS_DEFAULT,					"default",					FALSE },
-	{ SCE_CSS_COMMENT,					"comment",					FALSE },
-	{ SCE_CSS_TAG,						"tag",						FALSE },
-	{ SCE_CSS_CLASS,					"class",					FALSE },
-	{ SCE_CSS_PSEUDOCLASS,				"pseudoclass",				FALSE },
-	{ SCE_CSS_UNKNOWN_PSEUDOCLASS,		"unknown_pseudoclass",		FALSE },
-	{ SCE_CSS_UNKNOWN_IDENTIFIER,		"unknown_identifier",		FALSE },
-	{ SCE_CSS_OPERATOR,					"operator",					FALSE },
-	{ SCE_CSS_IDENTIFIER,				"identifier",				FALSE },
-	{ SCE_CSS_DOUBLESTRING,				"doublestring",				FALSE },
-	{ SCE_CSS_SINGLESTRING,				"singlestring",				FALSE },
-	{ SCE_CSS_ATTRIBUTE,				"attribute",				FALSE },
-	{ SCE_CSS_VALUE,					"value",					FALSE },
-	{ SCE_CSS_ID,						"id",						FALSE },
-	{ SCE_CSS_IDENTIFIER2,				"identifier2",				FALSE },
-	{ SCE_CSS_VARIABLE,					"variable",					FALSE },
-	{ SCE_CSS_IMPORTANT,				"important",				FALSE },
-	{ SCE_CSS_DIRECTIVE,				"directive",				FALSE },
-	{ SCE_CSS_IDENTIFIER3,				"identifier3",				FALSE },
-	{ SCE_CSS_PSEUDOELEMENT,			"pseudoelement",			FALSE },
-	{ SCE_CSS_EXTENDED_IDENTIFIER,		"extended_identifier",		FALSE },
-	{ SCE_CSS_EXTENDED_PSEUDOCLASS,		"extended_pseudoclass",		FALSE },
-	{ SCE_CSS_EXTENDED_PSEUDOELEMENT,	"extended_pseudoelement",	FALSE },
-	{ SCE_CSS_MEDIA,					"media",					FALSE }
+	{ "default",				SCE_CSS_DEFAULT,					FALSE },
+	{ "comment",				SCE_CSS_COMMENT,					FALSE },
+	{ "tag",					SCE_CSS_TAG,						FALSE },
+	{ "class",					SCE_CSS_CLASS,						FALSE },
+	{ "pseudoclass",			SCE_CSS_PSEUDOCLASS,				FALSE },
+	{ "unknown_pseudoclass",	SCE_CSS_UNKNOWN_PSEUDOCLASS,		FALSE },
+	{ "unknown_identifier",		SCE_CSS_UNKNOWN_IDENTIFIER,			FALSE },
+	{ "operator",				SCE_CSS_OPERATOR,					FALSE },
+	{ "identifier",				SCE_CSS_IDENTIFIER,					FALSE },
+	{ "doublestring",			SCE_CSS_DOUBLESTRING,				FALSE },
+	{ "singlestring",			SCE_CSS_SINGLESTRING,				FALSE },
+	{ "attribute",				SCE_CSS_ATTRIBUTE,					FALSE },
+	{ "value",					SCE_CSS_VALUE,						FALSE },
+	{ "id",						SCE_CSS_ID,							FALSE },
+	{ "identifier2",			SCE_CSS_IDENTIFIER2,				FALSE },
+	{ "variable",				SCE_CSS_VARIABLE,					FALSE },
+	{ "important",				SCE_CSS_IMPORTANT,					FALSE },
+	{ "directive",				SCE_CSS_DIRECTIVE,					FALSE },
+	{ "identifier3",			SCE_CSS_IDENTIFIER3,				FALSE },
+	{ "pseudoelement",			SCE_CSS_PSEUDOELEMENT,				FALSE },
+	{ "extended_identifier",	SCE_CSS_EXTENDED_IDENTIFIER,		FALSE },
+	{ "extended_pseudoclass",	SCE_CSS_EXTENDED_PSEUDOCLASS,		FALSE },
+	{ "extended_pseudoelement",	SCE_CSS_EXTENDED_PSEUDOELEMENT,		FALSE },
+	{ "media",					SCE_CSS_MEDIA,						FALSE }
 };
 static const HLKeyword highlighting_keywords_CSS[] =
 {
-	{ 0, "primary",					FALSE },
-	{ 1, "pseudoclasses",			FALSE },
-	{ 2, "secondary",				FALSE },
-	{ 3, "css3_properties",			FALSE },
-	{ 4, "pseudo_elements",			FALSE },
-	{ 5, "browser_css_properties",	FALSE },
-	{ 6, "browser_pseudo_classes",	FALSE },
-	{ 7, "browser_pseudo_elements",	FALSE }
+	{ "primary",					0,	FALSE },
+	{ "pseudoclasses",				1,	FALSE },
+	{ "secondary",					2,	FALSE },
+	{ "css3_properties",			3,	FALSE },
+	{ "pseudo_elements",			4,	FALSE },
+	{ "browser_css_properties",		5 ,	FALSE },
+	{ "browser_pseudo_classes",		6,	FALSE },
+	{ "browser_pseudo_elements",	7,	FALSE }
 };
 #define highlighting_properties_CSS		EMPTY_PROPERTIES
 
@@ -409,9 +409,9 @@ static const HLKeyword highlighting_keywords_CSS[] =
 #define highlighting_styles_COBOL		highlighting_styles_C
 static const HLKeyword highlighting_keywords_COBOL[] =
 {
-	{ 0, "primary",				FALSE },
-	{ 1, "secondary",			FALSE },
-	{ 2, "extended_keywords",	FALSE }
+	{ "primary",			0,	FALSE },
+	{ "secondary",			1,	FALSE },
+	{ "extended_keywords",	2,	FALSE }
 };
 #define highlighting_properties_COBOL	highlighting_properties_C
 
@@ -420,12 +420,12 @@ static const HLKeyword highlighting_keywords_COBOL[] =
 #define highlighting_lexer_CONF			SCLEX_PROPERTIES
 static const HLStyle highlighting_styles_CONF[] =
 {
-	{ SCE_PROPS_DEFAULT,	"default",		FALSE },
-	{ SCE_PROPS_COMMENT,	"comment",		FALSE },
-	{ SCE_PROPS_SECTION,	"section",		FALSE },
-	{ SCE_PROPS_KEY,		"key",			FALSE },
-	{ SCE_PROPS_ASSIGNMENT,	"assignment",	FALSE },
-	{ SCE_PROPS_DEFVAL,		"defval",		FALSE }
+	{ "default",	SCE_PROPS_DEFAULT,		FALSE },
+	{ "comment",	SCE_PROPS_COMMENT,		FALSE },
+	{ "section",	SCE_PROPS_SECTION,		FALSE },
+	{ "key",		SCE_PROPS_KEY,			FALSE },
+	{ "assignment",	SCE_PROPS_ASSIGNMENT,	FALSE },
+	{ "defval",		SCE_PROPS_DEFVAL,		FALSE }
 };
 #define highlighting_keywords_CONF		EMPTY_KEYWORDS
 #define highlighting_properties_CONF	EMPTY_PROPERTIES
@@ -435,39 +435,39 @@ static const HLStyle highlighting_styles_CONF[] =
 #define highlighting_lexer_D		SCLEX_D
 static const HLStyle highlighting_styles_D[] =
 {
-	{ SCE_D_DEFAULT,				"default",					FALSE },
-	{ SCE_D_COMMENT,				"comment",					FALSE },
-	{ SCE_D_COMMENTLINE,			"commentline",				FALSE },
-	{ SCE_D_COMMENTDOC,				"commentdoc",				FALSE },
-	{ SCE_D_COMMENTNESTED,			"commentnested",			FALSE },
-	{ SCE_D_NUMBER,					"number",					FALSE },
-	{ SCE_D_WORD,					"word",						FALSE },
-	{ SCE_D_WORD2,					"word2",					FALSE },
-	{ SCE_D_WORD3,					"word3",					FALSE },
-	{ SCE_D_TYPEDEF,				"typedef",					FALSE }, /* FIXME: don't remap here */
-	{ SCE_D_WORD5,					"typedef",					FALSE },
-	{ SCE_D_STRING,					"string",					FALSE },
-	{ SCE_D_STRINGB,				"string",					FALSE },
-	{ SCE_D_STRINGR,				"string",					FALSE },
-	{ SCE_D_STRINGEOL,				"stringeol",				FALSE },
-	{ SCE_D_CHARACTER,				"character",				FALSE },
-	{ SCE_D_OPERATOR,				"operator",					FALSE },
-	{ SCE_D_IDENTIFIER,				"identifier",				FALSE },
-	{ SCE_D_COMMENTLINEDOC,			"commentlinedoc",			FALSE },
-	{ SCE_D_COMMENTDOCKEYWORD,		"commentdockeyword",		FALSE },
-	{ SCE_D_COMMENTDOCKEYWORDERROR,	"commentdockeyworderror",	FALSE }
+	{ "default",					SCE_D_DEFAULT,						FALSE },
+	{ "comment",					SCE_D_COMMENT,						FALSE },
+	{ "commentline",				SCE_D_COMMENTLINE,					FALSE },
+	{ "commentdoc",					SCE_D_COMMENTDOC,					FALSE },
+	{ "commentnested",				SCE_D_COMMENTNESTED,				FALSE },
+	{ "number",						SCE_D_NUMBER,						FALSE },
+	{ "word",						SCE_D_WORD,							FALSE },
+	{ "word2",						SCE_D_WORD2,						FALSE },
+	{ "word3",						SCE_D_WORD3,						FALSE },
+	{ "typedef",					SCE_D_TYPEDEF,						FALSE }, /* FIXME: don't remap here */
+	{ "typedef",					SCE_D_WORD5,						FALSE },
+	{ "string",						SCE_D_STRING,						FALSE },
+	{ "string",						SCE_D_STRINGB,						FALSE },
+	{ "string",						SCE_D_STRINGR,						FALSE },
+	{ "stringeol",					SCE_D_STRINGEOL,					FALSE },
+	{ "character",					SCE_D_CHARACTER,					FALSE },
+	{ "operator",					SCE_D_OPERATOR,						FALSE },
+	{ "identifier",					SCE_D_IDENTIFIER,					FALSE },
+	{ "commentlinedoc",				SCE_D_COMMENTLINEDOC,				FALSE },
+	{ "commentdockeyword",			SCE_D_COMMENTDOCKEYWORD,			FALSE },
+	{ "commentdockeyworderror",		SCE_D_COMMENTDOCKEYWORDERROR,		FALSE }
 	/* these are for user-defined keywords we don't set yet */
-	/*{ SCE_D_WORD6,					"word6",					FALSE },
-	{ SCE_D_WORD7,					"word7",					FALSE }*/
+	/*{ "word6",					SCE_D_WORD6,						FALSE },
+	{ "word7",						SCE_D_WORD7,						FALSE }*/
 };
 static const HLKeyword highlighting_keywords_D[] =
 {
-	{ 0, "primary",		FALSE },
+	{ "primary",	0,	FALSE },
 	/* SCI_SETKEYWORDS = 1 - secondary + global tags file types */
-	{ 1, "secondary",	TRUE },
-	{ 2, "docComment",	FALSE },
+	{ "secondary",	1,	TRUE },
+	{ "docComment",	2,	FALSE },
 	/* SCI_SETKEYWORDS = 3 is for current session types - see document_highlight_tags() */
-	{ 4, "types",		FALSE },
+	{ "types",		4,	FALSE },
 };
 #define highlighting_properties_D		EMPTY_PROPERTIES
 
@@ -476,18 +476,18 @@ static const HLKeyword highlighting_keywords_D[] =
 #define highlighting_lexer_DIFF			SCLEX_DIFF
 static const HLStyle highlighting_styles_DIFF[] =
 {
-	{ SCE_DIFF_DEFAULT,					"default",				FALSE },
-	{ SCE_DIFF_COMMENT,					"comment",				FALSE },
-	{ SCE_DIFF_COMMAND,					"command",				FALSE },
-	{ SCE_DIFF_HEADER,					"header",				FALSE },
-	{ SCE_DIFF_POSITION,				"position",				FALSE },
-	{ SCE_DIFF_DELETED,					"deleted",				FALSE },
-	{ SCE_DIFF_ADDED,					"added",				FALSE },
-	{ SCE_DIFF_CHANGED,					"changed",				FALSE },
-	{ SCE_DIFF_PATCH_ADD,				"patch_add",			FALSE },
-	{ SCE_DIFF_PATCH_DELETE,			"patch_delete",			FALSE },
-	{ SCE_DIFF_REMOVED_PATCH_ADD,		"removed_patch_add",	FALSE },
-	{ SCE_DIFF_REMOVED_PATCH_DELETE,	"removed_patch_delete",	FALSE }
+	{ "default",					SCE_DIFF_DEFAULT,					FALSE },
+	{ "comment",					SCE_DIFF_COMMENT,					FALSE },
+	{ "command",					SCE_DIFF_COMMAND,					FALSE },
+	{ "header",						SCE_DIFF_HEADER,					FALSE },
+	{ "position",					SCE_DIFF_POSITION,					FALSE },
+	{ "deleted",					SCE_DIFF_DELETED,					FALSE },
+	{ "added",						SCE_DIFF_ADDED,						FALSE },
+	{ "changed",					SCE_DIFF_CHANGED,					FALSE },
+	{ "patch_add",					SCE_DIFF_PATCH_ADD,					FALSE },
+	{ "patch_delete",				SCE_DIFF_PATCH_DELETE,				FALSE },
+	{ "removed_patch_add",			SCE_DIFF_REMOVED_PATCH_ADD,			FALSE },
+	{ "removed_patch_delete",		SCE_DIFF_REMOVED_PATCH_DELETE,		FALSE }
 };
 #define highlighting_keywords_DIFF		EMPTY_KEYWORDS
 #define highlighting_properties_DIFF	EMPTY_PROPERTIES
@@ -496,40 +496,40 @@ static const HLStyle highlighting_styles_DIFF[] =
 #define highlighting_lexer_DOCBOOK			SCLEX_XML
 static const HLStyle highlighting_styles_DOCBOOK[] =
 {
-	{ SCE_H_DEFAULT,				"default",					FALSE	 },
-	{ SCE_H_TAG,					"tag",						FALSE	 },
-	{ SCE_H_TAGUNKNOWN,				"tagunknown",				FALSE	 },
-	{ SCE_H_ATTRIBUTE,				"attribute",				FALSE	 },
-	{ SCE_H_ATTRIBUTEUNKNOWN,		"attributeunknown",			FALSE	 },
-	{ SCE_H_NUMBER,					"number",					FALSE	 },
-	{ SCE_H_DOUBLESTRING,			"doublestring",				FALSE	 },
-	{ SCE_H_SINGLESTRING,			"singlestring",				FALSE	 },
-	{ SCE_H_OTHER,					"other",					FALSE	 },
-	{ SCE_H_COMMENT,				"comment",					FALSE	 },
-	{ SCE_H_ENTITY,					"entity",					FALSE	 },
-	{ SCE_H_TAGEND,					"tagend",					FALSE	 },
-	{ SCE_H_XMLSTART,				"xmlstart",					TRUE	 },
-	{ SCE_H_XMLEND,					"xmlend",					FALSE	 },
-	{ SCE_H_CDATA,					"cdata",					FALSE	 },
-	{ SCE_H_QUESTION,				"question",					FALSE	 },
-	{ SCE_H_VALUE,					"value",					FALSE	 },
-	{ SCE_H_XCCOMMENT,				"xccomment",				FALSE	 },
-	{ SCE_H_SGML_DEFAULT,			"sgml_default",				FALSE	 },
-	{ SCE_H_SGML_COMMENT,			"sgml_comment",				FALSE	 },
-	{ SCE_H_SGML_SPECIAL,			"sgml_special",				FALSE	 },
-	{ SCE_H_SGML_COMMAND,			"sgml_command",				FALSE	 },
-	{ SCE_H_SGML_DOUBLESTRING,		"sgml_doublestring",		FALSE	 },
-	{ SCE_H_SGML_SIMPLESTRING,		"sgml_simplestring",		FALSE	 },
-	{ SCE_H_SGML_1ST_PARAM,			"sgml_1st_param",			FALSE	 },
-	{ SCE_H_SGML_ENTITY,			"sgml_entity",				FALSE	 },
-	{ SCE_H_SGML_BLOCK_DEFAULT,		"sgml_block_default",		FALSE	 },
-	{ SCE_H_SGML_1ST_PARAM_COMMENT,	"sgml_1st_param_comment",	FALSE	 },
-	{ SCE_H_SGML_ERROR,				"sgml_error",				FALSE	 }
+	{ "default",				SCE_H_DEFAULT,					FALSE	 },
+	{ "tag",					SCE_H_TAG,						FALSE	 },
+	{ "tagunknown",				SCE_H_TAGUNKNOWN,				FALSE	 },
+	{ "attribute",				SCE_H_ATTRIBUTE,				FALSE	 },
+	{ "attributeunknown",		SCE_H_ATTRIBUTEUNKNOWN,			FALSE	 },
+	{ "number",					SCE_H_NUMBER,					FALSE	 },
+	{ "doublestring",			SCE_H_DOUBLESTRING,				FALSE	 },
+	{ "singlestring",			SCE_H_SINGLESTRING,				FALSE	 },
+	{ "other",					SCE_H_OTHER,					FALSE	 },
+	{ "comment",				SCE_H_COMMENT,					FALSE	 },
+	{ "entity",					SCE_H_ENTITY,					FALSE	 },
+	{ "tagend",					SCE_H_TAGEND,					FALSE	 },
+	{ "xmlstart",				SCE_H_XMLSTART,					TRUE	 },
+	{ "xmlend",					SCE_H_XMLEND,					FALSE	 },
+	{ "cdata",					SCE_H_CDATA,					FALSE	 },
+	{ "question",				SCE_H_QUESTION,					FALSE	 },
+	{ "value",					SCE_H_VALUE,					FALSE	 },
+	{ "xccomment",				SCE_H_XCCOMMENT,				FALSE	 },
+	{ "sgml_default",			SCE_H_SGML_DEFAULT,				FALSE	 },
+	{ "sgml_comment",			SCE_H_SGML_COMMENT,				FALSE	 },
+	{ "sgml_special",			SCE_H_SGML_SPECIAL,				FALSE	 },
+	{ "sgml_command",			SCE_H_SGML_COMMAND,				FALSE	 },
+	{ "sgml_doublestring",		SCE_H_SGML_DOUBLESTRING,		FALSE	 },
+	{ "sgml_simplestring",		SCE_H_SGML_SIMPLESTRING,		FALSE	 },
+	{ "sgml_1st_param",			SCE_H_SGML_1ST_PARAM,			FALSE	 },
+	{ "sgml_entity",			SCE_H_SGML_ENTITY,				FALSE	 },
+	{ "sgml_block_default",		SCE_H_SGML_BLOCK_DEFAULT,		FALSE	 },
+	{ "sgml_1st_param_comment",	SCE_H_SGML_1ST_PARAM_COMMENT,	FALSE	 },
+	{ "sgml_error",				SCE_H_SGML_ERROR,				FALSE	 }
 };
 static const HLKeyword highlighting_keywords_DOCBOOK[] =
 {
-	{ 0, "elements",	FALSE },
-	{ 5, "dtd",			FALSE }
+	{ "elements",	0,	FALSE },
+	{ "dtd",		5,	FALSE }
 };
 #define highlighting_properties_DOCBOOK		EMPTY_PROPERTIES
 
@@ -538,41 +538,41 @@ static const HLKeyword highlighting_keywords_DOCBOOK[] =
 #define highlighting_lexer_ERLANG		SCLEX_ERLANG
 static const HLStyle highlighting_styles_ERLANG[] =
 {
-	{ SCE_ERLANG_DEFAULT,			"default",				FALSE },
-	{ SCE_ERLANG_COMMENT,			"comment",				FALSE },
-	{ SCE_ERLANG_VARIABLE,			"variable",				FALSE },
-	{ SCE_ERLANG_NUMBER,			"number",				FALSE },
-	{ SCE_ERLANG_KEYWORD,			"keyword",				FALSE },
-	{ SCE_ERLANG_STRING,			"string",				FALSE },
-	{ SCE_ERLANG_OPERATOR,			"operator",				FALSE },
-	{ SCE_ERLANG_ATOM,				"atom",					FALSE },
-	{ SCE_ERLANG_FUNCTION_NAME,		"function_name",		FALSE },
-	{ SCE_ERLANG_CHARACTER,			"character",			FALSE },
-	{ SCE_ERLANG_MACRO,				"macro",				FALSE },
-	{ SCE_ERLANG_RECORD,			"record",				FALSE },
-	{ SCE_ERLANG_PREPROC,			"preproc",				FALSE },
-	{ SCE_ERLANG_NODE_NAME,			"node_name",			FALSE },
-	{ SCE_ERLANG_COMMENT_FUNCTION,	"comment_function",		FALSE },
-	{ SCE_ERLANG_COMMENT_MODULE,	"comment_module",		FALSE },
-	{ SCE_ERLANG_COMMENT_DOC,		"comment_doc",			FALSE },
-	{ SCE_ERLANG_COMMENT_DOC_MACRO,	"comment_doc_macro",	FALSE },
-	{ SCE_ERLANG_ATOM_QUOTED,		"atom_quoted",			FALSE },
-	{ SCE_ERLANG_MACRO_QUOTED,		"macro_quoted",			FALSE },
-	{ SCE_ERLANG_RECORD_QUOTED,		"record_quoted",		FALSE },
-	{ SCE_ERLANG_NODE_NAME_QUOTED,	"node_name_quoted",		FALSE },
-	{ SCE_ERLANG_BIFS,				"bifs",					FALSE },
-	{ SCE_ERLANG_MODULES,			"modules",				FALSE },
-	{ SCE_ERLANG_MODULES_ATT,		"modules_att",			FALSE },
-	{ SCE_ERLANG_UNKNOWN,			"unknown",				FALSE }
+	{ "default",				SCE_ERLANG_DEFAULT,					FALSE },
+	{ "comment",				SCE_ERLANG_COMMENT,					FALSE },
+	{ "variable",				SCE_ERLANG_VARIABLE,				FALSE },
+	{ "number",					SCE_ERLANG_NUMBER,					FALSE },
+	{ "keyword",				SCE_ERLANG_KEYWORD,					FALSE },
+	{ "string",					SCE_ERLANG_STRING,					FALSE },
+	{ "operator",				SCE_ERLANG_OPERATOR,				FALSE },
+	{ "atom",					SCE_ERLANG_ATOM,					FALSE },
+	{ "function_name",			SCE_ERLANG_FUNCTION_NAME,			FALSE },
+	{ "character",				SCE_ERLANG_CHARACTER,				FALSE },
+	{ "macro",					SCE_ERLANG_MACRO,					FALSE },
+	{ "record",					SCE_ERLANG_RECORD,					FALSE },
+	{ "preproc",				SCE_ERLANG_PREPROC,					FALSE },
+	{ "node_name",				SCE_ERLANG_NODE_NAME,				FALSE },
+	{ "comment_function",		SCE_ERLANG_COMMENT_FUNCTION,		FALSE },
+	{ "comment_module",			SCE_ERLANG_COMMENT_MODULE,			FALSE },
+	{ "comment_doc",			SCE_ERLANG_COMMENT_DOC,				FALSE },
+	{ "comment_doc_macro",		SCE_ERLANG_COMMENT_DOC_MACRO,		FALSE },
+	{ "atom_quoted",			SCE_ERLANG_ATOM_QUOTED,				FALSE },
+	{ "macro_quoted",			SCE_ERLANG_MACRO_QUOTED,			FALSE },
+	{ "record_quoted",			SCE_ERLANG_RECORD_QUOTED,			FALSE },
+	{ "node_name_quoted",		SCE_ERLANG_NODE_NAME_QUOTED,		FALSE },
+	{ "bifs",					SCE_ERLANG_BIFS,					FALSE },
+	{ "modules",				SCE_ERLANG_MODULES,					FALSE },
+	{ "modules_att",			SCE_ERLANG_MODULES_ATT,				FALSE },
+	{ "unknown",				SCE_ERLANG_UNKNOWN,					FALSE }
 };
 static const HLKeyword highlighting_keywords_ERLANG[] =
 {
-	{ 0, "keywords",	FALSE },
-	{ 1, "bifs",		FALSE },
-	{ 2, "preproc",		FALSE },
-	{ 3, "module",		FALSE },
-	{ 4, "doc",			FALSE },
-	{ 5, "doc_macro",	FALSE }
+	{ "keywords",	0,		FALSE },
+	{ "bifs",		1,		FALSE },
+	{ "preproc",	2,		FALSE },
+	{ "module",		3,		FALSE },
+	{ "doc",		4,		FALSE },
+	{ "doc_macro",	5,		FALSE }
 };
 #define highlighting_properties_ERLANG	EMPTY_PROPERTIES
 
@@ -581,27 +581,27 @@ static const HLKeyword highlighting_keywords_ERLANG[] =
 #define highlighting_lexer_F77			SCLEX_F77
 static const HLStyle highlighting_styles_F77[] =
 {
-	{ SCE_F_DEFAULT,		"default",			FALSE },
-	{ SCE_F_COMMENT,		"comment",			FALSE },
-	{ SCE_F_NUMBER,			"number",			FALSE },
-	{ SCE_F_STRING1,		"string",			FALSE },
-	{ SCE_F_OPERATOR,		"operator",			FALSE },
-	{ SCE_F_IDENTIFIER,		"identifier",		FALSE },
-	{ SCE_F_STRING2,		"string2",			FALSE },
-	{ SCE_F_WORD,			"word",				FALSE },
-	{ SCE_F_WORD2,			"word2",			FALSE },
-	{ SCE_F_WORD3,			"word3",			FALSE },
-	{ SCE_F_PREPROCESSOR,	"preprocessor",		FALSE },
-	{ SCE_F_OPERATOR2,		"operator2",		FALSE },
-	{ SCE_F_CONTINUATION,	"continuation",		FALSE },
-	{ SCE_F_STRINGEOL,		"stringeol",		FALSE },
-	{ SCE_F_LABEL,			"label",			FALSE }
+	{ "default",		SCE_F_DEFAULT,			FALSE },
+	{ "comment",		SCE_F_COMMENT,			FALSE },
+	{ "number",			SCE_F_NUMBER,			FALSE },
+	{ "string",			SCE_F_STRING1,			FALSE },
+	{ "operator",		SCE_F_OPERATOR,			FALSE },
+	{ "identifier",		SCE_F_IDENTIFIER,		FALSE },
+	{ "string2",		SCE_F_STRING2,			FALSE },
+	{ "word",			SCE_F_WORD,				FALSE },
+	{ "word2",			SCE_F_WORD2,			FALSE },
+	{ "word3",			SCE_F_WORD3,			FALSE },
+	{ "preprocessor",	SCE_F_PREPROCESSOR,		FALSE },
+	{ "operator2",		SCE_F_OPERATOR2,		FALSE },
+	{ "continuation",	SCE_F_CONTINUATION,		FALSE },
+	{ "stringeol",		SCE_F_STRINGEOL,		FALSE },
+	{ "label",			SCE_F_LABEL,			FALSE }
 };
 static const HLKeyword highlighting_keywords_F77[] =
 {
-	{ 0, "primary",				FALSE },
-	{ 1, "intrinsic_functions",	FALSE },
-	{ 2, "user_functions",		FALSE }
+	{ "primary",				0,	FALSE },
+	{ "intrinsic_functions",	1,	FALSE },
+	{ "user_functions",			2,	FALSE }
 };
 #define highlighting_properties_F77		EMPTY_PROPERTIES
 
@@ -611,9 +611,9 @@ static const HLKeyword highlighting_keywords_F77[] =
 #define highlighting_styles_FERITE		highlighting_styles_C
 static const HLKeyword highlighting_keywords_FERITE[] =
 {
-	{ 0, "primary",		FALSE },
-	{ 1, "types",		FALSE },
-	{ 2, "docComment",	FALSE }
+	{ "primary",	0,	FALSE },
+	{ "types",		1,	FALSE },
+	{ "docComment", 2,	FALSE }
 };
 #define highlighting_properties_FERITE	highlighting_properties_C
 
@@ -622,27 +622,27 @@ static const HLKeyword highlighting_keywords_FERITE[] =
 #define highlighting_lexer_FORTH		SCLEX_FORTH
 static const HLStyle highlighting_styles_FORTH[] =
 {
-	{ SCE_FORTH_DEFAULT,	"default",		FALSE },
-	{ SCE_FORTH_COMMENT,	"comment",		FALSE },
-	{ SCE_FORTH_COMMENT_ML,	"commentml",	FALSE },
-	{ SCE_FORTH_IDENTIFIER,	"identifier",	FALSE },
-	{ SCE_FORTH_CONTROL,	"control",		FALSE },
-	{ SCE_FORTH_KEYWORD,	"keyword",		FALSE },
-	{ SCE_FORTH_DEFWORD,	"defword",		FALSE },
-	{ SCE_FORTH_PREWORD1,	"preword1",		FALSE },
-	{ SCE_FORTH_PREWORD2,	"preword2",		FALSE },
-	{ SCE_FORTH_NUMBER,		"number",		FALSE },
-	{ SCE_FORTH_STRING,		"string",		FALSE },
-	{ SCE_FORTH_LOCALE,		"locale",		FALSE }
+	{ "default",	SCE_FORTH_DEFAULT,		FALSE },
+	{ "comment",	SCE_FORTH_COMMENT,		FALSE },
+	{ "commentml",	SCE_FORTH_COMMENT_ML,	FALSE },
+	{ "identifier",	SCE_FORTH_IDENTIFIER,	FALSE },
+	{ "control",	SCE_FORTH_CONTROL,		FALSE },
+	{ "keyword",	SCE_FORTH_KEYWORD,		FALSE },
+	{ "defword",	SCE_FORTH_DEFWORD,		FALSE },
+	{ "preword1",	SCE_FORTH_PREWORD1,		FALSE },
+	{ "preword2",	SCE_FORTH_PREWORD2,		FALSE },
+	{ "number",		SCE_FORTH_NUMBER,		FALSE },
+	{ "string",		SCE_FORTH_STRING,		FALSE },
+	{ "locale",		SCE_FORTH_LOCALE,		FALSE }
 };
 static const HLKeyword highlighting_keywords_FORTH[] =
 {
-	{ 0, "primary",		FALSE },
-	{ 1, "keyword",		FALSE },
-	{ 2, "defword",		FALSE },
-	{ 3, "preword1",	FALSE },
-	{ 4, "preword2",	FALSE },
-	{ 5, "string",		FALSE }
+	{ "primary",	0,	FALSE },
+	{ "keyword",	1,	FALSE },
+	{ "defword",	2,	FALSE },
+	{ "preword1",	3,	FALSE },
+	{ "preword2",	4,	FALSE },
+	{ "string",		5,	FALSE }
 };
 #define highlighting_properties_FORTH	EMPTY_PROPERTIES
 
@@ -666,35 +666,35 @@ static const HLKeyword highlighting_keywords_FORTH[] =
 #define highlighting_lexer_HASKELL			SCLEX_HASKELL
 static const HLStyle highlighting_styles_HASKELL[] =
 {
-	{ SCE_HA_DEFAULT,				"default",				FALSE },
-	{ SCE_HA_COMMENTLINE,			"commentline",			FALSE },
-	{ SCE_HA_COMMENTBLOCK,			"commentblock",			FALSE },
-	{ SCE_HA_COMMENTBLOCK2,			"commentblock2",		FALSE },
-	{ SCE_HA_COMMENTBLOCK3,			"commentblock3",		FALSE },
-	{ SCE_HA_NUMBER,				"number",				FALSE },
-	{ SCE_HA_KEYWORD,				"keyword",				FALSE },
-	{ SCE_HA_IMPORT,				"import",				FALSE },
-	{ SCE_HA_STRING,				"string",				FALSE },
-	{ SCE_HA_CHARACTER,				"character",			FALSE },
-	{ SCE_HA_CLASS,					"class",				FALSE },
-	{ SCE_HA_OPERATOR,				"operator",				FALSE },
-	{ SCE_HA_IDENTIFIER,			"identifier",			FALSE },
-	{ SCE_HA_INSTANCE,				"instance",				FALSE },
-	{ SCE_HA_CAPITAL,				"capital",				FALSE },
-	{ SCE_HA_MODULE,				"module",				FALSE },
-	{ SCE_HA_DATA,					"data",					FALSE },
-	{ SCE_HA_PRAGMA,				"pragma",				FALSE },
-	{ SCE_HA_PREPROCESSOR,			"preprocessor",			FALSE },
-	{ SCE_HA_STRINGEOL,				"stringeol",			FALSE },
-	{ SCE_HA_RESERVED_OPERATOR,		"reserved_operator",	FALSE },
-	{ SCE_HA_LITERATE_COMMENT,		"literate_comment",		FALSE },
-	{ SCE_HA_LITERATE_CODEDELIM,	"literate_codedelim",	FALSE }
+	{ "default",				SCE_HA_DEFAULT,					FALSE },
+	{ "commentline",			SCE_HA_COMMENTLINE,				FALSE },
+	{ "commentblock",			SCE_HA_COMMENTBLOCK,			FALSE },
+	{ "commentblock2",			SCE_HA_COMMENTBLOCK2,			FALSE },
+	{ "commentblock3",			SCE_HA_COMMENTBLOCK3,			FALSE },
+	{ "number",					SCE_HA_NUMBER,					FALSE },
+	{ "keyword",				SCE_HA_KEYWORD,					FALSE },
+	{ "import",					SCE_HA_IMPORT,					FALSE },
+	{ "string",					SCE_HA_STRING,					FALSE },
+	{ "character",				SCE_HA_CHARACTER,				FALSE },
+	{ "class",					SCE_HA_CLASS,					FALSE },
+	{ "operator",				SCE_HA_OPERATOR,				FALSE },
+	{ "identifier",				SCE_HA_IDENTIFIER,				FALSE },
+	{ "instance",				SCE_HA_INSTANCE,				FALSE },
+	{ "capital",				SCE_HA_CAPITAL,					FALSE },
+	{ "module",					SCE_HA_MODULE,					FALSE },
+	{ "data",					SCE_HA_DATA,					FALSE },
+	{ "pragma",					SCE_HA_PRAGMA,					FALSE },
+	{ "preprocessor",			SCE_HA_PREPROCESSOR,			FALSE },
+	{ "stringeol",				SCE_HA_STRINGEOL,				FALSE },
+	{ "reserved_operator",		SCE_HA_RESERVED_OPERATOR,		FALSE },
+	{ "literate_comment",		SCE_HA_LITERATE_COMMENT,		FALSE },
+	{ "literate_codedelim",		SCE_HA_LITERATE_CODEDELIM,		FALSE }
 };
 static const HLKeyword highlighting_keywords_HASKELL[] =
 {
-	{ 0, "keywords",		   FALSE },
-	{ 1, "ffi",				   FALSE },
-	{ 2, "reserved_operators", FALSE }
+	{ "keywords",			0,		FALSE },
+	{ "ffi",				1,		FALSE },
+	{ "reserved_operators",	2,		FALSE }
 };
 #define highlighting_properties_HASKELL		EMPTY_PROPERTIES
 
@@ -704,9 +704,9 @@ static const HLKeyword highlighting_keywords_HASKELL[] =
 #define highlighting_styles_HAXE		highlighting_styles_C
 static const HLKeyword highlighting_keywords_HAXE[] =
 {
-	{ 0, "primary",		FALSE },
-	{ 1, "secondary",	FALSE },
-	{ 3, "classes",		FALSE }
+	{ "primary",		0,	FALSE },
+	{ "secondary",		1,	FALSE },
+	{ "classes",		3,	FALSE }
 };
 #define highlighting_properties_HAXE	highlighting_properties_C
 
@@ -715,141 +715,141 @@ static const HLKeyword highlighting_keywords_HAXE[] =
 #define highlighting_lexer_HTML		SCLEX_HTML
 static const HLStyle highlighting_styles_HTML[] =
 {
-	{ SCE_H_DEFAULT,				"html_default",				FALSE	 },
-	{ SCE_H_TAG,					"html_tag",					FALSE	 },
-	{ SCE_H_TAGUNKNOWN,				"html_tagunknown",			FALSE	 },
-	{ SCE_H_ATTRIBUTE,				"html_attribute",			FALSE	 },
-	{ SCE_H_ATTRIBUTEUNKNOWN,		"html_attributeunknown",	FALSE	 },
-	{ SCE_H_NUMBER,					"html_number",				FALSE	 },
-	{ SCE_H_DOUBLESTRING,			"html_doublestring",		FALSE	 },
-	{ SCE_H_SINGLESTRING,			"html_singlestring",		FALSE	 },
-	{ SCE_H_OTHER,					"html_other",				FALSE	 },
-	{ SCE_H_COMMENT,				"html_comment",				FALSE	 },
-	{ SCE_H_ENTITY,					"html_entity",				FALSE	 },
-	{ SCE_H_TAGEND,					"html_tagend",				FALSE	 },
-	{ SCE_H_XMLSTART,				"html_xmlstart", 			TRUE	 },
-	{ SCE_H_XMLEND,					"html_xmlend",				FALSE	 },
-	{ SCE_H_SCRIPT,					"html_script",				FALSE	 },
-	{ SCE_H_ASP,					"html_asp",					TRUE	 },
-	{ SCE_H_ASPAT,					"html_aspat",				TRUE	 },
-	{ SCE_H_CDATA,					"html_cdata",				FALSE	 },
-	{ SCE_H_QUESTION,				"html_question",			FALSE	 },
-	{ SCE_H_VALUE,					"html_value",				FALSE	 },
-	{ SCE_H_XCCOMMENT,				"html_xccomment",			FALSE	 },
+	{ "html_default",				SCE_H_DEFAULT,					FALSE	 },
+	{ "html_tag",					SCE_H_TAG,						FALSE	 },
+	{ "html_tagunknown",			SCE_H_TAGUNKNOWN,				FALSE	 },
+	{ "html_attribute",				SCE_H_ATTRIBUTE,				FALSE	 },
+	{ "html_attributeunknown",		SCE_H_ATTRIBUTEUNKNOWN,			FALSE	 },
+	{ "html_number",				SCE_H_NUMBER,					FALSE	 },
+	{ "html_doublestring",			SCE_H_DOUBLESTRING,				FALSE	 },
+	{ "html_singlestring",			SCE_H_SINGLESTRING,				FALSE	 },
+	{ "html_other",					SCE_H_OTHER,					FALSE	 },
+	{ "html_comment",				SCE_H_COMMENT,					FALSE	 },
+	{ "html_entity",				SCE_H_ENTITY,					FALSE	 },
+	{ "html_tagend",				SCE_H_TAGEND,					FALSE	 },
+	{ "html_xmlstart",				SCE_H_XMLSTART,					TRUE	 },
+	{ "html_xmlend",				SCE_H_XMLEND,					FALSE	 },
+	{ "html_script",				SCE_H_SCRIPT,					FALSE	 },
+	{ "html_asp",					SCE_H_ASP,						TRUE	 },
+	{ "html_aspat",					SCE_H_ASPAT,					TRUE	 },
+	{ "html_cdata",					SCE_H_CDATA,					FALSE	 },
+	{ "html_question",				SCE_H_QUESTION,					FALSE	 },
+	{ "html_value",					SCE_H_VALUE,					FALSE	 },
+	{ "html_xccomment",				SCE_H_XCCOMMENT,				FALSE	 },
 
-	{ SCE_H_SGML_DEFAULT,			"sgml_default",				FALSE	 },
-	{ SCE_H_SGML_COMMENT,			"sgml_comment",				FALSE	 },
-	{ SCE_H_SGML_SPECIAL,			"sgml_special",				FALSE	 },
-	{ SCE_H_SGML_COMMAND,			"sgml_command",				FALSE	 },
-	{ SCE_H_SGML_DOUBLESTRING,		"sgml_doublestring",		FALSE	 },
-	{ SCE_H_SGML_SIMPLESTRING,		"sgml_simplestring",		FALSE	 },
-	{ SCE_H_SGML_1ST_PARAM,			"sgml_1st_param",			FALSE	 },
-	{ SCE_H_SGML_ENTITY,			"sgml_entity",				FALSE	 },
-	{ SCE_H_SGML_BLOCK_DEFAULT,		"sgml_block_default",		FALSE	 },
-	{ SCE_H_SGML_1ST_PARAM_COMMENT,	"sgml_1st_param_comment",	FALSE	 },
-	{ SCE_H_SGML_ERROR,				"sgml_error",				FALSE	 },
+	{ "sgml_default",				SCE_H_SGML_DEFAULT,				FALSE	 },
+	{ "sgml_comment",				SCE_H_SGML_COMMENT,				FALSE	 },
+	{ "sgml_special",				SCE_H_SGML_SPECIAL,				FALSE	 },
+	{ "sgml_command",				SCE_H_SGML_COMMAND,				FALSE	 },
+	{ "sgml_doublestring",			SCE_H_SGML_DOUBLESTRING,		FALSE	 },
+	{ "sgml_simplestring",			SCE_H_SGML_SIMPLESTRING,		FALSE	 },
+	{ "sgml_1st_param",				SCE_H_SGML_1ST_PARAM,			FALSE	 },
+	{ "sgml_entity",				SCE_H_SGML_ENTITY,				FALSE	 },
+	{ "sgml_block_default",			SCE_H_SGML_BLOCK_DEFAULT,		FALSE	 },
+	{ "sgml_1st_param_comment",		SCE_H_SGML_1ST_PARAM_COMMENT,	FALSE	 },
+	{ "sgml_error",					SCE_H_SGML_ERROR,				FALSE	 },
 
 	/* embedded JavaScript */
-	{ SCE_HJ_START,					"jscript_start",			FALSE	 },
-	{ SCE_HJ_DEFAULT,				"jscript_default",			FALSE	 },
-	{ SCE_HJ_COMMENT,				"jscript_comment",			FALSE	 },
-	{ SCE_HJ_COMMENTLINE,			"jscript_commentline",		FALSE	 },
-	{ SCE_HJ_COMMENTDOC,			"jscript_commentdoc",		FALSE	 },
-	{ SCE_HJ_NUMBER,				"jscript_number",			FALSE	 },
-	{ SCE_HJ_WORD,					"jscript_word",				FALSE	 },
-	{ SCE_HJ_KEYWORD,				"jscript_keyword",			FALSE	 },
-	{ SCE_HJ_DOUBLESTRING,			"jscript_doublestring",		FALSE	 },
-	{ SCE_HJ_SINGLESTRING,			"jscript_singlestring",		FALSE	 },
-	{ SCE_HJ_SYMBOLS,				"jscript_symbols",			FALSE	 },
-	{ SCE_HJ_STRINGEOL,				"jscript_stringeol",		FALSE	 },
-	{ SCE_HJ_REGEX,					"jscript_regex",			FALSE	 },
+	{ "jscript_start",				SCE_HJ_START,					FALSE	 },
+	{ "jscript_default",			SCE_HJ_DEFAULT,					FALSE	 },
+	{ "jscript_comment",			SCE_HJ_COMMENT,					FALSE	 },
+	{ "jscript_commentline",		SCE_HJ_COMMENTLINE,				FALSE	 },
+	{ "jscript_commentdoc",			SCE_HJ_COMMENTDOC,				FALSE	 },
+	{ "jscript_number",				SCE_HJ_NUMBER,					FALSE	 },
+	{ "jscript_word",				SCE_HJ_WORD,					FALSE	 },
+	{ "jscript_keyword",			SCE_HJ_KEYWORD,					FALSE	 },
+	{ "jscript_doublestring",		SCE_HJ_DOUBLESTRING,			FALSE	 },
+	{ "jscript_singlestring",		SCE_HJ_SINGLESTRING,			FALSE	 },
+	{ "jscript_symbols",			SCE_HJ_SYMBOLS,					FALSE	 },
+	{ "jscript_stringeol",			SCE_HJ_STRINGEOL,				FALSE	 },
+	{ "jscript_regex",				SCE_HJ_REGEX,					FALSE	 },
 
 	/* for HB, VBScript?, use the same styles as for JavaScript */
-	{ SCE_HB_START,					"jscript_start",			FALSE	 },
-	{ SCE_HB_DEFAULT,				"jscript_default",			FALSE	 },
-	{ SCE_HB_COMMENTLINE,			"jscript_commentline",		FALSE	 },
-	{ SCE_HB_NUMBER,				"jscript_number",			FALSE	 },
-	{ SCE_HB_WORD,					"jscript_keyword",			FALSE	 }, /* keywords */
-	{ SCE_HB_STRING,				"jscript_doublestring",		FALSE	 },
-	{ SCE_HB_IDENTIFIER,			"jscript_symbols",			FALSE	 },
-	{ SCE_HB_STRINGEOL,				"jscript_stringeol",		FALSE	 },
+	{ "jscript_start",				SCE_HB_START,					FALSE	 },
+	{ "jscript_default",			SCE_HB_DEFAULT,					FALSE	 },
+	{ "jscript_commentline",		SCE_HB_COMMENTLINE,				FALSE	 },
+	{ "jscript_number",				SCE_HB_NUMBER,					FALSE	 },
+	{ "jscript_keyword",			SCE_HB_WORD,					FALSE	 }, /* keywords */
+	{ "jscript_doublestring",		SCE_HB_STRING,					FALSE	 },
+	{ "jscript_symbols",			SCE_HB_IDENTIFIER,				FALSE	 },
+	{ "jscript_stringeol",			SCE_HB_STRINGEOL,				FALSE	 },
 
 	/* for HBA, VBScript?, use the same styles as for JavaScript */
-	{ SCE_HBA_START,				"jscript_start",			FALSE	 },
-	{ SCE_HBA_DEFAULT,				"jscript_default",			FALSE	 },
-	{ SCE_HBA_COMMENTLINE,			"jscript_commentline",		FALSE	 },
-	{ SCE_HBA_NUMBER,				"jscript_number",			FALSE	 },
-	{ SCE_HBA_WORD,					"jscript_keyword",			FALSE	 }, /* keywords */
-	{ SCE_HBA_STRING,				"jscript_doublestring",		FALSE	 },
-	{ SCE_HBA_IDENTIFIER,			"jscript_symbols",			FALSE	 },
-	{ SCE_HBA_STRINGEOL,			"jscript_stringeol",		FALSE	 },
+	{ "jscript_start",				SCE_HBA_START,					FALSE	 },
+	{ "jscript_default",			SCE_HBA_DEFAULT,				FALSE	 },
+	{ "jscript_commentline",		SCE_HBA_COMMENTLINE,			FALSE	 },
+	{ "jscript_number",				SCE_HBA_NUMBER,					FALSE	 },
+	{ "jscript_keyword",			SCE_HBA_WORD,					FALSE	 }, /* keywords */
+	{ "jscript_doublestring",		SCE_HBA_STRING,					FALSE	 },
+	{ "jscript_symbols",			SCE_HBA_IDENTIFIER,				FALSE	 },
+	{ "jscript_stringeol",			SCE_HBA_STRINGEOL,				FALSE	 },
 
 	/* for HJA, ASP Javascript, use the same styles as for JavaScript */
-	{ SCE_HJA_START,				"jscript_start",			FALSE	 },
-	{ SCE_HJA_DEFAULT,				"jscript_default",			FALSE	 },
-	{ SCE_HJA_COMMENT,				"jscript_comment",			FALSE	 },
-	{ SCE_HJA_COMMENTLINE,			"jscript_commentline",		FALSE	 },
-	{ SCE_HJA_COMMENTDOC,			"jscript_commentdoc",		FALSE	 },
-	{ SCE_HJA_NUMBER,				"jscript_number",			FALSE	 },
-	{ SCE_HJA_WORD,					"jscript_word",				FALSE	 },
-	{ SCE_HJA_KEYWORD,				"jscript_keyword",			FALSE	 },
-	{ SCE_HJA_DOUBLESTRING,			"jscript_doublestring",		FALSE	 },
-	{ SCE_HJA_SINGLESTRING,			"jscript_singlestring",		FALSE	 },
-	{ SCE_HJA_SYMBOLS,				"jscript_symbols",			FALSE	 },
-	{ SCE_HJA_STRINGEOL,			"jscript_stringeol",		FALSE	 },
-	{ SCE_HJA_REGEX,				"jscript_regex",			FALSE	 },
+	{ "jscript_start",				SCE_HJA_START,					FALSE	 },
+	{ "jscript_default",			SCE_HJA_DEFAULT,				FALSE	 },
+	{ "jscript_comment",			SCE_HJA_COMMENT,				FALSE	 },
+	{ "jscript_commentline",		SCE_HJA_COMMENTLINE,			FALSE	 },
+	{ "jscript_commentdoc",			SCE_HJA_COMMENTDOC,				FALSE	 },
+	{ "jscript_number",				SCE_HJA_NUMBER,					FALSE	 },
+	{ "jscript_word",				SCE_HJA_WORD,					FALSE	 },
+	{ "jscript_keyword",			SCE_HJA_KEYWORD,				FALSE	 },
+	{ "jscript_doublestring",		SCE_HJA_DOUBLESTRING,			FALSE	 },
+	{ "jscript_singlestring",		SCE_HJA_SINGLESTRING,			FALSE	 },
+	{ "jscript_symbols",			SCE_HJA_SYMBOLS,				FALSE	 },
+	{ "jscript_stringeol",			SCE_HJA_STRINGEOL,				FALSE	 },
+	{ "jscript_regex",				SCE_HJA_REGEX,					FALSE	 },
 
 	/* embedded Python */
-	{ SCE_HP_START,					"jscript_start",			FALSE	 },
-	{ SCE_HP_DEFAULT,				"python_default",			FALSE	 },
-	{ SCE_HP_COMMENTLINE,			"python_commentline",		FALSE	 },
-	{ SCE_HP_NUMBER,				"python_number",			FALSE	 },
-	{ SCE_HP_STRING,				"python_string",			FALSE	 },
-	{ SCE_HP_CHARACTER,				"python_character",			FALSE	 },
-	{ SCE_HP_WORD,					"python_word",				FALSE	 },
-	{ SCE_HP_TRIPLE,				"python_triple",			FALSE	 },
-	{ SCE_HP_TRIPLEDOUBLE,			"python_tripledouble",		FALSE	 },
-	{ SCE_HP_CLASSNAME,				"python_classname",			FALSE	 },
-	{ SCE_HP_DEFNAME,				"python_defname",			FALSE	 },
-	{ SCE_HP_OPERATOR,				"python_operator",			FALSE	 },
-	{ SCE_HP_IDENTIFIER,			"python_identifier",		FALSE	 },
+	{ "jscript_start",				SCE_HP_START,					FALSE	 },
+	{ "python_default",				SCE_HP_DEFAULT,					FALSE	 },
+	{ "python_commentline",			SCE_HP_COMMENTLINE,				FALSE	 },
+	{ "python_number",				SCE_HP_NUMBER,					FALSE	 },
+	{ "python_string",				SCE_HP_STRING,					FALSE	 },
+	{ "python_character",			SCE_HP_CHARACTER,				FALSE	 },
+	{ "python_word",				SCE_HP_WORD,					FALSE	 },
+	{ "python_triple",				SCE_HP_TRIPLE,					FALSE	 },
+	{ "python_tripledouble",		SCE_HP_TRIPLEDOUBLE,			FALSE	 },
+	{ "python_classname",			SCE_HP_CLASSNAME,				FALSE	 },
+	{ "python_defname",				SCE_HP_DEFNAME,					FALSE	 },
+	{ "python_operator",			SCE_HP_OPERATOR,				FALSE	 },
+	{ "python_identifier",			SCE_HP_IDENTIFIER,				FALSE	 },
 
 	/* for embedded HPA (what is this?) we use the Python styles */
-	{ SCE_HPA_START,				"jscript_start",			FALSE	 },
-	{ SCE_HPA_DEFAULT,				"python_default",			FALSE	 },
-	{ SCE_HPA_COMMENTLINE,			"python_commentline",		FALSE	 },
-	{ SCE_HPA_NUMBER,				"python_number",			FALSE	 },
-	{ SCE_HPA_STRING,				"python_string",			FALSE	 },
-	{ SCE_HPA_CHARACTER,			"python_character",			FALSE	 },
-	{ SCE_HPA_WORD,					"python_word",				FALSE	 },
-	{ SCE_HPA_TRIPLE,				"python_triple",			FALSE	 },
-	{ SCE_HPA_TRIPLEDOUBLE,			"python_tripledouble",		FALSE	 },
-	{ SCE_HPA_CLASSNAME,			"python_classname",			FALSE	 },
-	{ SCE_HPA_DEFNAME,				"python_defname",			FALSE	 },
-	{ SCE_HPA_OPERATOR,				"python_operator",			FALSE	 },
-	{ SCE_HPA_IDENTIFIER,			"python_identifier",		FALSE	 },
+	{ "jscript_start",				SCE_HPA_START,					FALSE	 },
+	{ "python_default",				SCE_HPA_DEFAULT,				FALSE	 },
+	{ "python_commentline",			SCE_HPA_COMMENTLINE,			FALSE	 },
+	{ "python_number",				SCE_HPA_NUMBER,					FALSE	 },
+	{ "python_string",				SCE_HPA_STRING,					FALSE	 },
+	{ "python_character",			SCE_HPA_CHARACTER,				FALSE	 },
+	{ "python_word",				SCE_HPA_WORD,					FALSE	 },
+	{ "python_triple",				SCE_HPA_TRIPLE,					FALSE	 },
+	{ "python_tripledouble",		SCE_HPA_TRIPLEDOUBLE,			FALSE	 },
+	{ "python_classname",			SCE_HPA_CLASSNAME,				FALSE	 },
+	{ "python_defname",				SCE_HPA_DEFNAME,				FALSE	 },
+	{ "python_operator",			SCE_HPA_OPERATOR,				FALSE	 },
+	{ "python_identifier",			SCE_HPA_IDENTIFIER,				FALSE	 },
 
 	/* PHP */
-	{ SCE_HPHP_DEFAULT,				"php_default",				FALSE	 },
-	{ SCE_HPHP_SIMPLESTRING,		"php_simplestring",			FALSE	 },
-	{ SCE_HPHP_HSTRING,				"php_hstring",				FALSE	 },
-	{ SCE_HPHP_NUMBER,				"php_number",				FALSE	 },
-	{ SCE_HPHP_WORD,				"php_word",					FALSE	 },
-	{ SCE_HPHP_VARIABLE,			"php_variable",				FALSE	 },
-	{ SCE_HPHP_COMMENT,				"php_comment",				FALSE	 },
-	{ SCE_HPHP_COMMENTLINE,			"php_commentline",			FALSE	 },
-	{ SCE_HPHP_OPERATOR,			"php_operator",				FALSE	 },
-	{ SCE_HPHP_HSTRING_VARIABLE,	"php_hstring_variable",		FALSE	 },
-	{ SCE_HPHP_COMPLEX_VARIABLE,	"php_complex_variable",		FALSE	 }
+	{ "php_default",				SCE_HPHP_DEFAULT,				FALSE	 },
+	{ "php_simplestring",			SCE_HPHP_SIMPLESTRING,			FALSE	 },
+	{ "php_hstring",				SCE_HPHP_HSTRING,				FALSE	 },
+	{ "php_number",					SCE_HPHP_NUMBER,				FALSE	 },
+	{ "php_word",					SCE_HPHP_WORD,					FALSE	 },
+	{ "php_variable",				SCE_HPHP_VARIABLE,				FALSE	 },
+	{ "php_comment",				SCE_HPHP_COMMENT,				FALSE	 },
+	{ "php_commentline",			SCE_HPHP_COMMENTLINE,			FALSE	 },
+	{ "php_operator",				SCE_HPHP_OPERATOR,				FALSE	 },
+	{ "php_hstring_variable",		SCE_HPHP_HSTRING_VARIABLE,		FALSE	 },
+	{ "php_complex_variable",		SCE_HPHP_COMPLEX_VARIABLE,		FALSE	 }
 };
 static const HLKeyword highlighting_keywords_HTML[] =
 {
-	{ 0, "html",		FALSE },
-	{ 1, "javascript",	FALSE },
-	{ 2, "vbscript",	FALSE },
-	{ 3, "python",		FALSE },
-	{ 4, "php",			FALSE },
-	{ 5, "sgml",		FALSE }
+	{ "html",		0,	FALSE },
+	{ "javascript", 1,	FALSE },
+	{ "vbscript",	2,	FALSE },
+	{ "python",		3,	FALSE },
+	{ "php",		4,	FALSE },
+	{ "sgml",		5,	FALSE }
 };
 static const HLProperty highlighting_properties_HTML[] =
 {
@@ -863,12 +863,12 @@ static const HLProperty highlighting_properties_HTML[] =
 #define highlighting_styles_JAVA		highlighting_styles_C
 static const HLKeyword highlighting_keywords_JAVA[] =
 {
-	{ 0, "primary",		FALSE },
+	{ "primary",	0,	FALSE },
 	/* SCI_SETKEYWORDS = 1 - secondary + global tags file types, see below */
-	{ 1, "secondary",	TRUE },
-	{ 2, "doccomment",	FALSE },
+	{ "secondary",	1,	TRUE },
+	{ "doccomment",	2,	FALSE },
 	/* SCI_SETKEYWORDS = 3 is for current session types - see document_highlight_tags() */
-	{ 4, "typedefs",	FALSE }
+	{ "typedefs",	4,	FALSE }
 };
 #define highlighting_properties_JAVA	highlighting_properties_C
 
@@ -878,8 +878,8 @@ static const HLKeyword highlighting_keywords_JAVA[] =
 #define highlighting_styles_JS		highlighting_styles_C
 static const HLKeyword highlighting_keywords_JS[] =
 {
-	{ 0, "primary",		FALSE },
-	{ 1, "secondary",	FALSE }
+	{ "primary",		0,	FALSE },
+	{ "secondary",		1,	FALSE }
 };
 #define highlighting_properties_JS	highlighting_properties_C
 
@@ -887,35 +887,35 @@ static const HLKeyword highlighting_keywords_JS[] =
 #define highlighting_lexer_JULIA		SCLEX_JULIA
 static const HLStyle highlighting_styles_JULIA[] =
 {
-	{ SCE_JULIA_DEFAULT,			"default",				FALSE },
-	{ SCE_JULIA_COMMENT,			"comment",				FALSE },
-	{ SCE_JULIA_NUMBER,				"number",				FALSE },
-	{ SCE_JULIA_KEYWORD1,			"keyword1",				FALSE },
-	{ SCE_JULIA_KEYWORD2,			"keyword2",				FALSE },
-	{ SCE_JULIA_KEYWORD3,			"keyword3",				FALSE },
-	{ SCE_JULIA_CHAR,				"char",					FALSE },
-	{ SCE_JULIA_OPERATOR,			"operator",				FALSE },
-	{ SCE_JULIA_BRACKET,			"bracket",				FALSE },
-	{ SCE_JULIA_IDENTIFIER,			"identifier",			FALSE },
-	{ SCE_JULIA_STRING,				"string",				FALSE },
-	{ SCE_JULIA_SYMBOL,				"symbol",				FALSE },
-	{ SCE_JULIA_MACRO,				"macro",				FALSE },
-	{ SCE_JULIA_STRINGINTERP,		"stringinterp",			FALSE },
-	{ SCE_JULIA_DOCSTRING,			"docstring",			FALSE },
-	{ SCE_JULIA_STRINGLITERAL,		"stringliteral",		FALSE },
-	{ SCE_JULIA_COMMAND,			"command",				FALSE },
-	{ SCE_JULIA_COMMANDLITERAL,		"commandliteral",		FALSE },
-	{ SCE_JULIA_TYPEANNOT,			"typeannotation",		FALSE },
-	{ SCE_JULIA_LEXERROR,			"lexerror",				FALSE },
-	{ SCE_JULIA_KEYWORD4,			"keyword4",				FALSE },
-	{ SCE_JULIA_TYPEOPERATOR,		"typeoperator",			FALSE },
+	{ "default",			SCE_JULIA_DEFAULT,			FALSE },
+	{ "comment",			SCE_JULIA_COMMENT,			FALSE },
+	{ "number",				SCE_JULIA_NUMBER,			FALSE },
+	{ "keyword1",			SCE_JULIA_KEYWORD1,			FALSE },
+	{ "keyword2",			SCE_JULIA_KEYWORD2,			FALSE },
+	{ "keyword3",			SCE_JULIA_KEYWORD3,			FALSE },
+	{ "char",				SCE_JULIA_CHAR,				FALSE },
+	{ "operator",			SCE_JULIA_OPERATOR,			FALSE },
+	{ "bracket",			SCE_JULIA_BRACKET,			FALSE },
+	{ "identifier",			SCE_JULIA_IDENTIFIER,		FALSE },
+	{ "string",				SCE_JULIA_STRING,			FALSE },
+	{ "symbol",				SCE_JULIA_SYMBOL,			FALSE },
+	{ "macro",				SCE_JULIA_MACRO,			FALSE },
+	{ "stringinterp",		SCE_JULIA_STRINGINTERP,		FALSE },
+	{ "docstring",			SCE_JULIA_DOCSTRING,		FALSE },
+	{ "stringliteral",		SCE_JULIA_STRINGLITERAL,	FALSE },
+	{ "command",			SCE_JULIA_COMMAND,			FALSE },
+	{ "commandliteral",		SCE_JULIA_COMMANDLITERAL,	FALSE },
+	{ "typeannotation",		SCE_JULIA_TYPEANNOT,		FALSE },
+	{ "lexerror",			SCE_JULIA_LEXERROR,			FALSE },
+	{ "keyword4",			SCE_JULIA_KEYWORD4,			FALSE },
+	{ "typeoperator",		SCE_JULIA_TYPEOPERATOR,		FALSE },
 };
 static const HLKeyword highlighting_keywords_JULIA[] =
 {
-	{ 0, "primary",		FALSE },
-	{ 1, "secondary",	FALSE },
-	{ 2, "tertiary",	FALSE },
-	{ 3, "functions",	FALSE }
+	{ "primary",		0,	FALSE },
+	{ "secondary",		1,	FALSE },
+	{ "tertiary",		2,	FALSE },
+	{ "functions",		3,	FALSE }
 };
 #define highlighting_properties_JULIA	EMPTY_PROPERTIES
 
@@ -924,23 +924,23 @@ static const HLKeyword highlighting_keywords_JULIA[] =
 #define highlighting_lexer_LATEX		SCLEX_LATEX
 static const HLStyle highlighting_styles_LATEX[] =
 {
-	{ SCE_L_DEFAULT,	"default",		FALSE },
-	{ SCE_L_COMMAND,	"command",		FALSE },
-	{ SCE_L_TAG,		"tag",			FALSE },
-	{ SCE_L_MATH,		"math",			FALSE },
-	{ SCE_L_COMMENT,	"comment",		FALSE },
-	{ SCE_L_TAG2,		"tag2",			FALSE },
-	{ SCE_L_MATH2,		"math2",		FALSE },
-	{ SCE_L_COMMENT2,	"comment2",		FALSE },
-	{ SCE_L_VERBATIM,	"verbatim",		FALSE },
-	{ SCE_L_SHORTCMD,	"shortcmd",		FALSE },
-	{ SCE_L_SPECIAL,	"special",		FALSE },
-	{ SCE_L_CMDOPT,		"cmdopt",		FALSE },
-	{ SCE_L_ERROR,		"error",		FALSE }
+	{ "default",		SCE_L_DEFAULT,		FALSE },
+	{ "command",		SCE_L_COMMAND,		FALSE },
+	{ "tag",			SCE_L_TAG,			FALSE },
+	{ "math",			SCE_L_MATH,			FALSE },
+	{ "comment",		SCE_L_COMMENT,		FALSE },
+	{ "tag2",			SCE_L_TAG2,			FALSE },
+	{ "math2",			SCE_L_MATH2,		FALSE },
+	{ "comment2",		SCE_L_COMMENT2,		FALSE },
+	{ "verbatim",		SCE_L_VERBATIM,		FALSE },
+	{ "shortcmd",		SCE_L_SHORTCMD,		FALSE },
+	{ "special",		SCE_L_SPECIAL,		FALSE },
+	{ "cmdopt",			SCE_L_CMDOPT,		FALSE },
+	{ "error",			SCE_L_ERROR,		FALSE }
 };
 static const HLKeyword highlighting_keywords_LATEX[] =
 {
-	{ 0, "primary",	FALSE }
+	{ "primary", 0,	FALSE }
 };
 #define highlighting_properties_LATEX	EMPTY_PROPERTIES
 
@@ -949,23 +949,23 @@ static const HLKeyword highlighting_keywords_LATEX[] =
 #define highlighting_lexer_LISP			SCLEX_LISP
 static const HLStyle highlighting_styles_LISP[] =
 {
-	{ SCE_LISP_DEFAULT,			"default",			FALSE },
-	{ SCE_LISP_COMMENT,			"comment",			FALSE },
-	{ SCE_LISP_MULTI_COMMENT,	"multicomment",		FALSE },
-	{ SCE_LISP_NUMBER,			"number",			FALSE },
-	{ SCE_LISP_KEYWORD,			"keyword",			FALSE },
-	{ SCE_LISP_SYMBOL,			"symbol",			FALSE },
-	{ SCE_LISP_STRING,			"string",			FALSE },
-	{ SCE_LISP_STRINGEOL,		"stringeol",		FALSE },
-	{ SCE_LISP_IDENTIFIER,		"identifier",		FALSE },
-	{ SCE_LISP_OPERATOR,		"operator",			FALSE },
-	{ SCE_LISP_SPECIAL,			"special",			FALSE },
-	{ SCE_LISP_KEYWORD_KW,		"keywordkw",		FALSE }
+	{ "default",			SCE_LISP_DEFAULT,			FALSE },
+	{ "comment",			SCE_LISP_COMMENT,			FALSE },
+	{ "multicomment",		SCE_LISP_MULTI_COMMENT,		FALSE },
+	{ "number",				SCE_LISP_NUMBER,			FALSE },
+	{ "keyword",			SCE_LISP_KEYWORD,			FALSE },
+	{ "symbol",				SCE_LISP_SYMBOL,			FALSE },
+	{ "string",				SCE_LISP_STRING,			FALSE },
+	{ "stringeol",			SCE_LISP_STRINGEOL,			FALSE },
+	{ "identifier",			SCE_LISP_IDENTIFIER,		FALSE },
+	{ "operator",			SCE_LISP_OPERATOR,			FALSE },
+	{ "special",			SCE_LISP_SPECIAL,			FALSE },
+	{ "keywordkw",			SCE_LISP_KEYWORD_KW,		FALSE }
 };
 static const HLKeyword highlighting_keywords_LISP[] =
 {
-	{ 0, "keywords",			FALSE },
-	{ 1, "special_keywords",	FALSE }
+	{ "keywords",			0,	FALSE },
+	{ "special_keywords",	1,	FALSE }
 };
 #define highlighting_properties_LISP	EMPTY_PROPERTIES
 
@@ -974,38 +974,38 @@ static const HLKeyword highlighting_keywords_LISP[] =
 #define highlighting_lexer_LUA			SCLEX_LUA
 static const HLStyle highlighting_styles_LUA[] =
 {
-	{ SCE_LUA_DEFAULT,			"default",			FALSE },
-	{ SCE_LUA_COMMENT,			"comment",			FALSE },
-	{ SCE_LUA_COMMENTLINE,		"commentline",		FALSE },
-	{ SCE_LUA_COMMENTDOC,		"commentdoc",		FALSE },
-	{ SCE_LUA_NUMBER,			"number",			FALSE },
-	{ SCE_LUA_WORD,				"word",				FALSE },
-	{ SCE_LUA_STRING,			"string",			FALSE },
-	{ SCE_LUA_CHARACTER,		"character",		FALSE },
-	{ SCE_LUA_LITERALSTRING,	"literalstring",	FALSE },
-	{ SCE_LUA_PREPROCESSOR,		"preprocessor",		FALSE },
-	{ SCE_LUA_OPERATOR,			"operator",			FALSE },
-	{ SCE_LUA_IDENTIFIER,		"identifier",		FALSE },
-	{ SCE_LUA_STRINGEOL,		"stringeol",		FALSE },
-	{ SCE_LUA_WORD2,			"function_basic",	FALSE },
-	{ SCE_LUA_WORD3,			"function_other",	FALSE },
-	{ SCE_LUA_WORD4,			"coroutines",		FALSE },
-	{ SCE_LUA_WORD5,			"word5",			FALSE },
-	{ SCE_LUA_WORD6,			"word6",			FALSE },
-	{ SCE_LUA_WORD7,			"word7",			FALSE },
-	{ SCE_LUA_WORD8,			"word8",			FALSE },
-	{ SCE_LUA_LABEL,			"label",			FALSE }
+	{ "default",			SCE_LUA_DEFAULT,		FALSE },
+	{ "comment",			SCE_LUA_COMMENT,		FALSE },
+	{ "commentline",		SCE_LUA_COMMENTLINE,	FALSE },
+	{ "commentdoc",			SCE_LUA_COMMENTDOC,		FALSE },
+	{ "number",				SCE_LUA_NUMBER,			FALSE },
+	{ "word",				SCE_LUA_WORD,			FALSE },
+	{ "string",				SCE_LUA_STRING,			FALSE },
+	{ "character",			SCE_LUA_CHARACTER,		FALSE },
+	{ "literalstring",		SCE_LUA_LITERALSTRING,	FALSE },
+	{ "preprocessor",		SCE_LUA_PREPROCESSOR,	FALSE },
+	{ "operator",			SCE_LUA_OPERATOR,		FALSE },
+	{ "identifier",			SCE_LUA_IDENTIFIER,		FALSE },
+	{ "stringeol",			SCE_LUA_STRINGEOL,		FALSE },
+	{ "function_basic",		SCE_LUA_WORD2,			FALSE },
+	{ "function_other",		SCE_LUA_WORD3,			FALSE },
+	{ "coroutines",			SCE_LUA_WORD4,			FALSE },
+	{ "word5",				SCE_LUA_WORD5,			FALSE },
+	{ "word6",				SCE_LUA_WORD6,			FALSE },
+	{ "word7",				SCE_LUA_WORD7,			FALSE },
+	{ "word8",				SCE_LUA_WORD8,			FALSE },
+	{ "label",				SCE_LUA_LABEL,			FALSE }
 };
 static const HLKeyword highlighting_keywords_LUA[] =
 {
-	{ 0, "keywords",		FALSE },
-	{ 1, "function_basic",	FALSE },
-	{ 2, "function_other",	FALSE },
-	{ 3, "coroutines",		FALSE },
-	{ 4, "user1",			FALSE },
-	{ 5, "user2",			FALSE },
-	{ 6, "user3",			FALSE },
-	{ 7, "user4",			FALSE }
+	{ "keywords",			0,		FALSE },
+	{ "function_basic",		1,		FALSE },
+	{ "function_other",		2,		FALSE },
+	{ "coroutines",			3,		FALSE },
+	{ "user1",				4,		FALSE },
+	{ "user2",				5,		FALSE },
+	{ "user3",				6,		FALSE },
+	{ "user4",				7,		FALSE }
 };
 #define highlighting_properties_LUA		EMPTY_PROPERTIES
 
@@ -1014,13 +1014,13 @@ static const HLKeyword highlighting_keywords_LUA[] =
 #define highlighting_lexer_MAKE			SCLEX_MAKEFILE
 static const HLStyle highlighting_styles_MAKE[] =
 {
-	{ SCE_MAKE_DEFAULT,			"default",		FALSE },
-	{ SCE_MAKE_COMMENT,			"comment",		FALSE },
-	{ SCE_MAKE_PREPROCESSOR,	"preprocessor",	FALSE },
-	{ SCE_MAKE_IDENTIFIER,		"identifier",	FALSE },
-	{ SCE_MAKE_OPERATOR,		"operator",		FALSE },
-	{ SCE_MAKE_TARGET,			"target",		FALSE },
-	{ SCE_MAKE_IDEOL,			"ideol",		FALSE }
+	{ "default",		SCE_MAKE_DEFAULT,			FALSE },
+	{ "comment",		SCE_MAKE_COMMENT,			FALSE },
+	{ "preprocessor",	SCE_MAKE_PREPROCESSOR,		FALSE },
+	{ "identifier",		SCE_MAKE_IDENTIFIER,		FALSE },
+	{ "operator",		SCE_MAKE_OPERATOR,			FALSE },
+	{ "target",			SCE_MAKE_TARGET,			FALSE },
+	{ "ideol",			SCE_MAKE_IDEOL,				FALSE }
 };
 #define highlighting_keywords_MAKE		EMPTY_KEYWORDS
 #define highlighting_properties_MAKE	EMPTY_PROPERTIES
@@ -1030,28 +1030,28 @@ static const HLStyle highlighting_styles_MAKE[] =
 #define highlighting_lexer_MARKDOWN			SCLEX_MARKDOWN
 static const HLStyle highlighting_styles_MARKDOWN[] =
 {
-	{ SCE_MARKDOWN_DEFAULT,		"default",		FALSE },
-	{ SCE_MARKDOWN_LINE_BEGIN,	"default",		FALSE }, /* FIXME: avoid in-code re-mappings */
-	{ SCE_MARKDOWN_PRECHAR,		"default",		FALSE },
-	{ SCE_MARKDOWN_STRONG1,		"strong",		FALSE },
-	{ SCE_MARKDOWN_STRONG2,		"strong",		FALSE },
-	{ SCE_MARKDOWN_EM1,			"emphasis",		FALSE },
-	{ SCE_MARKDOWN_EM2,			"emphasis",		FALSE },
-	{ SCE_MARKDOWN_HEADER1,		"header1",		FALSE },
-	{ SCE_MARKDOWN_HEADER2,		"header2",		FALSE },
-	{ SCE_MARKDOWN_HEADER3,		"header3",		FALSE },
-	{ SCE_MARKDOWN_HEADER4,		"header4",		FALSE },
-	{ SCE_MARKDOWN_HEADER5,		"header5",		FALSE },
-	{ SCE_MARKDOWN_HEADER6,		"header6",		FALSE },
-	{ SCE_MARKDOWN_ULIST_ITEM,	"ulist_item",	FALSE },
-	{ SCE_MARKDOWN_OLIST_ITEM,	"olist_item",	FALSE },
-	{ SCE_MARKDOWN_BLOCKQUOTE,	"blockquote",	FALSE },
-	{ SCE_MARKDOWN_STRIKEOUT,	"strikeout",	FALSE },
-	{ SCE_MARKDOWN_HRULE,		"hrule",		FALSE },
-	{ SCE_MARKDOWN_LINK,		"link",			FALSE },
-	{ SCE_MARKDOWN_CODE,		"code",			FALSE },
-	{ SCE_MARKDOWN_CODE2,		"code",			FALSE },
-	{ SCE_MARKDOWN_CODEBK,		"codebk",		FALSE }
+	{ "default",		SCE_MARKDOWN_DEFAULT,			FALSE },
+	{ "default",		SCE_MARKDOWN_LINE_BEGIN,		FALSE }, /* FIXME: avoid in-code re-mappings */
+	{ "default",		SCE_MARKDOWN_PRECHAR,			FALSE },
+	{ "strong",			SCE_MARKDOWN_STRONG1,			FALSE },
+	{ "strong",			SCE_MARKDOWN_STRONG2,			FALSE },
+	{ "emphasis",		SCE_MARKDOWN_EM1,				FALSE },
+	{ "emphasis",		SCE_MARKDOWN_EM2,				FALSE },
+	{ "header1",		SCE_MARKDOWN_HEADER1,			FALSE },
+	{ "header2",		SCE_MARKDOWN_HEADER2,			FALSE },
+	{ "header3",		SCE_MARKDOWN_HEADER3,			FALSE },
+	{ "header4",		SCE_MARKDOWN_HEADER4,			FALSE },
+	{ "header5",		SCE_MARKDOWN_HEADER5,			FALSE },
+	{ "header6",		SCE_MARKDOWN_HEADER6,			FALSE },
+	{ "ulist_item",		SCE_MARKDOWN_ULIST_ITEM,		FALSE },
+	{ "olist_item",		SCE_MARKDOWN_OLIST_ITEM,		FALSE },
+	{ "blockquote",		SCE_MARKDOWN_BLOCKQUOTE,		FALSE },
+	{ "strikeout",		SCE_MARKDOWN_STRIKEOUT,			FALSE },
+	{ "hrule",			SCE_MARKDOWN_HRULE,				FALSE },
+	{ "link",			SCE_MARKDOWN_LINK,				FALSE },
+	{ "code",			SCE_MARKDOWN_CODE,				FALSE },
+	{ "code",			SCE_MARKDOWN_CODE2,				FALSE },
+	{ "codebk",			SCE_MARKDOWN_CODEBK,			FALSE }
 };
 #define highlighting_keywords_MARKDOWN		EMPTY_KEYWORDS
 #define highlighting_properties_MARKDOWN	EMPTY_PROPERTIES
@@ -1061,19 +1061,19 @@ static const HLStyle highlighting_styles_MARKDOWN[] =
 #define highlighting_lexer_MATLAB		SCLEX_OCTAVE /* not MATLAB to support Octave's # comments */
 static const HLStyle highlighting_styles_MATLAB[] =
 {
-	{ SCE_MATLAB_DEFAULT,			"default",				FALSE },
-	{ SCE_MATLAB_COMMENT,			"comment",				FALSE },
-	{ SCE_MATLAB_COMMAND,			"command",				FALSE },
-	{ SCE_MATLAB_NUMBER,			"number",				FALSE },
-	{ SCE_MATLAB_KEYWORD,			"keyword",				FALSE },
-	{ SCE_MATLAB_STRING,			"string",				FALSE },
-	{ SCE_MATLAB_OPERATOR,			"operator",				FALSE },
-	{ SCE_MATLAB_IDENTIFIER,		"identifier",			FALSE },
-	{ SCE_MATLAB_DOUBLEQUOTESTRING,	"doublequotedstring",	FALSE }
+	{ "default",			SCE_MATLAB_DEFAULT,				FALSE },
+	{ "comment",			SCE_MATLAB_COMMENT,				FALSE },
+	{ "command",			SCE_MATLAB_COMMAND,				FALSE },
+	{ "number",				SCE_MATLAB_NUMBER,				FALSE },
+	{ "keyword",			SCE_MATLAB_KEYWORD,				FALSE },
+	{ "string",				SCE_MATLAB_STRING,				FALSE },
+	{ "operator",			SCE_MATLAB_OPERATOR,			FALSE },
+	{ "identifier",			SCE_MATLAB_IDENTIFIER,			FALSE },
+	{ "doublequotedstring",	SCE_MATLAB_DOUBLEQUOTESTRING,	FALSE }
 };
 static const HLKeyword highlighting_keywords_MATLAB[] =
 {
-	{ 0, "primary",	FALSE }
+	{ "primary", 0,	FALSE }
 };
 #define highlighting_properties_MATLAB	EMPTY_PROPERTIES
 
@@ -1082,32 +1082,32 @@ static const HLKeyword highlighting_keywords_MATLAB[] =
 #define highlighting_lexer_NSIS			SCLEX_NSIS
 static const HLStyle highlighting_styles_NSIS[] =
 {
-	{ SCE_NSIS_DEFAULT,			"default",			FALSE },
-	{ SCE_NSIS_COMMENT,			"comment",			FALSE },
-	{ SCE_NSIS_STRINGDQ,		"stringdq",			FALSE },
-	{ SCE_NSIS_STRINGLQ,		"stringlq",			FALSE },
-	{ SCE_NSIS_STRINGRQ,		"stringrq",			FALSE },
-	{ SCE_NSIS_FUNCTION,		"function",			FALSE },
-	{ SCE_NSIS_VARIABLE,		"variable",			FALSE },
-	{ SCE_NSIS_LABEL,			"label",			FALSE },
-	{ SCE_NSIS_USERDEFINED,		"userdefined",		FALSE },
-	{ SCE_NSIS_SECTIONDEF,		"sectiondef",		FALSE },
-	{ SCE_NSIS_SUBSECTIONDEF,	"subsectiondef",	FALSE },
-	{ SCE_NSIS_IFDEFINEDEF,		"ifdefinedef",		FALSE },
-	{ SCE_NSIS_MACRODEF,		"macrodef",			FALSE },
-	{ SCE_NSIS_STRINGVAR,		"stringvar",		FALSE },
-	{ SCE_NSIS_NUMBER,			"number",			FALSE },
-	{ SCE_NSIS_SECTIONGROUP,	"sectiongroup",		FALSE },
-	{ SCE_NSIS_PAGEEX,			"pageex",			FALSE },
-	{ SCE_NSIS_FUNCTIONDEF,		"functiondef",		FALSE },
-	{ SCE_NSIS_COMMENTBOX,		"commentbox",		FALSE }
+	{ "default",			SCE_NSIS_DEFAULT,			FALSE },
+	{ "comment",			SCE_NSIS_COMMENT,			FALSE },
+	{ "stringdq",			SCE_NSIS_STRINGDQ,			FALSE },
+	{ "stringlq",			SCE_NSIS_STRINGLQ,			FALSE },
+	{ "stringrq",			SCE_NSIS_STRINGRQ,			FALSE },
+	{ "function",			SCE_NSIS_FUNCTION,			FALSE },
+	{ "variable",			SCE_NSIS_VARIABLE,			FALSE },
+	{ "label",				SCE_NSIS_LABEL,				FALSE },
+	{ "userdefined",		SCE_NSIS_USERDEFINED,		FALSE },
+	{ "sectiondef",			SCE_NSIS_SECTIONDEF,		FALSE },
+	{ "subsectiondef",		SCE_NSIS_SUBSECTIONDEF,		FALSE },
+	{ "ifdefinedef",		SCE_NSIS_IFDEFINEDEF,		FALSE },
+	{ "macrodef",			SCE_NSIS_MACRODEF,			FALSE },
+	{ "stringvar",			SCE_NSIS_STRINGVAR,			FALSE },
+	{ "number",				SCE_NSIS_NUMBER,			FALSE },
+	{ "sectiongroup",		SCE_NSIS_SECTIONGROUP,		FALSE },
+	{ "pageex",				SCE_NSIS_PAGEEX,			FALSE },
+	{ "functiondef",		SCE_NSIS_FUNCTIONDEF,		FALSE },
+	{ "commentbox",			SCE_NSIS_COMMENTBOX,		FALSE }
 };
 static const HLKeyword highlighting_keywords_NSIS[] =
 {
-	{ 0, "functions",	FALSE },
-	{ 1, "variables",	FALSE },
-	{ 2, "lables",		FALSE },
-	{ 3, "userdefined",	FALSE }
+	{ "functions",			0,	FALSE },
+	{ "variables",			1,	FALSE },
+	{ "lables",				2,	FALSE },
+	{ "userdefined",		3,	FALSE }
 };
 #define highlighting_properties_NSIS	EMPTY_PROPERTIES
 
@@ -1117,10 +1117,10 @@ static const HLKeyword highlighting_keywords_NSIS[] =
 #define highlighting_styles_OBJECTIVEC		highlighting_styles_C
 static const HLKeyword highlighting_keywords_OBJECTIVEC[] =
 {
-	{ 0, "primary",		FALSE },
+	{ "primary",	0,	FALSE },
 	/* SCI_SETKEYWORDS = 1 - secondary + global tags file types, see below */
-	{ 1, "secondary",	TRUE },
-	{ 2, "docComment",	FALSE }
+	{ "secondary",	1,	TRUE },
+	{ "docComment",	2,	FALSE }
 	/* SCI_SETKEYWORDS = 3 is for current session types - see document_highlight_tags() */
 };
 #define highlighting_properties_OBJECTIVEC	highlighting_properties_C
@@ -1130,25 +1130,25 @@ static const HLKeyword highlighting_keywords_OBJECTIVEC[] =
 #define highlighting_lexer_PASCAL		SCLEX_PASCAL
 static const HLStyle highlighting_styles_PASCAL[] =
 {
-	{ SCE_PAS_DEFAULT,			"default",			FALSE },
-	{ SCE_PAS_IDENTIFIER,		"identifier",		FALSE },
-	{ SCE_PAS_COMMENT,			"comment",			FALSE },
-	{ SCE_PAS_COMMENT2,			"comment2",			FALSE },
-	{ SCE_PAS_COMMENTLINE,		"commentline",		FALSE },
-	{ SCE_PAS_PREPROCESSOR,		"preprocessor",		FALSE },
-	{ SCE_PAS_PREPROCESSOR2,	"preprocessor2",	FALSE },
-	{ SCE_PAS_NUMBER,			"number",			FALSE },
-	{ SCE_PAS_HEXNUMBER,		"hexnumber",		FALSE },
-	{ SCE_PAS_WORD,				"word",				FALSE },
-	{ SCE_PAS_STRING,			"string",			FALSE },
-	{ SCE_PAS_STRINGEOL,		"stringeol",		FALSE },
-	{ SCE_PAS_CHARACTER,		"character",		FALSE },
-	{ SCE_PAS_OPERATOR,			"operator",			FALSE },
-	{ SCE_PAS_ASM,				"asm",				FALSE }
+	{ "default",			SCE_PAS_DEFAULT,			FALSE },
+	{ "identifier",			SCE_PAS_IDENTIFIER,			FALSE },
+	{ "comment",			SCE_PAS_COMMENT,			FALSE },
+	{ "comment2",			SCE_PAS_COMMENT2,			FALSE },
+	{ "commentline",		SCE_PAS_COMMENTLINE,		FALSE },
+	{ "preprocessor",		SCE_PAS_PREPROCESSOR,		FALSE },
+	{ "preprocessor2",		SCE_PAS_PREPROCESSOR2,		FALSE },
+	{ "number",				SCE_PAS_NUMBER,				FALSE },
+	{ "hexnumber",			SCE_PAS_HEXNUMBER,			FALSE },
+	{ "word",				SCE_PAS_WORD,				FALSE },
+	{ "string",				SCE_PAS_STRING,				FALSE },
+	{ "stringeol",			SCE_PAS_STRINGEOL,			FALSE },
+	{ "character",			SCE_PAS_CHARACTER,			FALSE },
+	{ "operator",			SCE_PAS_OPERATOR,			FALSE },
+	{ "asm",				SCE_PAS_ASM,				FALSE }
 };
 static const HLKeyword highlighting_keywords_PASCAL[] =
 {
-	{ 0, "primary",	FALSE }
+	{ "primary", 0,	FALSE }
 };
 #define highlighting_properties_PASCAL	EMPTY_PROPERTIES
 
@@ -1157,55 +1157,55 @@ static const HLKeyword highlighting_keywords_PASCAL[] =
 #define highlighting_lexer_PERL			SCLEX_PERL
 static const HLStyle highlighting_styles_PERL[] =
 {
-	{ SCE_PL_DEFAULT,			"default",				FALSE },
-	{ SCE_PL_ERROR,				"error",				FALSE },
-	{ SCE_PL_COMMENTLINE,		"commentline",			FALSE },
-	{ SCE_PL_NUMBER,			"number",				FALSE },
-	{ SCE_PL_WORD,				"word",					FALSE },
-	{ SCE_PL_STRING,			"string",				FALSE },
-	{ SCE_PL_CHARACTER,			"character",			FALSE },
-	{ SCE_PL_PREPROCESSOR,		"preprocessor",			FALSE },
-	{ SCE_PL_OPERATOR,			"operator",				FALSE },
-	{ SCE_PL_IDENTIFIER,		"identifier",			FALSE },
-	{ SCE_PL_SCALAR,			"scalar",				FALSE },
-	{ SCE_PL_POD,				"pod",					FALSE },
-	{ SCE_PL_REGEX,				"regex",				FALSE },
-	{ SCE_PL_ARRAY,				"array",				FALSE },
-	{ SCE_PL_HASH,				"hash",					FALSE },
-	{ SCE_PL_SYMBOLTABLE,		"symboltable",			FALSE },
-	{ SCE_PL_BACKTICKS,			"backticks",			FALSE },
-	{ SCE_PL_POD_VERB,			"pod_verbatim",			FALSE },
-	{ SCE_PL_REGSUBST,			"reg_subst",			FALSE },
-	{ SCE_PL_DATASECTION,		"datasection",			FALSE },
-	{ SCE_PL_HERE_DELIM,		"here_delim",			FALSE },
-	{ SCE_PL_HERE_Q,			"here_q",				FALSE },
-	{ SCE_PL_HERE_QQ,			"here_qq",				FALSE },
-	{ SCE_PL_HERE_QX,			"here_qx",				FALSE },
-	{ SCE_PL_STRING_Q,			"string_q",				FALSE },
-	{ SCE_PL_STRING_QQ,			"string_qq",			FALSE },
-	{ SCE_PL_STRING_QX,			"string_qx",			FALSE },
-	{ SCE_PL_STRING_QR,			"string_qr",			FALSE },
-	{ SCE_PL_STRING_QW,			"string_qw",			FALSE },
-	{ SCE_PL_VARIABLE_INDEXER,	"variable_indexer",		FALSE },
-	{ SCE_PL_PUNCTUATION,		"punctuation",			FALSE },
-	{ SCE_PL_LONGQUOTE,			"longquote",			FALSE },
-	{ SCE_PL_SUB_PROTOTYPE,		"sub_prototype",		FALSE },
-	{ SCE_PL_FORMAT_IDENT,		"format_ident",			FALSE },
-	{ SCE_PL_FORMAT,			"format",				FALSE },
-	{ SCE_PL_STRING_VAR,		"string_var",			FALSE },
-	{ SCE_PL_XLAT,				"xlat",					FALSE },
-	{ SCE_PL_REGEX_VAR,			"regex_var",			FALSE },
-	{ SCE_PL_REGSUBST_VAR,		"regsubst_var",			FALSE },
-	{ SCE_PL_BACKTICKS_VAR,		"backticks_var",		FALSE },
-	{ SCE_PL_HERE_QQ_VAR,		"here_qq_var",			FALSE },
-	{ SCE_PL_HERE_QX_VAR,		"here_qx_var",			FALSE },
-	{ SCE_PL_STRING_QQ_VAR,		"string_qq_var",		FALSE },
-	{ SCE_PL_STRING_QX_VAR,		"string_qx_var",		FALSE },
-	{ SCE_PL_STRING_QR_VAR,		"string_qr_var",		FALSE }
+	{ "default",			SCE_PL_DEFAULT,				FALSE },
+	{ "error",				SCE_PL_ERROR,				FALSE },
+	{ "commentline",		SCE_PL_COMMENTLINE,			FALSE },
+	{ "number",				SCE_PL_NUMBER,				FALSE },
+	{ "word",				SCE_PL_WORD,				FALSE },
+	{ "string",				SCE_PL_STRING,				FALSE },
+	{ "character",			SCE_PL_CHARACTER,			FALSE },
+	{ "preprocessor",		SCE_PL_PREPROCESSOR,		FALSE },
+	{ "operator",			SCE_PL_OPERATOR,			FALSE },
+	{ "identifier",			SCE_PL_IDENTIFIER,			FALSE },
+	{ "scalar",				SCE_PL_SCALAR,				FALSE },
+	{ "pod",				SCE_PL_POD,					FALSE },
+	{ "regex",				SCE_PL_REGEX,				FALSE },
+	{ "array",				SCE_PL_ARRAY,				FALSE },
+	{ "hash",				SCE_PL_HASH,				FALSE },
+	{ "symboltable",		SCE_PL_SYMBOLTABLE,			FALSE },
+	{ "backticks",			SCE_PL_BACKTICKS,			FALSE },
+	{ "pod_verbatim",		SCE_PL_POD_VERB,			FALSE },
+	{ "reg_subst",			SCE_PL_REGSUBST,			FALSE },
+	{ "datasection",		SCE_PL_DATASECTION,			FALSE },
+	{ "here_delim",			SCE_PL_HERE_DELIM,			FALSE },
+	{ "here_q",				SCE_PL_HERE_Q,				FALSE },
+	{ "here_qq",			SCE_PL_HERE_QQ,				FALSE },
+	{ "here_qx",			SCE_PL_HERE_QX,				FALSE },
+	{ "string_q",			SCE_PL_STRING_Q,			FALSE },
+	{ "string_qq",			SCE_PL_STRING_QQ,			FALSE },
+	{ "string_qx",			SCE_PL_STRING_QX,			FALSE },
+	{ "string_qr",			SCE_PL_STRING_QR,			FALSE },
+	{ "string_qw",			SCE_PL_STRING_QW,			FALSE },
+	{ "variable_indexer",	SCE_PL_VARIABLE_INDEXER,	FALSE },
+	{ "punctuation",		SCE_PL_PUNCTUATION,			FALSE },
+	{ "longquote",			SCE_PL_LONGQUOTE,			FALSE },
+	{ "sub_prototype",		SCE_PL_SUB_PROTOTYPE,		FALSE },
+	{ "format_ident",		SCE_PL_FORMAT_IDENT,		FALSE },
+	{ "format",				SCE_PL_FORMAT,				FALSE },
+	{ "string_var",			SCE_PL_STRING_VAR,			FALSE },
+	{ "xlat",				SCE_PL_XLAT,				FALSE },
+	{ "regex_var",			SCE_PL_REGEX_VAR,			FALSE },
+	{ "regsubst_var",		SCE_PL_REGSUBST_VAR,		FALSE },
+	{ "backticks_var",		SCE_PL_BACKTICKS_VAR,		FALSE },
+	{ "here_qq_var",		SCE_PL_HERE_QQ_VAR,			FALSE },
+	{ "here_qx_var",		SCE_PL_HERE_QX_VAR,			FALSE },
+	{ "string_qq_var",		SCE_PL_STRING_QQ_VAR,		FALSE },
+	{ "string_qx_var",		SCE_PL_STRING_QX_VAR,		FALSE },
+	{ "string_qr_var",		SCE_PL_STRING_QR_VAR,		FALSE }
 };
 static const HLKeyword highlighting_keywords_PERL[] =
 {
-	{ 0, "primary",	FALSE }
+	{ "primary", 0,	FALSE }
 };
 #define highlighting_properties_PERL	EMPTY_PROPERTIES
 
@@ -1221,22 +1221,22 @@ static const HLKeyword highlighting_keywords_PERL[] =
 #define highlighting_lexer_PO		SCLEX_PO
 static const HLStyle highlighting_styles_PO[] =
 {
-	{ SCE_PO_DEFAULT,				"default",				FALSE },
-	{ SCE_PO_COMMENT,				"comment",				FALSE },
-	{ SCE_PO_PROGRAMMER_COMMENT,	"programmer_comment",	FALSE },
-	{ SCE_PO_REFERENCE,				"reference",			FALSE },
-	{ SCE_PO_FLAGS,					"flags",				FALSE },
-	{ SCE_PO_FUZZY,					"fuzzy",				FALSE },
-	{ SCE_PO_MSGID,					"msgid",				FALSE },
-	{ SCE_PO_MSGID_TEXT,			"msgid_text",			FALSE },
-	{ SCE_PO_MSGID_TEXT_EOL,		"msgid_text_eol",		FALSE },
-	{ SCE_PO_MSGSTR,				"msgstr",				FALSE },
-	{ SCE_PO_MSGSTR_TEXT,			"msgstr_text",			FALSE },
-	{ SCE_PO_MSGSTR_TEXT_EOL,		"msgstr_text_eol",		FALSE },
-	{ SCE_PO_MSGCTXT,				"msgctxt",				FALSE },
-	{ SCE_PO_MSGCTXT_TEXT,			"msgctxt_text",			FALSE },
-	{ SCE_PO_MSGCTXT_TEXT_EOL,		"msgctxt_text_eol",		FALSE },
-	{ SCE_PO_ERROR,					"error",				FALSE }
+	{ "default",			SCE_PO_DEFAULT,				FALSE },
+	{ "comment",			SCE_PO_COMMENT,				FALSE },
+	{ "programmer_comment",	SCE_PO_PROGRAMMER_COMMENT,	FALSE },
+	{ "reference",			SCE_PO_REFERENCE,			FALSE },
+	{ "flags",				SCE_PO_FLAGS,				FALSE },
+	{ "fuzzy",				SCE_PO_FUZZY,				FALSE },
+	{ "msgid",				SCE_PO_MSGID,				FALSE },
+	{ "msgid_text",			SCE_PO_MSGID_TEXT,			FALSE },
+	{ "msgid_text_eol",		SCE_PO_MSGID_TEXT_EOL,		FALSE },
+	{ "msgstr",				SCE_PO_MSGSTR,				FALSE },
+	{ "msgstr_text",		SCE_PO_MSGSTR_TEXT,			FALSE },
+	{ "msgstr_text_eol",	SCE_PO_MSGSTR_TEXT_EOL,		FALSE },
+	{ "msgctxt",			SCE_PO_MSGCTXT,				FALSE },
+	{ "msgctxt_text",		SCE_PO_MSGCTXT_TEXT,		FALSE },
+	{ "msgctxt_text_eol",	SCE_PO_MSGCTXT_TEXT_EOL,	FALSE },
+	{ "error",				SCE_PO_ERROR,				FALSE }
 };
 #define highlighting_keywords_PO	EMPTY_KEYWORDS
 #define highlighting_properties_PO	EMPTY_PROPERTIES
@@ -1246,32 +1246,32 @@ static const HLStyle highlighting_styles_PO[] =
 #define highlighting_lexer_POWERSHELL		SCLEX_POWERSHELL
 static const HLStyle highlighting_styles_POWERSHELL[] =
 {
-	{ SCE_POWERSHELL_DEFAULT,			"default",				FALSE },
-	{ SCE_POWERSHELL_COMMENT,			"comment",				FALSE },
-	{ SCE_POWERSHELL_STRING,			"string",				FALSE },
-	{ SCE_POWERSHELL_CHARACTER,			"character",			FALSE },
-	{ SCE_POWERSHELL_NUMBER,			"number",				FALSE },
-	{ SCE_POWERSHELL_VARIABLE,			"variable",				FALSE },
-	{ SCE_POWERSHELL_OPERATOR,			"operator",				FALSE },
-	{ SCE_POWERSHELL_IDENTIFIER,		"identifier",			FALSE },
-	{ SCE_POWERSHELL_KEYWORD,			"keyword",				FALSE },
-	{ SCE_POWERSHELL_CMDLET,			"cmdlet",				FALSE },
-	{ SCE_POWERSHELL_ALIAS,				"alias",				FALSE },
-	{ SCE_POWERSHELL_FUNCTION,			"function",				FALSE },
-	{ SCE_POWERSHELL_USER1,				"user1",				FALSE },
-	{ SCE_POWERSHELL_COMMENTSTREAM,		"commentstream",		FALSE },
-	{ SCE_POWERSHELL_HERE_STRING,		"here_string",			FALSE },
-	{ SCE_POWERSHELL_HERE_CHARACTER,	"here_character",		FALSE },
-	{ SCE_POWERSHELL_COMMENTDOCKEYWORD,	"commentdockeyword",	FALSE },
+	{ "default",			SCE_POWERSHELL_DEFAULT,				FALSE },
+	{ "comment",			SCE_POWERSHELL_COMMENT,				FALSE },
+	{ "string",				SCE_POWERSHELL_STRING,				FALSE },
+	{ "character",			SCE_POWERSHELL_CHARACTER,			FALSE },
+	{ "number",				SCE_POWERSHELL_NUMBER,				FALSE },
+	{ "variable",			SCE_POWERSHELL_VARIABLE,			FALSE },
+	{ "operator",			SCE_POWERSHELL_OPERATOR,			FALSE },
+	{ "identifier",			SCE_POWERSHELL_IDENTIFIER,			FALSE },
+	{ "keyword",			SCE_POWERSHELL_KEYWORD,				FALSE },
+	{ "cmdlet",				SCE_POWERSHELL_CMDLET,				FALSE },
+	{ "alias",				SCE_POWERSHELL_ALIAS,				FALSE },
+	{ "function",			SCE_POWERSHELL_FUNCTION,			FALSE },
+	{ "user1",				SCE_POWERSHELL_USER1,				FALSE },
+	{ "commentstream",		SCE_POWERSHELL_COMMENTSTREAM,		FALSE },
+	{ "here_string",		SCE_POWERSHELL_HERE_STRING,			FALSE },
+	{ "here_character",		SCE_POWERSHELL_HERE_CHARACTER,		FALSE },
+	{ "commentdockeyword",	SCE_POWERSHELL_COMMENTDOCKEYWORD,	FALSE },
 };
 static const HLKeyword highlighting_keywords_POWERSHELL[] =
 {
-	{ 0, "keywords",	FALSE },
-	{ 1, "cmdlets",		FALSE },
-	{ 2, "aliases",		FALSE },
-	{ 3, "functions",	FALSE },
-	{ 4, "user1",		FALSE },
-	{ 5, "docComment",	FALSE },
+	{ "keywords",	0,	FALSE },
+	{ "cmdlets",	1,	FALSE },
+	{ "aliases",	2,	FALSE },
+	{ "functions",	3,	FALSE },
+	{ "user1",		4,	FALSE },
+	{ "docComment",	5,	FALSE },
 };
 #define highlighting_properties_POWERSHELL	EMPTY_PROPERTIES
 
@@ -1280,31 +1280,31 @@ static const HLKeyword highlighting_keywords_POWERSHELL[] =
 #define highlighting_lexer_PYTHON		SCLEX_PYTHON
 static const HLStyle highlighting_styles_PYTHON[] =
 {
-	{ SCE_P_DEFAULT,		"default",			FALSE },
-	{ SCE_P_COMMENTLINE,	"commentline",		FALSE },
-	{ SCE_P_NUMBER,			"number",			FALSE },
-	{ SCE_P_STRING,			"string",			FALSE },
-	{ SCE_P_CHARACTER,		"character",		FALSE },
-	{ SCE_P_WORD,			"word",				FALSE },
-	{ SCE_P_TRIPLE,			"triple",			FALSE },
-	{ SCE_P_TRIPLEDOUBLE,	"tripledouble",		FALSE },
-	{ SCE_P_CLASSNAME,		"classname",		FALSE },
-	{ SCE_P_DEFNAME,		"defname",			FALSE },
-	{ SCE_P_OPERATOR,		"operator",			FALSE },
-	{ SCE_P_IDENTIFIER,		"identifier",		FALSE },
-	{ SCE_P_COMMENTBLOCK,	"commentblock",		FALSE },
-	{ SCE_P_STRINGEOL,		"stringeol",		FALSE },
-	{ SCE_P_WORD2,			"word2",			FALSE },
-	{ SCE_P_FSTRING,		"fstring",			FALSE },
-	{ SCE_P_FCHARACTER,		"fcharacter",		FALSE },
-	{ SCE_P_FTRIPLE,		"ftriple",			FALSE },
-	{ SCE_P_FTRIPLEDOUBLE,	"ftripledouble",	FALSE },
-	{ SCE_P_DECORATOR,		"decorator",		FALSE }
+	{ "default",		SCE_P_DEFAULT,			FALSE },
+	{ "commentline",	SCE_P_COMMENTLINE,		FALSE },
+	{ "number",			SCE_P_NUMBER,			FALSE },
+	{ "string",			SCE_P_STRING,			FALSE },
+	{ "character",		SCE_P_CHARACTER,		FALSE },
+	{ "word",			SCE_P_WORD,				FALSE },
+	{ "triple",			SCE_P_TRIPLE,			FALSE },
+	{ "tripledouble",	SCE_P_TRIPLEDOUBLE,		FALSE },
+	{ "classname",		SCE_P_CLASSNAME,		FALSE },
+	{ "defname",		SCE_P_DEFNAME,			FALSE },
+	{ "operator",		SCE_P_OPERATOR,			FALSE },
+	{ "identifier",		SCE_P_IDENTIFIER,		FALSE },
+	{ "commentblock",	SCE_P_COMMENTBLOCK,		FALSE },
+	{ "stringeol",		SCE_P_STRINGEOL,		FALSE },
+	{ "word2",			SCE_P_WORD2,			FALSE },
+	{ "fstring",		SCE_P_FSTRING,			FALSE },
+	{ "fcharacter",		SCE_P_FCHARACTER,		FALSE },
+	{ "ftriple",		SCE_P_FTRIPLE,			FALSE },
+	{ "ftripledouble",	SCE_P_FTRIPLEDOUBLE,	FALSE },
+	{ "decorator",		SCE_P_DECORATOR,		FALSE }
 };
 static const HLKeyword highlighting_keywords_PYTHON[] =
 {
-	{ 0, "primary",		FALSE },
-	{ 1, "identifiers",	FALSE }
+	{ "primary",			0,	FALSE },
+	{ "identifiers",		1,	FALSE }
 };
 #define highlighting_properties_PYTHON	EMPTY_PROPERTIES
 
@@ -1313,24 +1313,24 @@ static const HLKeyword highlighting_keywords_PYTHON[] =
 #define highlighting_lexer_R		SCLEX_R
 static const HLStyle highlighting_styles_R[] =
 {
-	{ SCE_R_DEFAULT,	"default",		FALSE },
-	{ SCE_R_COMMENT,	"comment",		FALSE },
-	{ SCE_R_KWORD,		"kword",		FALSE },
-	{ SCE_R_OPERATOR,	"operator",		FALSE },
-	{ SCE_R_BASEKWORD,	"basekword",	FALSE },
-	{ SCE_R_OTHERKWORD,	"otherkword",	FALSE },
-	{ SCE_R_NUMBER,		"number",		FALSE },
-	{ SCE_R_STRING,		"string",		FALSE },
-	{ SCE_R_STRING2,	"string2",		FALSE },
-	{ SCE_R_IDENTIFIER,	"identifier",	FALSE },
-	{ SCE_R_INFIX,		"infix",		FALSE },
-	{ SCE_R_INFIXEOL,	"infixeol",		FALSE }
+	{ "default",		SCE_R_DEFAULT,		FALSE },
+	{ "comment",		SCE_R_COMMENT,		FALSE },
+	{ "kword",			SCE_R_KWORD,		FALSE },
+	{ "operator",		SCE_R_OPERATOR,		FALSE },
+	{ "basekword",		SCE_R_BASEKWORD,	FALSE },
+	{ "otherkword",		SCE_R_OTHERKWORD,	FALSE },
+	{ "number",			SCE_R_NUMBER,		FALSE },
+	{ "string",			SCE_R_STRING,		FALSE },
+	{ "string2",		SCE_R_STRING2,		FALSE },
+	{ "identifier",		SCE_R_IDENTIFIER,	FALSE },
+	{ "infix",			SCE_R_INFIX,		FALSE },
+	{ "infixeol",		SCE_R_INFIXEOL,		FALSE }
 };
 static const HLKeyword highlighting_keywords_R[] =
 {
-	{ 0, "primary",			FALSE },
-	{ 1, "package",			FALSE },
-	{ 2, "package_other",	FALSE }
+	{ "primary",			0,	FALSE },
+	{ "package",			1,	FALSE },
+	{ "package_other",		2,	FALSE }
 };
 #define highlighting_properties_R	EMPTY_PROPERTIES
 
@@ -1339,44 +1339,44 @@ static const HLKeyword highlighting_keywords_R[] =
 #define highlighting_lexer_RUBY			SCLEX_RUBY
 static const HLStyle highlighting_styles_RUBY[] =
 {
-	{ SCE_RB_DEFAULT,		"default",			FALSE },
-	{ SCE_RB_COMMENTLINE,	"commentline",		FALSE },
-	{ SCE_RB_NUMBER,		"number",			FALSE },
-	{ SCE_RB_STRING,		"string",			FALSE },
-	{ SCE_RB_CHARACTER,		"character",		FALSE },
-	{ SCE_RB_WORD,			"word",				FALSE },
-	{ SCE_RB_GLOBAL,		"global",			FALSE },
-	{ SCE_RB_SYMBOL,		"symbol",			FALSE },
-	{ SCE_RB_CLASSNAME,		"classname",		FALSE },
-	{ SCE_RB_DEFNAME,		"defname",			FALSE },
-	{ SCE_RB_OPERATOR,		"operator",			FALSE },
-	{ SCE_RB_IDENTIFIER,	"identifier",		FALSE },
-	{ SCE_RB_MODULE_NAME,	"modulename",		FALSE },
-	{ SCE_RB_BACKTICKS,		"backticks",		FALSE },
-	{ SCE_RB_INSTANCE_VAR,	"instancevar",		FALSE },
-	{ SCE_RB_CLASS_VAR,		"classvar",			FALSE },
-	{ SCE_RB_DATASECTION,	"datasection",		FALSE },
-	{ SCE_RB_HERE_DELIM,	"heredelim",		FALSE },
-	{ SCE_RB_WORD_DEMOTED,	"worddemoted",		FALSE },
-	{ SCE_RB_STDIN,			"stdin",			FALSE },
-	{ SCE_RB_STDOUT,		"stdout",			FALSE },
-	{ SCE_RB_STDERR,		"stderr",			FALSE },
-	{ SCE_RB_REGEX,			"regex",			FALSE },
-	{ SCE_RB_HERE_Q,		"here_q",			FALSE },
-	{ SCE_RB_HERE_QQ,		"here_qq",			FALSE },
-	{ SCE_RB_HERE_QX,		"here_qx",			FALSE },
-	{ SCE_RB_STRING_Q,		"string_q",			FALSE },
-	{ SCE_RB_STRING_QQ,		"string_qq",		FALSE },
-	{ SCE_RB_STRING_QX,		"string_qx",		FALSE },
-	{ SCE_RB_STRING_QR,		"string_qr",		FALSE },
-	{ SCE_RB_STRING_QW,		"string_qw",		FALSE },
-	{ SCE_RB_UPPER_BOUND,	"upper_bound",		FALSE },
-	{ SCE_RB_ERROR,			"error",			FALSE },
-	{ SCE_RB_POD,			"pod",				FALSE }
+	{ "default",			SCE_RB_DEFAULT,				FALSE },
+	{ "commentline",		SCE_RB_COMMENTLINE,			FALSE },
+	{ "number",				SCE_RB_NUMBER,				FALSE },
+	{ "string",				SCE_RB_STRING,				FALSE },
+	{ "character",			SCE_RB_CHARACTER,			FALSE },
+	{ "word",				SCE_RB_WORD,				FALSE },
+	{ "global",				SCE_RB_GLOBAL,				FALSE },
+	{ "symbol",				SCE_RB_SYMBOL,				FALSE },
+	{ "classname",			SCE_RB_CLASSNAME,			FALSE },
+	{ "defname",			SCE_RB_DEFNAME,				FALSE },
+	{ "operator",			SCE_RB_OPERATOR,			FALSE },
+	{ "identifier",			SCE_RB_IDENTIFIER,			FALSE },
+	{ "modulename",			SCE_RB_MODULE_NAME,			FALSE },
+	{ "backticks",			SCE_RB_BACKTICKS,			FALSE },
+	{ "instancevar",		SCE_RB_INSTANCE_VAR,		FALSE },
+	{ "classvar",			SCE_RB_CLASS_VAR,			FALSE },
+	{ "datasection",		SCE_RB_DATASECTION,			FALSE },
+	{ "heredelim",			SCE_RB_HERE_DELIM,			FALSE },
+	{ "worddemoted",		SCE_RB_WORD_DEMOTED,		FALSE },
+	{ "stdin",				SCE_RB_STDIN,				FALSE },
+	{ "stdout",				SCE_RB_STDOUT,				FALSE },
+	{ "stderr",				SCE_RB_STDERR,				FALSE },
+	{ "regex",				SCE_RB_REGEX,				FALSE },
+	{ "here_q",				SCE_RB_HERE_Q,				FALSE },
+	{ "here_qq",			SCE_RB_HERE_QQ,				FALSE },
+	{ "here_qx",			SCE_RB_HERE_QX,				FALSE },
+	{ "string_q",			SCE_RB_STRING_Q,			FALSE },
+	{ "string_qq",			SCE_RB_STRING_QQ,			FALSE },
+	{ "string_qx",			SCE_RB_STRING_QX,			FALSE },
+	{ "string_qr",			SCE_RB_STRING_QR,			FALSE },
+	{ "string_qw",			SCE_RB_STRING_QW,			FALSE },
+	{ "upper_bound",		SCE_RB_UPPER_BOUND,			FALSE },
+	{ "error",				SCE_RB_ERROR,				FALSE },
+	{ "pod",				SCE_RB_POD,					FALSE }
 };
 static const HLKeyword highlighting_keywords_RUBY[] =
 {
-	{ 0, "primary",	FALSE }
+	{ "primary", 0,	FALSE }
 };
 #define highlighting_properties_RUBY	EMPTY_PROPERTIES
 
@@ -1384,37 +1384,37 @@ static const HLKeyword highlighting_keywords_RUBY[] =
 #define highlighting_lexer_RUST		SCLEX_RUST
 static const HLStyle highlighting_styles_RUST[] =
 {
-	{ SCE_RUST_DEFAULT,				"default",					FALSE },
-	{ SCE_RUST_COMMENTBLOCK,		"commentblock",				FALSE },
-	{ SCE_RUST_COMMENTLINE,			"commentline",				FALSE },
-	{ SCE_RUST_COMMENTBLOCKDOC,		"commentblockdoc",			FALSE },
-	{ SCE_RUST_COMMENTLINEDOC,		"commentlinedoc",			FALSE },
-	{ SCE_RUST_NUMBER,				"number",					FALSE },
-	{ SCE_RUST_WORD,				"word",						FALSE },
-	{ SCE_RUST_WORD2,				"word2",					FALSE },
-	{ SCE_RUST_WORD3,				"word3",					FALSE },
-	{ SCE_RUST_WORD4,				"word4",					FALSE },
-	{ SCE_RUST_WORD5,				"word5",					FALSE },
-	{ SCE_RUST_WORD6,				"word6",					FALSE },
-	{ SCE_RUST_WORD7,				"word7",					FALSE },
-	{ SCE_RUST_STRING,				"string",					FALSE },
-	{ SCE_RUST_STRINGR,				"stringraw",				FALSE },
-	{ SCE_RUST_CHARACTER,			"character",				FALSE },
-	{ SCE_RUST_OPERATOR,			"operator",					FALSE },
-	{ SCE_RUST_IDENTIFIER,			"identifier",				FALSE },
-	{ SCE_RUST_LIFETIME,			"lifetime",					FALSE },
-	{ SCE_RUST_MACRO,				"macro",					FALSE },
-	{ SCE_RUST_LEXERROR,			"lexerror",					FALSE },
-	{ SCE_RUST_BYTESTRING,			"bytestring",				FALSE },
-	{ SCE_RUST_BYTESTRINGR,			"bytestringr",				FALSE },
-	{ SCE_RUST_BYTECHARACTER,		"bytecharacter",			FALSE }
+	{ "default",				SCE_RUST_DEFAULT,				FALSE },
+	{ "commentblock",			SCE_RUST_COMMENTBLOCK,			FALSE },
+	{ "commentline",			SCE_RUST_COMMENTLINE,			FALSE },
+	{ "commentblockdoc",		SCE_RUST_COMMENTBLOCKDOC,		FALSE },
+	{ "commentlinedoc",			SCE_RUST_COMMENTLINEDOC,		FALSE },
+	{ "number",					SCE_RUST_NUMBER,				FALSE },
+	{ "word",					SCE_RUST_WORD,					FALSE },
+	{ "word2",					SCE_RUST_WORD2,					FALSE },
+	{ "word3",					SCE_RUST_WORD3,					FALSE },
+	{ "word4",					SCE_RUST_WORD4,					FALSE },
+	{ "word5",					SCE_RUST_WORD5,					FALSE },
+	{ "word6",					SCE_RUST_WORD6,					FALSE },
+	{ "word7",					SCE_RUST_WORD7,					FALSE },
+	{ "string",					SCE_RUST_STRING,				FALSE },
+	{ "stringraw",				SCE_RUST_STRINGR,				FALSE },
+	{ "character",				SCE_RUST_CHARACTER,				FALSE },
+	{ "operator",				SCE_RUST_OPERATOR,				FALSE },
+	{ "identifier",				SCE_RUST_IDENTIFIER,			FALSE },
+	{ "lifetime",				SCE_RUST_LIFETIME,				FALSE },
+	{ "macro",					SCE_RUST_MACRO,					FALSE },
+	{ "lexerror",				SCE_RUST_LEXERROR,				FALSE },
+	{ "bytestring",				SCE_RUST_BYTESTRING,			FALSE },
+	{ "bytestringr",			SCE_RUST_BYTESTRINGR,			FALSE },
+	{ "bytecharacter",			SCE_RUST_BYTECHARACTER,			FALSE }
 };
 static const HLKeyword highlighting_keywords_RUST[] =
 {
-	{ 0, "primary",		FALSE },
+	{ "primary",		0,	FALSE },
 	/* SCI_SETKEYWORDS = 1 - secondary + global tags file types */
-	{ 1, "secondary",	TRUE },
-	{ 2, "tertiary",	FALSE },
+	{ "secondary",		1,	TRUE },
+	{ "tertiary",		2,	FALSE },
 	/* SCI_SETKEYWORDS = 3 is for current session types - see document_highlight_tags() */
 };
 #define highlighting_properties_RUST		EMPTY_PROPERTIES
@@ -1423,24 +1423,24 @@ static const HLKeyword highlighting_keywords_RUST[] =
 #define highlighting_lexer_SH		SCLEX_BASH
 static const HLStyle highlighting_styles_SH[] =
 {
-	{ SCE_SH_DEFAULT,		"default",		FALSE },
-	{ SCE_SH_COMMENTLINE,	"commentline",	FALSE },
-	{ SCE_SH_NUMBER,		"number",		FALSE },
-	{ SCE_SH_WORD,			"word",			FALSE },
-	{ SCE_SH_STRING,		"string",		FALSE },
-	{ SCE_SH_CHARACTER,		"character",	FALSE },
-	{ SCE_SH_OPERATOR,		"operator",		FALSE },
-	{ SCE_SH_IDENTIFIER,	"identifier",	FALSE },
-	{ SCE_SH_BACKTICKS,		"backticks",	FALSE },
-	{ SCE_SH_PARAM,			"param",		FALSE },
-	{ SCE_SH_SCALAR,		"scalar",		FALSE },
-	{ SCE_SH_ERROR,			"error",		FALSE },
-	{ SCE_SH_HERE_DELIM,	"here_delim",	FALSE },
-	{ SCE_SH_HERE_Q,		"here_q",		FALSE }
+	{ "default",		SCE_SH_DEFAULT,		FALSE },
+	{ "commentline",	SCE_SH_COMMENTLINE,	FALSE },
+	{ "number",			SCE_SH_NUMBER,		FALSE },
+	{ "word",			SCE_SH_WORD,		FALSE },
+	{ "string",			SCE_SH_STRING,		FALSE },
+	{ "character",		SCE_SH_CHARACTER,	FALSE },
+	{ "operator",		SCE_SH_OPERATOR,	FALSE },
+	{ "identifier",		SCE_SH_IDENTIFIER,	FALSE },
+	{ "backticks",		SCE_SH_BACKTICKS,	FALSE },
+	{ "param",			SCE_SH_PARAM,		FALSE },
+	{ "scalar",			SCE_SH_SCALAR,		FALSE },
+	{ "error",			SCE_SH_ERROR,		FALSE },
+	{ "here_delim",		SCE_SH_HERE_DELIM,	FALSE },
+	{ "here_q",			SCE_SH_HERE_Q,		FALSE }
 };
 static const HLKeyword highlighting_keywords_SH[] =
 {
-	{ 0, "primary",	FALSE }
+	{ "primary", 0,	FALSE }
 };
 #define highlighting_properties_SH	EMPTY_PROPERTIES
 
@@ -1449,27 +1449,27 @@ static const HLKeyword highlighting_keywords_SH[] =
 #define highlighting_lexer_SMALLTALK SCLEX_SMALLTALK
 static const HLStyle highlighting_styles_SMALLTALK[] =
 {
-	{ SCE_ST_DEFAULT,		"default",				FALSE },
-	{ SCE_ST_SPECIAL,		"special",				FALSE },
-	{ SCE_ST_SYMBOL,		"symbol",				FALSE },
-	{ SCE_ST_ASSIGN,		"assignment",			FALSE },
-	{ SCE_ST_RETURN,		"return",				FALSE },
-	{ SCE_ST_NUMBER,		"number",				FALSE },
-	{ SCE_ST_BINARY,		"binary",				FALSE },
-	{ SCE_ST_SPEC_SEL,		"special_selector",		FALSE },
-	{ SCE_ST_KWSEND,		"keyword_send",			FALSE },
-	{ SCE_ST_GLOBAL,		"global",				FALSE },
-	{ SCE_ST_SELF,			"self",					FALSE },
-	{ SCE_ST_SUPER,			"super",				FALSE },
-	{ SCE_ST_NIL,			"nil",					FALSE },
-	{ SCE_ST_BOOL,			"bool",					FALSE },
-	{ SCE_ST_COMMENT,		"comment",				FALSE },
-	{ SCE_ST_STRING,		"string",				FALSE },
-	{ SCE_ST_CHARACTER,		"character",			FALSE }
+	{ "default",			SCE_ST_DEFAULT,		FALSE },
+	{ "special",			SCE_ST_SPECIAL,		FALSE },
+	{ "symbol",				SCE_ST_SYMBOL,		FALSE },
+	{ "assignment",			SCE_ST_ASSIGN,		FALSE },
+	{ "return",				SCE_ST_RETURN,		FALSE },
+	{ "number",				SCE_ST_NUMBER,		FALSE },
+	{ "binary",				SCE_ST_BINARY,		FALSE },
+	{ "special_selector",	SCE_ST_SPEC_SEL,	FALSE },
+	{ "keyword_send",		SCE_ST_KWSEND,		FALSE },
+	{ "global",				SCE_ST_GLOBAL,		FALSE },
+	{ "self",				SCE_ST_SELF,		FALSE },
+	{ "super",				SCE_ST_SUPER,		FALSE },
+	{ "nil",				SCE_ST_NIL,			FALSE },
+	{ "bool",				SCE_ST_BOOL,		FALSE },
+	{ "comment",			SCE_ST_COMMENT,		FALSE },
+	{ "string",				SCE_ST_STRING,		FALSE },
+	{ "character",			SCE_ST_CHARACTER,	FALSE }
 };
 static const HLKeyword highlighting_keywords_SMALLTALK[] =
 {
-	{ 0, "special_selector",	FALSE }
+	{ "special_selector", 0,	FALSE }
 };
 #define highlighting_properties_SMALLTALK	EMPTY_PROPERTIES
 
@@ -1478,34 +1478,34 @@ static const HLKeyword highlighting_keywords_SMALLTALK[] =
 #define highlighting_lexer_SQL			SCLEX_SQL
 static const HLStyle highlighting_styles_SQL[] =
 {
-	{ SCE_SQL_DEFAULT,					"default",					FALSE },
-	{ SCE_SQL_COMMENT,					"comment",					FALSE },
-	{ SCE_SQL_COMMENTLINE,				"commentline",				FALSE },
-	{ SCE_SQL_COMMENTDOC,				"commentdoc",				FALSE },
-	{ SCE_SQL_COMMENTLINEDOC,			"commentlinedoc",			FALSE },
-	{ SCE_SQL_COMMENTDOCKEYWORD,		"commentdockeyword",		FALSE },
-	{ SCE_SQL_COMMENTDOCKEYWORDERROR,	"commentdockeyworderror",	FALSE },
-	{ SCE_SQL_NUMBER,					"number",					FALSE },
-	{ SCE_SQL_WORD,						"word",						FALSE },
-	{ SCE_SQL_WORD2,					"word2",					FALSE },
-	{ SCE_SQL_STRING,					"string",					FALSE },
-	{ SCE_SQL_CHARACTER,				"character",				FALSE },
-	{ SCE_SQL_OPERATOR,					"operator",					FALSE },
-	{ SCE_SQL_IDENTIFIER,				"identifier",				FALSE },
-	{ SCE_SQL_SQLPLUS,					"sqlplus",					FALSE },
-	{ SCE_SQL_SQLPLUS_PROMPT,			"sqlplus_prompt",			FALSE },
-	{ SCE_SQL_SQLPLUS_COMMENT,			"sqlplus_comment",			FALSE },
-	{ SCE_SQL_QUOTEDIDENTIFIER,			"quotedidentifier",			FALSE },
-	{ SCE_SQL_QOPERATOR,				"qoperator",				FALSE }
+	{ "default",				SCE_SQL_DEFAULT,					FALSE },
+	{ "comment",				SCE_SQL_COMMENT,					FALSE },
+	{ "commentline",			SCE_SQL_COMMENTLINE,				FALSE },
+	{ "commentdoc",				SCE_SQL_COMMENTDOC,					FALSE },
+	{ "commentlinedoc",			SCE_SQL_COMMENTLINEDOC,				FALSE },
+	{ "commentdockeyword",		SCE_SQL_COMMENTDOCKEYWORD,			FALSE },
+	{ "commentdockeyworderror",	SCE_SQL_COMMENTDOCKEYWORDERROR,		FALSE },
+	{ "number",					SCE_SQL_NUMBER,						FALSE },
+	{ "word",					SCE_SQL_WORD,						FALSE },
+	{ "word2",					SCE_SQL_WORD2,						FALSE },
+	{ "string",					SCE_SQL_STRING,						FALSE },
+	{ "character",				SCE_SQL_CHARACTER,					FALSE },
+	{ "operator",				SCE_SQL_OPERATOR,					FALSE },
+	{ "identifier",				SCE_SQL_IDENTIFIER,					FALSE },
+	{ "sqlplus",				SCE_SQL_SQLPLUS,					FALSE },
+	{ "sqlplus_prompt",			SCE_SQL_SQLPLUS_PROMPT,				FALSE },
+	{ "sqlplus_comment",		SCE_SQL_SQLPLUS_COMMENT,			FALSE },
+	{ "quotedidentifier",		SCE_SQL_QUOTEDIDENTIFIER,			FALSE },
+	{ "qoperator",				SCE_SQL_QOPERATOR,					FALSE }
 	/* these are for user-defined keywords we don't set yet */
-	/*{ SCE_SQL_USER1,					"user1",					FALSE },
-	{ SCE_SQL_USER2,					"user2",					FALSE },
-	{ SCE_SQL_USER3,					"user3",					FALSE },
-	{ SCE_SQL_USER4,					"user4",					FALSE }*/
+	/*{ "user1",				SCE_SQL_USER1,						FALSE },
+	{ "user2",					SCE_SQL_USER2,						FALSE },
+	{ "user3",					SCE_SQL_USER3,						FALSE },
+	{ "user4",					SCE_SQL_USER4,						FALSE }*/
 };
 static const HLKeyword highlighting_keywords_SQL[] =
 {
-	{ 0, "keywords",	FALSE }
+	{ "keywords", 0,	FALSE }
 };
 #define highlighting_properties_SQL		EMPTY_PROPERTIES
 
@@ -1514,37 +1514,37 @@ static const HLKeyword highlighting_keywords_SQL[] =
 #define highlighting_lexer_TCL			SCLEX_TCL
 static const HLStyle highlighting_styles_TCL[] =
 {
-	{ SCE_TCL_DEFAULT,			"default",			FALSE },
-	{ SCE_TCL_COMMENT,			"comment",			FALSE },
-	{ SCE_TCL_COMMENTLINE,		"commentline",		FALSE },
-	{ SCE_TCL_NUMBER,			"number",			FALSE },
-	{ SCE_TCL_OPERATOR,			"operator",			FALSE },
-	{ SCE_TCL_IDENTIFIER,		"identifier",		FALSE },
-	{ SCE_TCL_WORD_IN_QUOTE,	"wordinquote",		FALSE },
-	{ SCE_TCL_IN_QUOTE,			"inquote",			FALSE },
-	{ SCE_TCL_SUBSTITUTION,		"substitution",		FALSE },
-	{ SCE_TCL_MODIFIER,			"modifier",			FALSE },
-	{ SCE_TCL_EXPAND,			"expand",			FALSE },
-	{ SCE_TCL_WORD,				"wordtcl",			FALSE },
-	{ SCE_TCL_WORD2,			"wordtk",			FALSE },
-	{ SCE_TCL_WORD3,			"worditcl",			FALSE },
-	{ SCE_TCL_WORD4,			"wordtkcmds",		FALSE },
-	{ SCE_TCL_WORD5,			"wordexpand",		FALSE },
-	{ SCE_TCL_COMMENT_BOX,		"commentbox",		FALSE },
-	{ SCE_TCL_BLOCK_COMMENT,	"blockcomment",		FALSE },
-	{ SCE_TCL_SUB_BRACE,		"subbrace",			FALSE }
+	{ "default",			SCE_TCL_DEFAULT,		FALSE },
+	{ "comment",			SCE_TCL_COMMENT,		FALSE },
+	{ "commentline",		SCE_TCL_COMMENTLINE,	FALSE },
+	{ "number",				SCE_TCL_NUMBER,			FALSE },
+	{ "operator",			SCE_TCL_OPERATOR,		FALSE },
+	{ "identifier",			SCE_TCL_IDENTIFIER,		FALSE },
+	{ "wordinquote",		SCE_TCL_WORD_IN_QUOTE,	FALSE },
+	{ "inquote",			SCE_TCL_IN_QUOTE,		FALSE },
+	{ "substitution",		SCE_TCL_SUBSTITUTION,	FALSE },
+	{ "modifier",			SCE_TCL_MODIFIER,		FALSE },
+	{ "expand",				SCE_TCL_EXPAND,			FALSE },
+	{ "wordtcl",			SCE_TCL_WORD,			FALSE },
+	{ "wordtk",				SCE_TCL_WORD2,			FALSE },
+	{ "worditcl",			SCE_TCL_WORD3,			FALSE },
+	{ "wordtkcmds",			SCE_TCL_WORD4,			FALSE },
+	{ "wordexpand",			SCE_TCL_WORD5,			FALSE },
+	{ "commentbox",			SCE_TCL_COMMENT_BOX,	FALSE },
+	{ "blockcomment",		SCE_TCL_BLOCK_COMMENT,	FALSE },
+	{ "subbrace",			SCE_TCL_SUB_BRACE,		FALSE }
 	/* these are for user-defined keywords we don't set yet */
-	/*{ SCE_TCL_WORD6,			"user2",			FALSE },
-	{ SCE_TCL_WORD7,			"user3",			FALSE },
-	{ SCE_TCL_WORD8,			"user4",			FALSE }*/
+	/*{ "user2",			SCE_TCL_WORD6,			FALSE },
+	{ "user3",				SCE_TCL_WORD7,			FALSE },
+	{ "user4",				SCE_TCL_WORD8,			FALSE }*/
 };
 static const HLKeyword highlighting_keywords_TCL[] =
 {
-	{ 0, "tcl",			FALSE },
-	{ 1, "tk",			FALSE },
-	{ 2, "itcl",		FALSE },
-	{ 3, "tkcommands",	FALSE },
-	{ 4, "expand",		FALSE }
+	{ "tcl",		0,	FALSE },
+	{ "tk",			1,	FALSE },
+	{ "itcl",		2,	FALSE },
+	{ "tkcommands", 3,	FALSE },
+	{ "expand",		4,	FALSE }
 };
 #define highlighting_properties_TCL		EMPTY_PROPERTIES
 
@@ -1553,32 +1553,32 @@ static const HLKeyword highlighting_keywords_TCL[] =
 #define highlighting_lexer_TXT2TAGS			SCLEX_TXT2TAGS
 static const HLStyle highlighting_styles_TXT2TAGS[] =
 {
-	{ SCE_TXT2TAGS_DEFAULT,		"default",		FALSE },
-	{ SCE_TXT2TAGS_LINE_BEGIN,	"default",		FALSE }, /* XIFME: remappings should be avoided */
-	{ SCE_TXT2TAGS_PRECHAR,		"default",		FALSE },
-	{ SCE_TXT2TAGS_STRONG1,		"strong",		FALSE },
-	{ SCE_TXT2TAGS_STRONG2,		"strong",		FALSE },
-	{ SCE_TXT2TAGS_EM1,			"emphasis",		FALSE },
-	{ SCE_TXT2TAGS_EM2,			"underlined",	FALSE }, /* WTF? */
-	{ SCE_TXT2TAGS_HEADER1,		"header1",		FALSE },
-	{ SCE_TXT2TAGS_HEADER2,		"header2",		FALSE },
-	{ SCE_TXT2TAGS_HEADER3,		"header3",		FALSE },
-	{ SCE_TXT2TAGS_HEADER4,		"header4",		FALSE },
-	{ SCE_TXT2TAGS_HEADER5,		"header5",		FALSE },
-	{ SCE_TXT2TAGS_HEADER6,		"header6",		FALSE },
-	{ SCE_TXT2TAGS_ULIST_ITEM,	"ulist_item",	FALSE },
-	{ SCE_TXT2TAGS_OLIST_ITEM,	"olist_item",	FALSE },
-	{ SCE_TXT2TAGS_BLOCKQUOTE,	"blockquote",	FALSE },
-	{ SCE_TXT2TAGS_STRIKEOUT,	"strikeout",	FALSE },
-	{ SCE_TXT2TAGS_HRULE,		"hrule",		FALSE },
-	{ SCE_TXT2TAGS_LINK,		"link",			FALSE },
-	{ SCE_TXT2TAGS_CODE,		"code",			FALSE },
-	{ SCE_TXT2TAGS_CODE2,		"code",			FALSE },
-	{ SCE_TXT2TAGS_CODEBK,		"codebk",		FALSE },
-	{ SCE_TXT2TAGS_COMMENT,		"comment",		FALSE },
-	{ SCE_TXT2TAGS_OPTION,		"option",		FALSE },
-	{ SCE_TXT2TAGS_PREPROC,		"preproc",		FALSE },
-	{ SCE_TXT2TAGS_POSTPROC,	"postproc",		FALSE }
+	{ "default",		SCE_TXT2TAGS_DEFAULT,		FALSE },
+	{ "default",		SCE_TXT2TAGS_LINE_BEGIN,	FALSE }, /* FIXME: remappings should be avoided */
+	{ "default",		SCE_TXT2TAGS_PRECHAR,		FALSE },
+	{ "strong",			SCE_TXT2TAGS_STRONG1,		FALSE },
+	{ "strong",			SCE_TXT2TAGS_STRONG2,		FALSE },
+	{ "emphasis",		SCE_TXT2TAGS_EM1,			FALSE },
+	{ "underlined",		SCE_TXT2TAGS_EM2,			FALSE }, /* WTF? */
+	{ "header1",		SCE_TXT2TAGS_HEADER1,		FALSE },
+	{ "header2",		SCE_TXT2TAGS_HEADER2,		FALSE },
+	{ "header3",		SCE_TXT2TAGS_HEADER3,		FALSE },
+	{ "header4",		SCE_TXT2TAGS_HEADER4,		FALSE },
+	{ "header5",		SCE_TXT2TAGS_HEADER5,		FALSE },
+	{ "header6",		SCE_TXT2TAGS_HEADER6,		FALSE },
+	{ "ulist_item",		SCE_TXT2TAGS_ULIST_ITEM,	FALSE },
+	{ "olist_item",		SCE_TXT2TAGS_OLIST_ITEM,	FALSE },
+	{ "blockquote",		SCE_TXT2TAGS_BLOCKQUOTE,	FALSE },
+	{ "strikeout",		SCE_TXT2TAGS_STRIKEOUT,		FALSE },
+	{ "hrule",			SCE_TXT2TAGS_HRULE,			FALSE },
+	{ "link",			SCE_TXT2TAGS_LINK,			FALSE },
+	{ "code",			SCE_TXT2TAGS_CODE,			FALSE },
+	{ "code",			SCE_TXT2TAGS_CODE2,			FALSE },
+	{ "codebk",			SCE_TXT2TAGS_CODEBK,		FALSE },
+	{ "comment",		SCE_TXT2TAGS_COMMENT,		FALSE },
+	{ "option",			SCE_TXT2TAGS_OPTION,		FALSE },
+	{ "preproc",		SCE_TXT2TAGS_PREPROC,		FALSE },
+	{ "postproc",		SCE_TXT2TAGS_POSTPROC,		FALSE }
 };
 #define highlighting_keywords_TXT2TAGS		EMPTY_KEYWORDS
 #define highlighting_properties_TXT2TAGS	EMPTY_PROPERTIES
@@ -1588,32 +1588,32 @@ static const HLStyle highlighting_styles_TXT2TAGS[] =
 #define highlighting_lexer_VHDL			SCLEX_VHDL
 static const HLStyle highlighting_styles_VHDL[] =
 {
-	{ SCE_VHDL_DEFAULT,			"default",				FALSE },
-	{ SCE_VHDL_COMMENT,			"comment",				FALSE },
-	{ SCE_VHDL_COMMENTLINEBANG,	"comment_line_bang",	FALSE },
-	{ SCE_VHDL_BLOCK_COMMENT,	"block_comment",		FALSE },
-	{ SCE_VHDL_NUMBER,			"number",				FALSE },
-	{ SCE_VHDL_STRING,			"string",				FALSE },
-	{ SCE_VHDL_OPERATOR,		"operator",				FALSE },
-	{ SCE_VHDL_IDENTIFIER,		"identifier",			FALSE },
-	{ SCE_VHDL_STRINGEOL,		"stringeol",			FALSE },
-	{ SCE_VHDL_KEYWORD,			"keyword",				FALSE },
-	{ SCE_VHDL_STDOPERATOR,		"stdoperator",			FALSE },
-	{ SCE_VHDL_ATTRIBUTE,		"attribute",			FALSE },
-	{ SCE_VHDL_STDFUNCTION,		"stdfunction",			FALSE },
-	{ SCE_VHDL_STDPACKAGE,		"stdpackage",			FALSE },
-	{ SCE_VHDL_STDTYPE,			"stdtype",				FALSE },
-	{ SCE_VHDL_USERWORD,		"userword",				FALSE }
+	{ "default",			SCE_VHDL_DEFAULT,			FALSE },
+	{ "comment",			SCE_VHDL_COMMENT,			FALSE },
+	{ "comment_line_bang",	SCE_VHDL_COMMENTLINEBANG,	FALSE },
+	{ "block_comment",		SCE_VHDL_BLOCK_COMMENT,		FALSE },
+	{ "number",				SCE_VHDL_NUMBER,			FALSE },
+	{ "string",				SCE_VHDL_STRING,			FALSE },
+	{ "operator",			SCE_VHDL_OPERATOR,			FALSE },
+	{ "identifier",			SCE_VHDL_IDENTIFIER,		FALSE },
+	{ "stringeol",			SCE_VHDL_STRINGEOL,			FALSE },
+	{ "keyword",			SCE_VHDL_KEYWORD,			FALSE },
+	{ "stdoperator",		SCE_VHDL_STDOPERATOR,		FALSE },
+	{ "attribute",			SCE_VHDL_ATTRIBUTE,			FALSE },
+	{ "stdfunction",		SCE_VHDL_STDFUNCTION,		FALSE },
+	{ "stdpackage",			SCE_VHDL_STDPACKAGE,		FALSE },
+	{ "stdtype",			SCE_VHDL_STDTYPE,			FALSE },
+	{ "userword",			SCE_VHDL_USERWORD,			FALSE }
 };
 static const HLKeyword highlighting_keywords_VHDL[] =
 {
-	{ 0, "keywords",		FALSE },
-	{ 1, "operators",		FALSE },
-	{ 2, "attributes",		FALSE },
-	{ 3, "std_functions",	FALSE },
-	{ 4, "std_packages",	FALSE },
-	{ 5, "std_types",		FALSE },
-	{ 6, "userwords",		FALSE },
+	{ "keywords",		0,	FALSE },
+	{ "operators",		1,	FALSE },
+	{ "attributes",		2,	FALSE },
+	{ "std_functions",	3,	FALSE },
+	{ "std_packages",	4,	FALSE },
+	{ "std_types",		5,	FALSE },
+	{ "userwords",		6,	FALSE },
 };
 #define highlighting_properties_VHDL	EMPTY_PROPERTIES
 
@@ -1622,32 +1622,32 @@ static const HLKeyword highlighting_keywords_VHDL[] =
 #define highlighting_lexer_VERILOG			SCLEX_VERILOG
 static const HLStyle highlighting_styles_VERILOG[] =
 {
-	{ SCE_V_DEFAULT,			"default",				FALSE },
-	{ SCE_V_COMMENT,			"comment",				FALSE },
-	{ SCE_V_COMMENTLINE,		"comment_line",			FALSE },
-	{ SCE_V_COMMENTLINEBANG,	"comment_line_bang",	FALSE },
-	{ SCE_V_NUMBER,				"number",				FALSE },
-	{ SCE_V_WORD,				"word",					FALSE },
-	{ SCE_V_STRING,				"string",				FALSE },
-	{ SCE_V_WORD2,				"word2",				FALSE },
-	{ SCE_V_WORD3,				"word3",				FALSE },
-	{ SCE_V_PREPROCESSOR,		"preprocessor",			FALSE },
-	{ SCE_V_OPERATOR,			"operator",				FALSE },
-	{ SCE_V_IDENTIFIER,			"identifier",			FALSE },
-	{ SCE_V_STRINGEOL,			"stringeol",			FALSE },
-	{ SCE_V_USER,				"userword",				FALSE },
-	{ SCE_V_COMMENT_WORD,		"comment_word",			FALSE },
-	{ SCE_V_INPUT,				"input",				FALSE },
-	{ SCE_V_OUTPUT,				"output",				FALSE },
-	{ SCE_V_INOUT,				"inout",				FALSE },
-	{ SCE_V_PORT_CONNECT,		"port_connect",			FALSE }
+	{ "default",			SCE_V_DEFAULT,			FALSE },
+	{ "comment",			SCE_V_COMMENT,			FALSE },
+	{ "comment_line",		SCE_V_COMMENTLINE,		FALSE },
+	{ "comment_line_bang",	SCE_V_COMMENTLINEBANG,	FALSE },
+	{ "number",				SCE_V_NUMBER,			FALSE },
+	{ "word",				SCE_V_WORD,				FALSE },
+	{ "string",				SCE_V_STRING,			FALSE },
+	{ "word2",				SCE_V_WORD2,			FALSE },
+	{ "word3",				SCE_V_WORD3,			FALSE },
+	{ "preprocessor",		SCE_V_PREPROCESSOR,		FALSE },
+	{ "operator",			SCE_V_OPERATOR,			FALSE },
+	{ "identifier",			SCE_V_IDENTIFIER,		FALSE },
+	{ "stringeol",			SCE_V_STRINGEOL,		FALSE },
+	{ "userword",			SCE_V_USER,				FALSE },
+	{ "comment_word",		SCE_V_COMMENT_WORD,		FALSE },
+	{ "input",				SCE_V_INPUT,			FALSE },
+	{ "output",				SCE_V_OUTPUT,			FALSE },
+	{ "inout",				SCE_V_INOUT,			FALSE },
+	{ "port_connect",		SCE_V_PORT_CONNECT,		FALSE }
 };
 static const HLKeyword highlighting_keywords_VERILOG[] =
 {
-	{ 0, "word",		FALSE },
-	{ 1, "word2",		FALSE },
-	{ 2, "word3",		FALSE },
-	{ 4, "docComment",	FALSE }
+	{ "word",		0,	FALSE },
+	{ "word2",		1,	FALSE },
+	{ "word3",		2,	FALSE },
+	{ "docComment", 4,	FALSE }
 };
 #define highlighting_properties_VERILOG		EMPTY_PROPERTIES
 
@@ -1657,7 +1657,7 @@ static const HLKeyword highlighting_keywords_VERILOG[] =
 #define highlighting_styles_XML			highlighting_styles_HTML
 static const HLKeyword highlighting_keywords_XML[] =
 {
-	{ 5, "sgml",	FALSE }
+	{ "sgml", 5,	FALSE }
 };
 #define highlighting_properties_XML		highlighting_properties_HTML
 
@@ -1666,20 +1666,20 @@ static const HLKeyword highlighting_keywords_XML[] =
 #define highlighting_lexer_YAML			SCLEX_YAML
 static const HLStyle highlighting_styles_YAML[] =
 {
-	{ SCE_YAML_DEFAULT,		"default",		FALSE },
-	{ SCE_YAML_COMMENT,		"comment",		FALSE },
-	{ SCE_YAML_IDENTIFIER,	"identifier",	FALSE },
-	{ SCE_YAML_KEYWORD,		"keyword",		FALSE },
-	{ SCE_YAML_NUMBER,		"number",		FALSE },
-	{ SCE_YAML_REFERENCE,	"reference",	FALSE },
-	{ SCE_YAML_DOCUMENT,	"document",		FALSE },
-	{ SCE_YAML_TEXT,		"text",			FALSE },
-	{ SCE_YAML_ERROR,		"error",		FALSE },
-	{ SCE_YAML_OPERATOR,	"operator",		FALSE }
+	{ "default",	SCE_YAML_DEFAULT,		FALSE },
+	{ "comment",	SCE_YAML_COMMENT,		FALSE },
+	{ "identifier",	SCE_YAML_IDENTIFIER,	FALSE },
+	{ "keyword",	SCE_YAML_KEYWORD,		FALSE },
+	{ "number",		SCE_YAML_NUMBER,		FALSE },
+	{ "reference",	SCE_YAML_REFERENCE,		FALSE },
+	{ "document",	SCE_YAML_DOCUMENT,		FALSE },
+	{ "text",		SCE_YAML_TEXT,			FALSE },
+	{ "error",		SCE_YAML_ERROR,			FALSE },
+	{ "operator",	SCE_YAML_OPERATOR,		FALSE }
 };
 static const HLKeyword highlighting_keywords_YAML[] =
 {
-	{ 0, "keywords",	FALSE }
+	{ "keywords", 0,	FALSE }
 };
 #define highlighting_properties_YAML	EMPTY_PROPERTIES
 


### PR DESCRIPTION
Hello!

On master, each struct has 8 padding bytes.

Found by: [scan-build](https://clang-analyzer.llvm.org/scan-build.html)

Thanks!