### PR TITLE
Open files without write permission as read only

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1297,6 +1297,11 @@ GeanyDocument *document_open_file_full(GeanyDocument *doc, const gchar *filename
 
 	g_return_val_if_fail(doc == NULL || doc->is_valid, NULL);
 
+	if (g_access(filename, W_OK) != 0)
+	{
+		readonly = TRUE;
+	}
+
 	if (reload)
 	{
 		utf8_filename = g_strdup(doc->file_name);


### PR DESCRIPTION
This PR makes Geany switch documents to read-only mode when the files being opened do not have write permission.  This will prevent the user from making changes that cannot later be saved.  If the document is saved with a different name, read-only mode will be turned off.  The document can also be manually switched out of read-only mode from the Documents menu.

`g_access()` is used to check permissions.  On Windows, it does not do a full permissions check, so files the user does not have permissions to change may still be opened in normal editing mode.

Effects on users:
* Visual notification that the file is read-only via tab color.
* Avoid warning popup for files that cannot be saved.
* Work flow adjustment: "save as" before editing, rather than after receiving warning popup.
* Reduced chance of data loss because user has to address write permission before before editing.
* User does not have to manually switch to read-only mode when viewing system files (`/usr/include/**/*.h`).
