### PR TITLE
Stash Settings: Expose StashPref to plugins, look up by name

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 242
+#define GEANY_API_VERSION 243
 
 /* hack to have a different ABI when built with different GTK major versions
  * because loading plugins linked to a different one leads to crashes.

--- a/src/stash.c
+++ b/src/stash.c
@@ -98,34 +98,6 @@ static GType get_combo_box_entry_type(void)
 	return type;
 }
 
-/* storage for StashPref default values */
-union Value
-{
-	gboolean bool_val;
-	gint int_val;
-	gdouble double_val;
-	gchar *str_val;
-	gchar **strv_val;
-	gpointer *ptr_val;
-	GtkWidget *widget_val;
-};
-
-struct StashPref
-{
-	GType setting_type;			/* e.g. G_TYPE_INT */
-	gpointer setting;			/* Address of a variable */
-	const gchar *key_name;
-	union Value default_value;	/* Default value, as per setting_type above, e.g. .int_val */
-	GType widget_type;			/* e.g. GTK_TYPE_TOGGLE_BUTTON */
-	StashWidgetID widget_id;	/* (GtkWidget*) or (gchar*) */
-	union
-	{
-		struct EnumWidget *radio_buttons;
-		const gchar *property_name;
-	} extra;	/* extra fields depending on widget_type */
-};
-
-typedef struct StashPref StashPref;
 
 struct StashGroup
 {
@@ -294,6 +266,30 @@ static void keyfile_action(SettingAction action, StashGroup *group, GKeyFile *ke
 						G_STRFUNC);
 		}
 	}
+}
+
+
+/** Get the StashPref within @a group with @a key_name.
+ * @param group .
+ * @param key_name Name of the preference to get.
+ * @return StashPref associated with @a key_name.  Otherwise, NULL. */
+GEANY_API_SYMBOL
+StashPref *stash_group_get_pref_by_name(StashGroup *group, const gchar *key_name)
+{
+	if (!key_name || !group || !group->entries)
+		return NULL;
+
+	StashPref *entry;
+	guint i;
+
+	foreach_ptr_array(entry, i, group->entries)
+	{
+		if (entry && g_strcmp0(key_name, entry->key_name) == 0)
+		{
+			return entry;
+		}
+	}
+	return NULL;
 }
 
 

--- a/src/stash.h
+++ b/src/stash.h
@@ -32,9 +32,45 @@ typedef struct StashGroup StashGroup;
  * stash_group_display() and stash_group_update(). */
 typedef gconstpointer StashWidgetID;
 
+/* storage for StashPref default values */
+union Value
+{
+	gboolean bool_val;
+	gint int_val;
+	gdouble double_val;
+	gchar *str_val;
+	gchar **strv_val;
+	gpointer *ptr_val;
+	GtkWidget *widget_val;
+};
+
+/**
+ *  Structure to hold a preference key and its properties.
+ */
+struct StashPref
+{
+	GType setting_type;			/**< Setting type. e.g., G_TYPE_INT */
+	gpointer setting;			/**< Address of a variable */
+	const gchar *key_name;		/**< Key name. */
+	union Value default_value;		/**< Default value, as per setting_type above, e.g., .int_val */
+	GType widget_type;			/**< Widget type, e.g., GTK_TYPE_TOGGLE_BUTTON */
+	StashWidgetID widget_id;	/**< Widget ID. (GtkWidget*) or (gchar*) */
+	/** extra fields depending on widget_type */
+	union
+	{
+		struct EnumWidget *radio_buttons;	/**< Radio buttons. */
+		const gchar *property_name;			/**< Property name. */
+	} extra;
+};
+
+typedef struct StashPref StashPref;
+
+
 GType stash_group_get_type(void);
 
 StashGroup *stash_group_new(const gchar *name);
+
+StashPref *stash_group_get_pref_by_name(StashGroup *group, const gchar *key_name);
 
 void stash_group_add_boolean(StashGroup *group, gboolean *setting,
 		const gchar *key_name, gboolean default_value);


### PR DESCRIPTION
This PR, split from #3000, exposes the StashPref struct to the plugin API.  Prefs can later by looked up by name with `stash_group_get_pref_by_name()`.  The caller needs to have a pointer to the StashGroup that contains the desired pref, so this currently isn't very useful.  But it is needed to further extend stash settings.

* `union Value` is also made public.  I don't know how to code it to keep it in `stash.c`.
* Is there a better name for `stash_group_get_pref_by_name()`?
* Existing code using stash settings should continue to work.
* StashGroup will be exposed in a later PR.
* Doesn't work after `stash_group_free()` is called.  This will be addressed in a later PR.

Example use of the new lookup function:
```C++
  StashPref *pref = stash_group_get_pref_by_name(group, "price");
  msgwin_status_add("%s = %f", pref->key_name, *(gdouble *)pref->setting);
```