### PR TITLE
session.conf split follow-up #3

### DIFF
--- a/src/keyfile.h
+++ b/src/keyfile.h
@@ -40,6 +40,8 @@ void configuration_add_pref_group(struct StashGroup *group, gboolean for_prefs_d
 void configuration_add_various_pref_group(struct StashGroup *group,
 	const gchar *prefix);
 
+void configuration_add_session_group(struct StashGroup *group);
+
 void configuration_save(void);
 
 gboolean configuration_load(void);

--- a/src/search.c
+++ b/src/search.c
@@ -197,9 +197,12 @@ static void init_prefs(void)
 		"pref_search_always_wrap", FALSE, "check_hide_find_dialog");
 	stash_group_add_toggle_button(group, &search_prefs.use_current_file_dir,
 		"pref_search_current_file_dir", TRUE, "check_fif_current_dir");
+
+	/* dialog layout & positions */
+	group = stash_group_new("search");
+	configuration_add_session_group(group);
 	stash_group_add_boolean(group, &find_dlg.all_expanded, "find_all_expanded", FALSE);
 	stash_group_add_boolean(group, &replace_dlg.all_expanded, "replace_all_expanded", FALSE);
-	/* dialog positions */
 	stash_group_add_integer(group, &find_dlg.position[0], "position_find_x", -1);
 	stash_group_add_integer(group, &find_dlg.position[1], "position_find_y", -1);
 	stash_group_add_integer(group, &replace_dlg.position[0], "position_replace_x", -1);


### PR DESCRIPTION
Recreated #3003 which was closed for some reason

Move search positions and layout to session.conf

This will remember the x,y positions as well as the find/replace
dialog expanders as part of session.conf.

To implemenet this, a new interface configuration_add_session_group()
is created that connects a StashGroup to session.conf.