### PR TITLE
Stash Settings: Add double key type

### DIFF
--- a/doc/stash-example.c
+++ b/doc/stash-example.c
@@ -1,19 +1,23 @@
 StashGroup *group;
-gboolean china_enabled;
+gboolean porcelain_enabled;
 gchar *potter_name;
+gint stock;
+gdouble price;
 const gchar filename[] = "/path/data.conf";
 
 /* setup the group */
 group = stash_group_new("cup");
-stash_group_add_boolean(group, &china_enabled, "china", TRUE);
+stash_group_add_boolean(group, &porcelain_enabled, "porcelain", TRUE);
 stash_group_add_string(group, &potter_name, "potter_name", "Miss Clay");
+stash_group_add_integer(group, &stock, "stock", 5);
+stash_group_add_double(group, &price, "price", 1.50);
 
 /* load the settings from a file */
 if (!stash_group_load_from_file(group, filename))
 	g_warning(_("Could not load keyfile %s!"), filename);
 
-/* now use settings china_enabled and potter_name */
-...
+/* now use settings porcelain_enabled, potter_name, stock, and price */
+/* ... */
 
 /* save settings to file */
 if (stash_group_save_to_file(group, filename, G_KEY_FILE_NONE) != 0)

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 241
+#define GEANY_API_VERSION 242
 
 /* hack to have a different ABI when built with different GTK major versions
  * because loading plugins linked to a different one leads to crashes.

--- a/src/stash.c
+++ b/src/stash.c
@@ -515,7 +515,7 @@ GEANY_API_SYMBOL
 void stash_group_add_double(StashGroup *group, gdouble *setting,
 		const gchar *key_name, gdouble default_value)
 {
-	gulong *default_long = (gulong*) &default_value;
+	guint64 *default_long = (guint64*) &default_value;
 	add_pref(group, G_TYPE_DOUBLE, setting, key_name, (gpointer) *default_long);
 }
 

--- a/src/stash.c
+++ b/src/stash.c
@@ -46,8 +46,8 @@
  * property. Macros could be added for common widget properties such as @c GtkExpander:"expanded".
  *
  * @section settings-example Settings Example
- * Here we have some settings for how to make a cup - whether it should be made of china
- * and who's going to make it. (Yes, it's a stupid example).
+ * Here we have some settings for a cup - whether it is made of porcelain, who made it,
+ * how many we have, and how much they cost. (Yes, it's a stupid example).
  * @include stash-example.c
  * @note You might want to handle the warning/error conditions differently from above.
  *
@@ -103,6 +103,7 @@ union Value
 {
 	gboolean bool_val;
 	gint int_val;
+	gdouble double_val;
 	gchar *str_val;
 	gchar **strv_val;
 	gpointer *ptr_val;
@@ -181,13 +182,12 @@ static void handle_double_setting(StashGroup *group, StashPref *se,
 		GKeyFile *config, SettingAction action)
 {
 	gdouble *setting = se->setting;
-	gdouble *default_double = (gdouble *) &se->default_value;
 
 	switch (action)
 	{
 		case SETTING_READ:
 			*setting = utils_get_setting_double(config, group->name, se->key_name,
-				*default_double);
+				se->default_value.double_val);
 			break;
 		case SETTING_WRITE:
 			g_key_file_set_double(config, group->name, se->key_name, *setting);
@@ -515,8 +515,7 @@ GEANY_API_SYMBOL
 void stash_group_add_double(StashGroup *group, gdouble *setting,
 		const gchar *key_name, gdouble default_value)
 {
-	guint64 *default_long = (guint64*) &default_value;
-	add_pref(group, G_TYPE_DOUBLE, setting, key_name, (gpointer) *default_long);
+	add_pref(group, G_TYPE_DOUBLE, setting, key_name, (union Value) {.double_val = default_value});
 }
 
 

--- a/src/stash.c
+++ b/src/stash.c
@@ -177,6 +177,25 @@ static void handle_boolean_setting(StashGroup *group, StashPref *se,
 }
 
 
+static void handle_double_setting(StashGroup *group, StashPref *se,
+		GKeyFile *config, SettingAction action)
+{
+	gdouble *setting = se->setting;
+	gdouble *default_double = (gdouble *) &se->default_value;
+
+	switch (action)
+	{
+		case SETTING_READ:
+			*setting = utils_get_setting_double(config, group->name, se->key_name,
+				*default_double);
+			break;
+		case SETTING_WRITE:
+			g_key_file_set_double(config, group->name, se->key_name, *setting);
+			break;
+	}
+}
+
+
 static void handle_integer_setting(StashGroup *group, StashPref *se,
 		GKeyFile *config, SettingAction action)
 {
@@ -262,6 +281,8 @@ static void keyfile_action(SettingAction action, StashGroup *group, GKeyFile *ke
 				handle_boolean_setting(group, entry, keyfile, action); break;
 			case G_TYPE_INT:
 				handle_integer_setting(group, entry, keyfile, action); break;
+			case G_TYPE_DOUBLE:
+				handle_double_setting(group, entry, keyfile, action); break;
 			case G_TYPE_STRING:
 				handle_string_setting(group, entry, keyfile, action); break;
 			default:
@@ -482,6 +503,20 @@ void stash_group_add_boolean(StashGroup *group, gboolean *setting,
 		const gchar *key_name, gboolean default_value)
 {
 	add_pref(group, G_TYPE_BOOLEAN, setting, key_name, (union Value) {.bool_val = default_value});
+}
+
+
+/** Adds double setting.
+ * @param group .
+ * @param setting Address of setting variable.
+ * @param key_name Name for key in a @c GKeyFile.
+ * @param default_value Value to use if the key doesn't exist when loading. */
+GEANY_API_SYMBOL
+void stash_group_add_double(StashGroup *group, gdouble *setting,
+		const gchar *key_name, gdouble default_value)
+{
+	gulong *default_long = (gulong*) &default_value;
+	add_pref(group, G_TYPE_DOUBLE, setting, key_name, (gpointer) *default_long);
 }
 
 

--- a/src/stash.h
+++ b/src/stash.h
@@ -39,6 +39,9 @@ StashGroup *stash_group_new(const gchar *name);
 void stash_group_add_boolean(StashGroup *group, gboolean *setting,
 		const gchar *key_name, gboolean default_value);
 
+void stash_group_add_double(StashGroup *group, gdouble *setting,
+		const gchar *key_name, gdouble default_value);
+
 void stash_group_add_integer(StashGroup *group, gint *setting,
 		const gchar *key_name, gint default_value);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -795,11 +795,11 @@ gchar *utils_get_initials(const gchar *name)
  *  @param config A GKeyFile object.
  *  @param section The group name to look in for the key.
  *  @param key The key to find.
- *  @param default_value The default value which will be returned when @a section or @a key
- *         don't exist.
+ *  @param default_value The default value which will be returned when @a section
+ *         or @a key don't exist.
  *
- *  @return The value associated with @a key as an integer, or the given default value if the value
- *          could not be retrieved.
+ *  @return The value associated with @a key as an integer, or the given default
+ *          value if the value could not be retrieved.
  **/
 GEANY_API_SYMBOL
 gint utils_get_setting_integer(GKeyFile *config, const gchar *section, const gchar *key,
@@ -826,11 +826,11 @@ gint utils_get_setting_integer(GKeyFile *config, const gchar *section, const gch
  *  @param config A GKeyFile object.
  *  @param section The group name to look in for the key.
  *  @param key The key to find.
- *  @param default_value The default value which will be returned when @c section or @c key
- *         don't exist.
+ *  @param default_value The default value which will be returned when @c section
+ *         or @c key don't exist.
  *
- *  @return The value associated with @a key as a boolean, or the given default value if the value
- *          could not be retrieved.
+ *  @return The value associated with @a key as a boolean, or the given default
+ *          value if the value could not be retrieved.
  **/
 GEANY_API_SYMBOL
 gboolean utils_get_setting_boolean(GKeyFile *config, const gchar *section, const gchar *key,
@@ -852,16 +852,47 @@ gboolean utils_get_setting_boolean(GKeyFile *config, const gchar *section, const
 
 
 /**
+ *  Wraps g_key_file_get_double() to add a default value argument.
+ *
+ *  @param config A GKeyFile object.
+ *  @param section The group name to look in for the key.
+ *  @param key The key to find.
+ *  @param default_value The default value which will be returned when @a section
+ *         or @a key don't exist.
+ *
+ *  @return The value associated with @a key as an integer, or the given default
+ *          value if the value could not be retrieved.
+ **/
+GEANY_API_SYMBOL
+gdouble utils_get_setting_double(GKeyFile *config, const gchar *section, const gchar *key,
+							   const gdouble default_value)
+{
+	gdouble tmp;
+	GError *error = NULL;
+
+	g_return_val_if_fail(config, default_value);
+
+	tmp = g_key_file_get_double(config, section, key, &error);
+	if (error)
+	{
+		g_error_free(error);
+		return default_value;
+	}
+	return tmp;
+}
+
+
+/**
  *  Wraps g_key_file_get_string() to add a default value argument.
  *
  *  @param config A GKeyFile object.
  *  @param section The group name to look in for the key.
  *  @param key The key to find.
- *  @param default_value The default value which will be returned when @a section or @a key
- *         don't exist.
+ *  @param default_value The default value which will be returned when @a section
+ *         or @a key don't exist.
  *
- *  @return A newly allocated string, either the value for @a key or a copy of the given
- *          default value if it could not be retrieved.
+ *  @return A newly allocated string, either the value for @a key or a copy of
+ *          the given default value if it could not be retrieved.
  **/
 GEANY_API_SYMBOL
 gchar *utils_get_setting_string(GKeyFile *config, const gchar *section, const gchar *key,

--- a/src/utils.c
+++ b/src/utils.c
@@ -795,11 +795,11 @@ gchar *utils_get_initials(const gchar *name)
  *  @param config A GKeyFile object.
  *  @param section The group name to look in for the key.
  *  @param key The key to find.
- *  @param default_value The default value which will be returned when @a section
- *         or @a key don't exist.
+ *  @param default_value The default value which will be returned when @a section or @a key
+ *         don't exist.
  *
- *  @return The value associated with @a key as an integer, or the given default
- *          value if the value could not be retrieved.
+ *  @return The value associated with @a key as an integer, or the given default value if the value
+ *          could not be retrieved.
  **/
 GEANY_API_SYMBOL
 gint utils_get_setting_integer(GKeyFile *config, const gchar *section, const gchar *key,
@@ -826,11 +826,11 @@ gint utils_get_setting_integer(GKeyFile *config, const gchar *section, const gch
  *  @param config A GKeyFile object.
  *  @param section The group name to look in for the key.
  *  @param key The key to find.
- *  @param default_value The default value which will be returned when @c section
- *         or @c key don't exist.
+ *  @param default_value The default value which will be returned when @c section or @c key
+ *         don't exist.
  *
- *  @return The value associated with @a key as a boolean, or the given default
- *          value if the value could not be retrieved.
+ *  @return The value associated with @a key as a boolean, or the given default value if the value
+ *          could not be retrieved.
  **/
 GEANY_API_SYMBOL
 gboolean utils_get_setting_boolean(GKeyFile *config, const gchar *section, const gchar *key,
@@ -857,11 +857,11 @@ gboolean utils_get_setting_boolean(GKeyFile *config, const gchar *section, const
  *  @param config A GKeyFile object.
  *  @param section The group name to look in for the key.
  *  @param key The key to find.
- *  @param default_value The default value which will be returned when @a section
- *         or @a key don't exist.
+ *  @param default_value The default value which will be returned when @a section or @a key
+ *         don't exist.
  *
- *  @return The value associated with @a key as an integer, or the given default
- *          value if the value could not be retrieved.
+ *  @return The value associated with @a key as an integer, or the given default value if the value
+ *          could not be retrieved.
  **/
 GEANY_API_SYMBOL
 gdouble utils_get_setting_double(GKeyFile *config, const gchar *section, const gchar *key,
@@ -888,11 +888,11 @@ gdouble utils_get_setting_double(GKeyFile *config, const gchar *section, const g
  *  @param config A GKeyFile object.
  *  @param section The group name to look in for the key.
  *  @param key The key to find.
- *  @param default_value The default value which will be returned when @a section
- *         or @a key don't exist.
+ *  @param default_value The default value which will be returned when @a section or @a key
+ *         don't exist.
  *
- *  @return A newly allocated string, either the value for @a key or a copy of
- *          the given default value if it could not be retrieved.
+ *  @return A newly allocated string, either the value for @a key or a copy of the given
+ *          default value if it could not be retrieved.
  **/
 GEANY_API_SYMBOL
 gchar *utils_get_setting_string(GKeyFile *config, const gchar *section, const gchar *key,

--- a/src/utils.h
+++ b/src/utils.h
@@ -182,6 +182,8 @@ gboolean utils_get_setting_boolean(GKeyFile *config, const gchar *section, const
 
 gint utils_get_setting_integer(GKeyFile *config, const gchar *section, const gchar *key, const gint default_value);
 
+gdouble utils_get_setting_double(GKeyFile *config, const gchar *section, const gchar *key, const gdouble default_value);
+
 gchar *utils_get_setting_string(GKeyFile *config, const gchar *section, const gchar *key, const gchar *default_value);
 
 gboolean utils_spawn_sync(const gchar *dir, gchar **argv, gchar **env, GSpawnFlags flags,


### PR DESCRIPTION
Split from #3000.  Adds double key type to stash settings.

Example usage (`stash-example.c`):
```C
StashGroup *group;
gboolean porcelain_enabled;
gchar *potter_name;
gint stock;
gdouble price;
const gchar filename[] = "/path/data.conf";

/* setup the group */
group = stash_group_new("cup");
stash_group_add_boolean(group, &porcelain_enabled, "porcelain", TRUE);
stash_group_add_string(group, &potter_name, "potter_name", "Miss Clay");
stash_group_add_integer(group, &stock, "stock", 5);
stash_group_add_double(group, &price, "price", 1.50);

/* load the settings from a file */
if (!stash_group_load_from_file(group, filename))
	g_warning(_("Could not load keyfile %s!"), filename);

/* now use settings porcelain_enabled, potter_name, stock, and price */
/* ... */

/* save settings to file */
if (stash_group_save_to_file(group, filename, G_KEY_FILE_NONE) != 0)
	g_error(_("Could not save keyfile %s!"), filename);

/* free memory */
stash_group_free(group);
```
Generated config:
```
[cup]
porcelain=true
potter_name=Miss Clay
stock=5
price=1.5
```