### PR TITLE
Add option and keybinding to hide menubar

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2544,6 +2544,7 @@ msgwin_scribble_visible           Whether to show the Scribble tab in the      t
                                   Messages Window
 warn_on_project_close             Whether to show a warning when opening       true        immediately
                                   a project while one is already open.
+on_startup_hide_menubar           Whether to hide the menu bar on startup      false       on restart
 **``terminal`` group**
 send_selection_unsafe             By default, Geany strips any trailing        false       immediately
                                   newline characters from the current
@@ -3667,8 +3668,10 @@ Action                          Default shortcut          Description
 =============================== ========================= ==================================================
 Fullscreen                      F11  (C)                  Switches to fullscreen mode.
 
-Toggle Messages Window                                    Toggles the message window (status and compiler
-                                                          messages) on and off.
+Toggle Menubar                                            Shows or hides the menubar.
+
+Toggle Messages Window                                    Shows or hides the message window
+                                                          (status and compiler messages).
 
 Toggle Sidebar                                            Shows or hides the sidebar.
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -603,6 +603,8 @@ static void init_default_kb(void)
 		"menu_toggle_all_additional_widgets1");
 	add_kb(group, GEANY_KEYS_VIEW_FULLSCREEN, cb_func_menu_fullscreen,
 		GDK_KEY_F11, 0, "menu_fullscreen", _("Fullscreen"), "menu_fullscreen1");
+	add_kb(group, GEANY_KEYS_TOGGLE_MENUBAR, NULL,
+		0, 0, "toggle_menubar", _("Toggle Menubar"), NULL);
 	add_kb(group, GEANY_KEYS_VIEW_MESSAGEWINDOW, cb_func_menu_messagewindow,
 		0, 0, "menu_messagewindow", _("Toggle Messages Window"),
 		"menu_show_messages_window1");
@@ -1630,6 +1632,27 @@ static gboolean cb_func_view_action(guint key_id)
 			break;
 		case GEANY_KEYS_VIEW_ZOOMRESET:
 			on_normal_size1_activate(NULL, NULL);
+			break;
+		case GEANY_KEYS_TOGGLE_MENUBAR:
+		{
+			GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
+			if (gtk_widget_is_visible(geany_menubar))
+			{
+				GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
+				GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
+				if (kb->key != 0)
+				{
+					gtk_widget_hide(geany_menubar);
+					gchar *val = gtk_accelerator_name(kb->key, kb->mods);
+					msgwin_status_add("Menubar has been hidden.  To reshow it, use: %s", val);
+					g_free(val);
+				}
+				else
+					msgwin_status_add("Menubar will not be hidden until after a keybinding to reshow it has been set.");
+			}
+			else
+				gtk_widget_show(geany_menubar);
+		}
 			break;
 		default:
 			break;

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -277,6 +277,8 @@ enum GeanyKeyBindingID
 												 * @since 1.34 (API 238) */
 	GEANY_KEYS_FILE_RELOAD_ALL,					/**< Keybinding.
 												 * @since 1.38 (API 240) */
+	GEANY_KEYS_TOGGLE_MENUBAR,					/**< Keybinding.
+												 * @since 1.39 (API 241) */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -584,6 +584,13 @@ static void save_ui_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "fullscreen", ui_prefs.fullscreen);
 	g_key_file_set_string(config, PACKAGE, "color_picker_palette", ui_prefs.color_picker_palette);
 
+	/* Update and save current menubar state */
+	{
+		GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
+		ui_prefs.menubar_visible = gtk_widget_is_visible(geany_menubar);
+		g_key_file_set_boolean(config, PACKAGE, "menubar_visible", ui_prefs.menubar_visible);
+	}
+
 	/* get the text from the scribble textview */
 	{
 		GtkTextBuffer *buffer;
@@ -1022,6 +1029,7 @@ static void load_ui_prefs(GKeyFile *config)
 	gint *geo;
 	gsize geo_len;
 
+	ui_prefs.menubar_visible = utils_get_setting_boolean(config, PACKAGE, "menubar_visible", TRUE);
 	ui_prefs.sidebar_visible = utils_get_setting_boolean(config, PACKAGE, "sidebar_visible", TRUE);
 	ui_prefs.msgwindow_visible = utils_get_setting_boolean(config, PACKAGE, "msgwindow_visible", TRUE);
 	ui_prefs.fullscreen = utils_get_setting_boolean(config, PACKAGE, "fullscreen", FALSE);

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1216,6 +1216,10 @@ gint main_lib(gint argc, gchar **argv)
 	gtk_widget_show(main_widgets.window);
 	main_status.main_window_realized = TRUE;
 
+	/* restore menubar state or hide on startup */
+	if (!ui_prefs.menubar_visible || interface_prefs.on_startup_hide_menubar)
+		keybindings_send_command(GEANY_KEY_GROUP_VIEW, GEANY_KEYS_TOGGLE_MENUBAR);
+
 	configuration_apply_settings();
 
 #ifdef HAVE_SOCKET

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2354,6 +2354,8 @@ void ui_init_prefs(void)
 		"msgwin_scribble_visible", TRUE);
 	stash_group_add_boolean(group, &interface_prefs.warn_on_project_close,
 		"warn_on_project_close", TRUE);
+	stash_group_add_boolean(group, &interface_prefs.on_startup_hide_menubar,
+		"on_startup_hide_menubar", FALSE);
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -71,6 +71,7 @@ typedef struct GeanyInterfacePrefs
 	gint 			symbols_sort_mode;			/**< symbol list sorting mode */
 	/** whether to show a warning when closing a project to open a new one */
 	gboolean		warn_on_project_close;
+	gboolean		on_startup_hide_menubar;	/**< hide menubar on startup */
 }
 GeanyInterfacePrefs;
 
@@ -164,6 +165,7 @@ typedef struct UIPrefs
 	gboolean	sidebar_visible;
 	gint		sidebar_page;
 	gboolean	msgwindow_visible;
+	gboolean	menubar_visible;
 	gboolean	allow_always_save; /* if set, files can always be saved, even if unchanged */
 	gchar		*statusbar_template;
 	gboolean	new_document_after_close;


### PR DESCRIPTION
This PR adds an option to hide the menubar at startup and a keybinding to toggle menubar visibility.  The menubar is hidden only if a keybinding to reshow it has been set.  A message is shown in the status window to remind the user of the keybinding setting.  When the option to hide at startup is disabled, the menubar state is saved and restored.

Notes:
* The menubar can currently be hidden with a GeanyLua script: `geany.signal("hbox_menubar", "hide")`
* Users have been known to edit the glade file to hide the menubar. #1559.
* Resolves #633.
* Potential workaround for #2950.