### PR TITLE
Remove deprecated symbols (documents_foreach, filetype_id)

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -129,14 +129,6 @@ GeanyDocument;
  * @see documents_array(). */
 #define documents ((GeanyDocument **)GEANY(documents_array)->pdata)
 
-/** @deprecated Use @ref foreach_document() instead.
- * Iterates all valid documents.
- * Use like a @c for statement.
- * @param i @c guint index for document_index(). */
-#ifndef GEANY_DISABLE_DEPRECATED
-#define documents_foreach(i) foreach_document(i)
-#endif
-
 /** Iterates all valid document indexes.
  * Use like a @c for statement.
  * @param i @c guint index for @ref GeanyData::documents_array.

--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -113,10 +113,6 @@ typedef enum
 }
 GeanyFiletypeID;
 
-#ifndef GEANY_DISABLE_DEPRECATED
-/* compat define - should be removed in the future */
-typedef GeanyFiletypeID filetype_id GEANY_DEPRECATED_FOR(GeanyFiletypeID);
-#endif /* GEANY_DISABLE_DEPRECATED */
 
 /** @gironly
  * Filetype categories


### PR DESCRIPTION
Remove deprecated symbols.  (See #3019.)

* `documents_foreach(i)` from `document.h`
* `filetype_id` from `filetypes.h`

They are not used by any plugins in geany-plugins.