### PR TITLE
Fix issues related to saving and restoring window position and geometry

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -1380,11 +1380,8 @@ void configuration_apply_settings(void)
 	g_free(scribble_text);
 
 	/* set the position of the hpaned and vpaned */
-	if (prefs.save_winpos)
-	{
-		gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "hpaned1")), hpan_position);
-		gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "vpaned1")), vpan_position);
-	}
+	gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "hpaned1")), hpan_position);
+	gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "vpaned1")), vpan_position);
 
 	/* set fullscreen after initial draw so that returning to normal view is the right size.
 	 * fullscreen mode is disabled by default, so act only if it is true */

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -167,9 +167,6 @@ static void setup_window_position(void)
 	gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "hpaned1")), ui_prefs.treeview_position);
 	gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "vpaned1")), ui_prefs.msgwindow_position);
 
-	g_print("ui_prefs.msgwindow_position = %d\n", ui_prefs.msgwindow_position);
-	g_print("ui_prefs.treeview_position = %d\n", ui_prefs.treeview_position);
-
 	if (ui_prefs.geometry[4] == 1)
 	{
 		gtk_window_maximize(GTK_WINDOW(main_widgets.window));

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -147,29 +147,24 @@ static GOptionEntry entries[] =
 };
 
 
+/* interprets the saved window geometry */
 static void setup_window_position(void)
 {
-	/* interprets the saved window geometry */
-	if (prefs.save_wingeom)
+	if (ui_prefs.geometry[2] != -1 && ui_prefs.geometry[3] != -1)
 	{
-		if (ui_prefs.geometry[2] != -1 && ui_prefs.geometry[3] != -1)
-		{
-			gtk_window_set_default_size(GTK_WINDOW(main_widgets.window),
-				ui_prefs.geometry[2], ui_prefs.geometry[3]);
-		}
+		gtk_window_set_default_size(GTK_WINDOW(main_widgets.window),
+			ui_prefs.geometry[2], ui_prefs.geometry[3]);
 	}
 
-	if (prefs.save_winpos)
+	if (ui_prefs.geometry[0] != -1 && ui_prefs.geometry[1] != -1)
 	{
-		if (ui_prefs.geometry[0] != -1 && ui_prefs.geometry[1] != -1)
-		{
-			gtk_window_move(GTK_WINDOW(main_widgets.window),
-				ui_prefs.geometry[0], ui_prefs.geometry[1]);
-		}
-		if (ui_prefs.geometry[4] == 1)
-		{
-			gtk_window_maximize(GTK_WINDOW(main_widgets.window));
-		}
+		gtk_window_move(GTK_WINDOW(main_widgets.window),
+			ui_prefs.geometry[0], ui_prefs.geometry[1]);
+	}
+
+	if (ui_prefs.geometry[4] == 1)
+	{
+		gtk_window_maximize(GTK_WINDOW(main_widgets.window));
 	}
 }
 

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -150,6 +150,7 @@ static GOptionEntry entries[] =
 /* interprets the saved window geometry */
 static void setup_window_position(void)
 {
+
 	if (ui_prefs.geometry[2] != -1 && ui_prefs.geometry[3] != -1)
 	{
 		gtk_window_set_default_size(GTK_WINDOW(main_widgets.window),
@@ -161,6 +162,13 @@ static void setup_window_position(void)
 		gtk_window_move(GTK_WINDOW(main_widgets.window),
 			ui_prefs.geometry[0], ui_prefs.geometry[1]);
 	}
+
+	/* set the position of the hpaned and vpaned */
+	gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "hpaned1")), ui_prefs.treeview_position);
+	gtk_paned_set_position(GTK_PANED(ui_lookup_widget(main_widgets.window, "vpaned1")), ui_prefs.msgwindow_position);
+
+	g_print("ui_prefs.msgwindow_position = %d\n", ui_prefs.msgwindow_position);
+	g_print("ui_prefs.treeview_position = %d\n", ui_prefs.treeview_position);
 
 	if (ui_prefs.geometry[4] == 1)
 	{

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -167,6 +167,8 @@ typedef struct UIPrefs
 	gboolean	allow_always_save; /* if set, files can always be saved, even if unchanged */
 	gchar		*statusbar_template;
 	gboolean	new_document_after_close;
+	gint		treeview_position;
+	gint		msgwindow_position;
 
 	/* Menu-item related data */
 	GQueue		*recent_queue;


### PR DESCRIPTION
A lot is happening in this pull request because the issues are connected.

* Always restore saved position and geometry (if they exist).
* Save position or geometry only when the respective setting is set.
* Don't save window size and position when maximized.
* Save sidebar and msgwin position adjusted to saved geometry.  
* Restore sidebar and msgwin positions before maximized state.
* Calculate default sidebar/msgwin positions
* Adjust default sidebar and msgwin sizes
* Handle fullscreen and iconified states
* Don't calculate default msgwin/sidebar sizes if not needed

Resolves #1401.  Resolves #2976.  Resolves #2977.  Resolves #2978.  Supercedes #576.  May also supercede #2195.