### PR TITLE
Add semantic labels to MsgColors enum in msgwindow.h

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -793,7 +793,7 @@ static void build_spawn_cmd(GeanyDocument *doc, const gchar *cmd, const gchar *d
 
 	gtk_list_store_clear(msgwindow.store_compiler);
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_COMPILER);
-	msgwin_compiler_add(COLOR_BLUE, _("%s (in directory: %s)"), cmd, utf8_working_dir);
+	msgwin_compiler_add(COLOR_MESSAGE, _("%s (in directory: %s)"), cmd, utf8_working_dir);
 	g_free(utf8_working_dir);
 
 #ifdef G_OS_UNIX
@@ -1024,7 +1024,7 @@ static void process_build_output_line(gchar *msg, gint color)
 			editor_indicator_set_on_line(doc->editor, GEANY_INDICATOR_ERROR, line);
 		}
 		build_info.message_count++;
-		color = COLOR_RED;	/* error message parsed on the line */
+		color = COLOR_ERROR;	/* error message parsed on the line */
 
 		if (build_info.message_count == 1)
 		{
@@ -1043,7 +1043,7 @@ static void build_iofunc(GString *string, GIOCondition condition, gpointer data)
 	if (condition & (G_IO_IN | G_IO_PRI))
 	{
 		process_build_output_line(string->str,
-			(GPOINTER_TO_INT(data)) ? COLOR_DARK_RED : COLOR_BLACK);
+			(GPOINTER_TO_INT(data)) ? COLOR_CONTEXT : COLOR_TEXT);
 	}
 }
 
@@ -1096,7 +1096,7 @@ static void show_build_result_message(gboolean failure)
 	if (failure)
 	{
 		msg = _("Compilation failed.");
-		msgwin_compiler_add_string(COLOR_BLUE, msg);
+		msgwin_compiler_add_string(COLOR_MESSAGE, msg);
 		/* If msgwindow is hidden, user will want to display it to see the error */
 		if (! ui_prefs.msgwindow_visible)
 		{
@@ -1110,7 +1110,7 @@ static void show_build_result_message(gboolean failure)
 	else
 	{
 		msg = _("Compilation finished successfully.");
-		msgwin_compiler_add_string(COLOR_BLUE, msg);
+		msgwin_compiler_add_string(COLOR_MESSAGE, msg);
 		if (! ui_prefs.msgwindow_visible ||
 			gtk_notebook_get_current_page(GTK_NOTEBOOK(msgwindow.notebook)) != MSG_COMPILER)
 				ui_set_statusbar(FALSE, "%s", msg);

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -297,10 +297,14 @@ static const GdkColor *get_color(gint msg_color)
 {
 	switch (msg_color)
 	{
-		case COLOR_RED: return &color_error;
-		case COLOR_DARK_RED: return &color_context;
-		case COLOR_BLUE: return &color_message;
-		default: return NULL;
+		case COLOR_ERROR:		/* red */
+			return &color_error;
+		case COLOR_CONTEXT:		/* orange */
+			return &color_context;
+		case COLOR_MESSAGE:		/* blue */
+			return &color_message;
+		default:				/* black */
+			return NULL;
 	}
 }
 

--- a/src/msgwindow.h
+++ b/src/msgwindow.h
@@ -25,19 +25,27 @@
 
 #include "gtkcompat.h"
 
-
 G_BEGIN_DECLS
 
 /**
- * Various colors for use in the compiler and messages treeviews when adding messages.
+ * Colors for use when adding messages to the compiler and messages treeviews.
+ * Defined in ``geany.css``
  **/
 enum MsgColors
 {
-	COLOR_RED,		/**< Color red */
-	COLOR_DARK_RED,	/**< Color dark red */
-	COLOR_BLACK,	/**< Color black */
-	COLOR_BLUE		/**< Color blue */
+	COLOR_ERROR,	/**< Color for ``geany-compiler-error``.  Default is red. */
+	COLOR_CONTEXT,	/**< Color for ``geany-compiler-context``.  Default is orange. */
+	COLOR_TEXT,		/**< Color for normal text.  Default is black. */
+	COLOR_MESSAGE,	/**< Color for ``geany-compiler-message``.  Default is blue. */
+
+#ifndef GEANY_DISABLE_DEPRECATED
+	COLOR_RED		GEANY_DEPRECATED = COLOR_ERROR,		/**< @deprecated Use COLOR_ERROR instead. */
+	COLOR_DARK_RED	GEANY_DEPRECATED = COLOR_CONTEXT,	/**< @deprecated Use COLOR_CONTEXT instead. */
+	COLOR_BLACK		GEANY_DEPRECATED = COLOR_TEXT,		/**< @deprecated Use COLOR_TEXT instead. */
+	COLOR_BLUE		GEANY_DEPRECATED = COLOR_MESSAGE,	/**< @deprecated Use COLOR_MESSAGE instead. */
+#endif  /* GEANY_DISABLE_DEPRECATED */
 };
+
 
 /** Indices of the notebooks in the messages window. */
 typedef enum

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 242
+#define GEANY_API_VERSION 243
 
 /* hack to have a different ABI when built with different GTK major versions
  * because loading plugins linked to a different one leads to crashes.

--- a/src/search.c
+++ b/src/search.c
@@ -1712,7 +1712,7 @@ search_find_in_files(const gchar *utf8_search_text, const gchar *utf8_dir, const
  		msgwin_set_messages_dir(dir);
 		utf8_str = g_strdup_printf(_("%s %s -- %s (in directory: %s)"),
 			tool_prefs.grep_cmd, opts, utf8_search_text, utf8_dir);
- 		msgwin_msg_add_string(COLOR_BLUE, -1, NULL, utf8_str);
+ 		msgwin_msg_add_string(COLOR_MESSAGE, -1, NULL, utf8_str);
 		g_free(utf8_str);
  		ret = TRUE;
 	}
@@ -1836,13 +1836,13 @@ static void read_fif_io(gchar *msg, GIOCondition condition, gchar *enc, gint msg
 
 static void search_read_io(GString *string, GIOCondition condition, gpointer data)
 {
-	read_fif_io(string->str, condition, data, COLOR_BLACK);
+	read_fif_io(string->str, condition, data, COLOR_TEXT);
 }
 
 
 static void search_read_io_stderr(GString *string, GIOCondition condition, gpointer data)
 {
-	read_fif_io(string->str, condition, data, COLOR_DARK_RED);
+	read_fif_io(string->str, condition, data, COLOR_CONTEXT);
 }
 
 
@@ -1875,7 +1875,7 @@ static void search_finished(GPid child_pid, gint status, gpointer user_data)
 						"Search completed with %d match.",
 						"Search completed with %d matches.", count);
 
-			msgwin_msg_add(COLOR_BLUE, -1, NULL, text, count);
+			msgwin_msg_add(COLOR_MESSAGE, -1, NULL, text, count);
 			ui_set_statusbar(FALSE, text, count);
 			break;
 		}
@@ -1883,7 +1883,7 @@ static void search_finished(GPid child_pid, gint status, gpointer user_data)
 			msg = _("No matches found.");
 			/* fall through */
 		default:
-			msgwin_msg_add_string(COLOR_BLUE, -1, NULL, msg);
+			msgwin_msg_add_string(COLOR_MESSAGE, -1, NULL, msg);
 			ui_set_statusbar(FALSE, "%s", msg);
 			break;
 	}
@@ -2171,7 +2171,7 @@ static gint find_document_usage(GeanyDocument *doc, const gchar *search_text, Ge
 		if (line != prev_line)
 		{
 			buffer = sci_get_line(doc->editor->sci, line);
-			msgwin_msg_add(COLOR_BLACK, line + 1, doc,
+			msgwin_msg_add(COLOR_TEXT, line + 1, doc,
 				"%s:%d: %s", short_file_name, line + 1, g_strstrip(buffer));
 			g_free(buffer);
 			prev_line = line;
@@ -2223,14 +2223,14 @@ void search_find_usage(const gchar *search_text, const gchar *original_search_te
 	if (count == 0) /* no matches were found */
 	{
 		ui_set_statusbar(FALSE, _("No matches found for \"%s\"."), original_search_text);
-		msgwin_msg_add(COLOR_BLUE, -1, NULL, _("No matches found for \"%s\"."), original_search_text);
+		msgwin_msg_add(COLOR_MESSAGE, -1, NULL, _("No matches found for \"%s\"."), original_search_text);
 	}
 	else
 	{
 		ui_set_statusbar(FALSE, ngettext(
 			"Found %d match for \"%s\".", "Found %d matches for \"%s\".", count),
 			count, original_search_text);
-		msgwin_msg_add(COLOR_BLUE, -1, NULL, ngettext(
+		msgwin_msg_add(COLOR_MESSAGE, -1, NULL, ngettext(
 			"Found %d match for \"%s\".", "Found %d matches for \"%s\".", count),
 			count, original_search_text);
 	}


### PR DESCRIPTION
Add semantic labels to `MsgColors enum` in `msgwindow.h`.

  COLOR_RED      → COLOR_ERROR   (geany-compiler-error)
  COLOR_DARK_RED → COLOR_CONTEXT (geany-compiler-context)
  COLOR_BLACK    → COLOR_TEXT
  COLOR_BLUE     → COLOR_MESSAGE (geany-compiler-message)

Documentation referring to "orange" won't be accurate until after #3013 is merged.  Opening PR now to allow more time for review.

Resolves #3016.