### PR TITLE
Improve user experience when creating new projects

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8679,7 +8679,7 @@
                   <object class="GtkEntry" id="entry_project_dialog_file_patterns">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">Space separated list of file patterns used for the find in files dialog (e.g. *.c *.h)</property>
+                    <property name="tooltip_text" translatable="yes">Space separated list of file patterns used by the find in files dialog and plugins (e.g. *.c *.h)</property>
                     <property name="invisible_char">•</property>
                     <property name="primary_icon_activatable">False</property>
                     <property name="secondary_icon_activatable">True</property>

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -783,7 +783,7 @@ static void load_dialog_prefs(GKeyFile *config)
 	prefs.suppress_status_messages = utils_get_setting_boolean(config, PACKAGE, "pref_main_suppress_status_messages", FALSE);
 	prefs.load_session = utils_get_setting_boolean(config, PACKAGE, "pref_main_load_session", TRUE);
 	project_prefs.project_session = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_session", TRUE);
-	project_prefs.project_file_in_basedir = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_file_in_basedir", FALSE);
+	project_prefs.project_file_in_basedir = utils_get_setting_boolean(config, PACKAGE, "pref_main_project_file_in_basedir", TRUE);
 	prefs.save_winpos = utils_get_setting_boolean(config, PACKAGE, "pref_main_save_winpos", TRUE);
 	prefs.save_wingeom = utils_get_setting_boolean(config, PACKAGE, "pref_main_save_wingeom", prefs.save_winpos);
 	prefs.beep_on_errors = utils_get_setting_boolean(config, PACKAGE, "beep_on_errors", TRUE);

--- a/src/project.c
+++ b/src/project.c
@@ -84,7 +84,7 @@ static gboolean load_config(const gchar *filename);
 static gboolean write_config(void);
 static void set_project_name_and_file(PropertyDialogElements *e, const gchar *base_path);
 static void on_radio_long_line_custom_toggled(GtkToggleButton *radio, GtkWidget *spin_long_line);
-static void run_new_dialog(PropertyDialogElements *e);
+static gboolean run_new_dialog(PropertyDialogElements *e);
 static void apply_editor_prefs(void);
 static void init_stash_prefs(void);
 static void destroy_project(gboolean open_default);
@@ -149,6 +149,7 @@ void project_new(void)
 	GtkWidget *label;
 	gchar *tooltip;
 	gchar *base_path;
+	gboolean project_created;
 	PropertyDialogElements e = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 };
 
 	/* open directory dialog to get base path */
@@ -225,18 +226,20 @@ void project_new(void)
 	g_free(base_path);
 
 	gtk_widget_show_all(e.dialog);
-	run_new_dialog(&e);
+	project_created = run_new_dialog(&e);
 	gtk_widget_destroy(e.dialog);
 	document_new_file_if_non_open();
 	ui_focus_current_document();
+	if (project_created)
+		project_properties();
 }
 
 
-static void run_new_dialog(PropertyDialogElements *e)
+static gboolean run_new_dialog(PropertyDialogElements *e)
 {
 	if (gtk_dialog_run(GTK_DIALOG(e->dialog)) != GTK_RESPONSE_OK ||
 		!handle_current_session())
-		return;
+		return FALSE;
 	do
 	{
 		if (update_config(e, TRUE))
@@ -251,7 +254,7 @@ static void run_new_dialog(PropertyDialogElements *e)
 			{
 				ui_set_statusbar(TRUE, _("Project \"%s\" created."), app->project->name);
 				ui_add_recent_project_file(app->project->file_name);
-				return;
+				return TRUE;
 			}
 		}
 	}
@@ -266,6 +269,7 @@ static void run_new_dialog(PropertyDialogElements *e)
 		configuration_reload_default_session();
 		configuration_open_files();
 	}
+	return FALSE;
 }
 
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1999,6 +1999,21 @@ static gchar *run_file_chooser(const gchar *title, GtkFileChooserAction action,
 #endif
 
 
+gchar *ui_get_project_directory(const gchar *path)
+{
+	gchar *utf8_path;
+	const gchar *title = _("Select Project Base Path");
+
+#ifdef G_OS_WIN32
+	utf8_path = win32_show_folder_dialog(ui_widgets.prefs_dialog, title, path);
+#else
+	utf8_path = run_file_chooser(title, GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, path);
+#endif
+
+	return utf8_path;
+}
+
+
 static void ui_path_box_open_clicked(GtkButton *button, gpointer user_data)
 {
 	GtkFileChooserAction action = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(button), "action"));

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -363,6 +363,8 @@ gint ui_encodings_combo_box_get_active_encoding(GtkComboBox *combo);
 
 gboolean ui_encodings_combo_box_set_active_encoding(GtkComboBox *combo, gint enc);
 
+gchar *ui_get_project_directory(const gchar *path);
+
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS


### PR DESCRIPTION
At the moment, when creating a project, the user is greeted with the
dialog containing:
1. Name
2. Filename
3. Base path

The user is expected to type the name of the project into (1), and then,
Geany tries to guess the base path and file name. The guess simply takes
the project directory specified in settings and appends the name. When the
project is located anywhere else than in the projects directory,
the guessed values are wrong and have to be entered manually which is
quite annoying. In addition, the dialog doesn't make it clear that the
user should start with (1), when he starts with (2) or (3), he has to
fill in all 3 values manually.

I think we can do better - instead of entering the project name and
guessing base path based on that, we can go the other way round; first,
get the base path and then, from the base path provided by the user,
set the project name and project file.

With this approach, Project->New:
a. First pops up a open directory dialog to specify base path
b. After that, opens the (currently used) New Project dialog which
is pre-filled in the following way:
1. Name: The last directory in base_path
2. Filename: depending on "store project file inside the project base
directory" settings either in base_path/(1).geany or projects_dir/(1).geany
3. Base path: path specified in (a)

This way, in most cases, the user will only have to select the base
directory in the first step and use the pre-filled values without
any modification no matter whether the project is stored in the projects
directory or not.

The other 2 patches:
1. Simplify configuration of the project by automatically opening the project properties dialog upon project creation.
2. Use "Store project file inside the project base directory" by default
For more description of these 2 patches, see the commit messages.