### PR TITLE
When "go to line" is out of bounds, go to beginning or end of document

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -921,17 +921,10 @@ void on_go_to_line_activate(GtkMenuItem *menuitem, gpointer user_data)
 		_("Enter the line you want to go to:"), value);
 	if (result != NULL)
 	{
-		GeanyDocument *doc = document_get_current();
-		g_return_if_fail(doc != NULL);
+		on_toolbutton_goto_entry_activate(NULL, result, NULL);
 
-		gint line_no = atoi(result);
-		gboolean offset = (*result == '+' || *result == '-');
-
-		if (! editor_goto_line(doc->editor, line_no, offset))
-			utils_beep();
 		/* remember value for future calls */
 		g_snprintf(value, sizeof(value), "%s", result);
-
 		g_free(result);
 	}
 }

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -911,21 +911,6 @@ void on_find_in_files1_activate(GtkMenuItem *menuitem, gpointer user_data)
 }
 
 
-static void get_line_and_offset_from_text(const gchar *text, gint *line_no, gint *offset)
-{
-	if (*text == '+' || *text == '-')
-	{
-		*line_no = atoi(text + 1);
-		*offset = (*text == '+') ? 1 : -1;
-	}
-	else
-	{
-		*line_no = atoi(text) - 1;
-		*offset = 0;
-	}
-}
-
-
 void on_go_to_line_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	static gchar value[16] = "";
@@ -937,12 +922,11 @@ void on_go_to_line_activate(GtkMenuItem *menuitem, gpointer user_data)
 	if (result != NULL)
 	{
 		GeanyDocument *doc = document_get_current();
-		gint offset;
-		gint line_no;
-
 		g_return_if_fail(doc != NULL);
 
-		get_line_and_offset_from_text(result, &line_no, &offset);
+		gint line_no = atoi(result);
+		gboolean offset = (*result == '+' || *result == '-');
+
 		if (! editor_goto_line(doc->editor, line_no, offset))
 			utils_beep();
 		/* remember value for future calls */
@@ -956,12 +940,11 @@ void on_go_to_line_activate(GtkMenuItem *menuitem, gpointer user_data)
 void on_toolbutton_goto_entry_activate(GtkAction *action, const gchar *text, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();
-	gint offset;
-	gint line_no;
-
 	g_return_if_fail(doc != NULL);
 
-	get_line_and_offset_from_text(text, &line_no, &offset);
+	gint line_no = atoi(text);
+	gboolean offset = (*text == '+' || *text == '-');
+
 	if (! editor_goto_line(doc->editor, line_no, offset))
 		utils_beep();
 	else

--- a/src/editor.c
+++ b/src/editor.c
@@ -4716,7 +4716,7 @@ void editor_set_indent(GeanyEditor *editor, GeanyIndentType type, gint width)
 gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gboolean offset)
 {
 	g_return_val_if_fail(editor, FALSE);
-	gulong line_count = sci_get_line_count(editor->sci);
+	gint line_count = sci_get_line_count(editor->sci);
 
 	if (offset)
 		line_no += sci_get_current_line(editor->sci) + 1;

--- a/src/editor.c
+++ b/src/editor.c
@@ -4702,11 +4702,14 @@ void editor_set_indent(GeanyEditor *editor, GeanyIndentType type, gint width)
 /* Convenience function for editor_goto_pos() to pass in a line number. */
 gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset)
 {
-	g_return_val_if_fail(editor, FALSE);
+	/* line number is always positive,
+	 * so it is a programming error if line_no < 0 */
 	g_return_val_if_fail(line_no >= 0, FALSE);
+	g_return_val_if_fail(editor, FALSE);
 
 	gulong line_count = sci_get_line_count(editor->sci);
 
+	/* sign is communicated in offset */
 	if (offset != 0)
 	{
 		gint current_line = sci_get_current_line(editor->sci);
@@ -4714,6 +4717,7 @@ gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset)
 		line_no = current_line + line_no;
 	}
 
+	/* ensure line_no is in bounds and determine whether to set line marker */
 	gboolean set_marker = line_no >= 0 && line_no < line_count;
 	line_no = (line_no < 0)           ? 0
 			: (line_no >= line_count) ? line_count - 1

--- a/src/editor.c
+++ b/src/editor.c
@@ -4699,20 +4699,8 @@ void editor_set_indent(GeanyEditor *editor, GeanyIndentType type, gint width)
 }
 
 
-/* Convenience function for editor_goto_pos() to pass in a line number.
- *
- * If @a offset is FALSE, goes to line @a line_no.  Otherwise, goes to
- * the current line + @a line_no.  Sets the line marker.
- *
- * If the destination line is not in the document, goes to the nearest 
- * line and does not set the marker.
- *
- * @param editor Editor.
- * @param line_no The line to go to or an offset from the current line.
- *                The first line of the document is 1.
- * @param offset Whether @a line_no is an offset from the current line.
- * @return @c TRUE if action has been performed, otherwise @c FALSE.
- */
+/* Convenience function for editor_goto_pos() to pass a line number.
+ * line_no is 1 based */
 gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gboolean offset)
 {
 	g_return_val_if_fail(editor, FALSE);
@@ -4723,8 +4711,8 @@ gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gboolean offset)
 
 	/* ensure line_no is in bounds and determine whether to set line marker */
 	gboolean set_marker = line_no > 0 && line_no < line_count;
-	line_no = (line_no <= 0)           ? 0
-			: (line_no >= line_count) ? line_count - 1
+	line_no = line_no <= 0          ? 0
+			: line_no >= line_count ? line_count - 1
 			: line_no - 1;
 
 	gint pos = sci_get_position_from_line(editor->sci, line_no);

--- a/src/editor.c
+++ b/src/editor.c
@@ -4703,19 +4703,10 @@ void editor_set_indent(GeanyEditor *editor, GeanyIndentType type, gint width)
 gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset)
 {
 	g_return_val_if_fail(editor, FALSE);
+	g_return_val_if_fail(line_no >= 0, FALSE);
+
 	gboolean set_marker = TRUE;
 	gulong line_count = sci_get_line_count(editor->sci);
-
-	if (line_no >= line_count)
-	{
-		line_no =  line_count - 1;
-		set_marker = FALSE;
-	}
-	if (line_no < 0)
-	{
-		line_no = 0;
-		set_marker = FALSE;
-	}
 
 	if (offset != 0)
 	{
@@ -4724,16 +4715,10 @@ gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset)
 		line_no = current_line + line_no;
 	}
 
-	if (line_no >= line_count)
-	{
-		line_no =  line_count - 1;
-		set_marker = FALSE;
-	}
-	if (line_no < 0)
-	{
-		line_no = 0;
-		set_marker = FALSE;
-	}
+	set_marker = line_no >= 0 && line_no < line_count;
+	line_no = (line_no < 0)           ? 0
+			: (line_no >= line_count) ? line_count - 1
+			: line_no;
 
 	gint pos = sci_get_position_from_line(editor->sci, line_no);
 	return editor_goto_pos(editor, pos, set_marker);

--- a/src/editor.c
+++ b/src/editor.c
@@ -4705,7 +4705,6 @@ gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset)
 	g_return_val_if_fail(editor, FALSE);
 	g_return_val_if_fail(line_no >= 0, FALSE);
 
-	gboolean set_marker = TRUE;
 	gulong line_count = sci_get_line_count(editor->sci);
 
 	if (offset != 0)
@@ -4715,7 +4714,7 @@ gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset)
 		line_no = current_line + line_no;
 	}
 
-	set_marker = line_no >= 0 && line_no < line_count;
+	gboolean set_marker = line_no >= 0 && line_no < line_count;
 	line_no = (line_no < 0)           ? 0
 			: (line_no >= line_count) ? line_count - 1
 			: line_no;

--- a/src/editor.c
+++ b/src/editor.c
@@ -4702,11 +4702,20 @@ void editor_set_indent(GeanyEditor *editor, GeanyIndentType type, gint width)
 /* Convenience function for editor_goto_pos() to pass in a line number. */
 gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset)
 {
-	gint pos;
-
 	g_return_val_if_fail(editor, FALSE);
-	if (line_no < 0 || line_no >= sci_get_line_count(editor->sci))
-		return FALSE;
+	gboolean set_marker = TRUE;
+	gulong line_count = sci_get_line_count(editor->sci);
+
+	if (line_no >= line_count)
+	{
+		line_no =  line_count - 1;
+		set_marker = FALSE;
+	}
+	if (line_no < 0)
+	{
+		line_no = 0;
+		set_marker = FALSE;
+	}
 
 	if (offset != 0)
 	{
@@ -4715,8 +4724,19 @@ gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset)
 		line_no = current_line + line_no;
 	}
 
-	pos = sci_get_position_from_line(editor->sci, line_no);
-	return editor_goto_pos(editor, pos, TRUE);
+	if (line_no >= line_count)
+	{
+		line_no =  line_count - 1;
+		set_marker = FALSE;
+	}
+	if (line_no < 0)
+	{
+		line_no = 0;
+		set_marker = FALSE;
+	}
+
+	gint pos = sci_get_position_from_line(editor->sci, line_no);
+	return editor_goto_pos(editor, pos, set_marker);
 }
 
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -319,7 +319,7 @@ void editor_set_indent(GeanyEditor *editor, GeanyIndentType type, gint width);
 
 void editor_set_line_wrapping(GeanyEditor *editor, gboolean wrap);
 
-gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gint offset);
+gboolean editor_goto_line(GeanyEditor *editor, gint line_no, gboolean offset);
 
 void editor_set_indentation_guides(GeanyEditor *editor);
 


### PR DESCRIPTION
This PR sends the cursor to the beginning or end of the document when "go to line" is out of bounds.  When this occurs, the line marker is not set.  Behavior of both the dialog and toolbar are affected.  Resolves #2146.