### PR TITLE
Use dark-theme friendly colors for compiler messages

### DIFF
--- a/data/filedefs/filetypes.common
+++ b/data/filedefs/filetypes.common
@@ -94,7 +94,7 @@ line_height=0;0;
 calltips=call_tips
 
 # error indicator color
-indicator_error=0xff0000
+indicator_error=0xff3030
 
 [settings]
 # which characters should be skipped when moving (or included when deleting) to word boundaries

--- a/data/geany.css
+++ b/data/geany.css
@@ -28,27 +28,27 @@
 
 /* document status colors */
 #geany-document-status-changed {
-	color: #ff0000;
+	color: #ff3030;
 }
 #geany-document-status-disk-changed {
-	color: #ff7f00;
+	color: #ee8000;
 }
 #geany-document-status-readonly {
-	color: #007f00;
+	color: #309030;
 }
 
 /* compiler message colors */
 #geany-compiler-error {
-    color: #ff0000;
+    color: #ff3030;
 }
 #geany-compiler-context {
-    color: #7f0000;
+    color: #ee8000;
 }
 #geany-compiler-message {
-    color: #0000D0;
+    color: #006eff;
 }
 
 /* red "Terminal" label when terminal dirty */
 #geany-terminal-dirty {
-	color: #ff0000;
+	color: #ff3030;
 }


### PR DESCRIPTION
When playing with the macOS bundle to look well both in light and dark themes, I noticed that in the dark theme colors in the message window are extremely hard to read with the default colors. While it may be hard to determine whether users use light or dark themes as discussed here

https://github.com/geany/geany/issues/2644

I think we should rather improve the default colors we use so they look reasonably well both in light and dark environments. I took the colors from the middle of the color spectrum here

https://uxplanet.org/create-an-easily-switchable-light-dark-styles-in-figma-ffee3cd542a7

and the result looks quite good IMO:
<img width="1244" alt="Screen Shot 2021-11-20 at 18 22 16" src="https://user-images.githubusercontent.com/713965/142735812-3e8eac67-23cc-4dcf-9179-4ea1e1973934.png">

<img width="1244" alt="Screen Shot 2021-11-20 at 18 22 46" src="https://user-images.githubusercontent.com/713965/142735816-fb2ccabe-3547-4fc8-b752-60ba9da6d654.png">

I changed just the `geany-compiler-context` and `geany-compiler-message` colors which are the worst dark-theme offenders but we could update all the colors so we use a single color palette. The palette I used is just an example which looks good IMO but we could use other palette if someone has some better idea.

What do you think?