### PR TITLE
Pascal parser: ensure TagEntryInfo is always initialized

### DIFF
--- a/ctags/parsers/geany_pascal.c
+++ b/ctags/parsers/geany_pascal.c
@@ -51,7 +51,7 @@ static void createPascalTag (tagEntryInfo* const tag,
 	else
 	{
 		/* TODO: Passing NULL as name makes an assertion behind initTagEntry failure */
-		/* initTagEntry (tag, NULL, NULL); */
+		initTagEntry (tag, NULL, KIND_GHOST_INDEX);
 	}
 }
 

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -181,6 +181,7 @@ test_sources = \
 	intro_orig.tex					\
 	intro.tex						\
 	invalid_name.f90				\
+	issue2358.pas					\
 	java_enum.java					\
 	js-broken-strings.js			\
 	js-class-related-unterminated.js	\

--- a/tests/ctags/issue2358.pas
+++ b/tests/ctags/issue2358.pas
@@ -1,0 +1,24 @@
+program test
+
+type {coucou}
+L3=string[3];
+L2=string[2];
+
+type
+
+  { comment }
+  TType = class
+    one: Integer;
+  end;
+
+type
+    atom = record
+	electrons: longword;
+	neutrons: longword;
+	protons: longword;
+    end;
+
+procedure some_function();
+begin
+	writeln('Hello');
+end;

--- a/tests/ctags/issue2358.pas.tags
+++ b/tests/ctags/issue2358.pas.tags
@@ -1,0 +1,3 @@
+# format=tagmanager
+atomÌ16Í()Ö0
+some_functionÌ16Í()Ö0


### PR DESCRIPTION
This fixes crashes when using incomplete "type" declarations.

Fixes #2358, fixes #2982 and fixes #2428.

The `initTagEntry()` call is necessary to initialize the `TagEntryInfo` object. The `KIND_GHOST_INDEX` argument is taken from the uctags Pascal parser.