### PR TITLE
Remove deprecated symbol: tm_get_real_path

### DIFF
--- a/src/tagmanager/tm_source_file.c
+++ b/src/tagmanager/tm_source_file.c
@@ -112,30 +112,6 @@ static char *realpath (const char *pathname, char *resolved_path)
 }
 #endif
 
-/**
- Given a file name, returns a newly allocated string containing the realpath()
- of the file.
- @param file_name The original file_name
- @return A newly allocated string containing the real path to the file. NULL if none is available.
- @deprecated since 1.32 (ABI 235)
- @see utils_get_real_path()
-*/
-GEANY_API_SYMBOL
-gchar *tm_get_real_path(const gchar *file_name)
-{
-	if (file_name)
-	{
-		gsize len = get_path_max(file_name) + 1;
-		gchar *path = g_malloc0(len);
-
-		if (realpath(file_name, path))
-			return path;
-		else
-			g_free(path);
-	}
-	return NULL;
-}
-
 gchar tm_source_file_get_tag_impl(const gchar *impl)
 {
 	if ((0 == strcmp("virtual", impl))

--- a/src/tagmanager/tm_source_file.h
+++ b/src/tagmanager/tm_source_file.h
@@ -43,12 +43,6 @@ TMSourceFile *tm_source_file_new(const char *file_name, const char *name);
 
 void tm_source_file_free(TMSourceFile *source_file);
 
-gchar *tm_get_real_path(const gchar *file_name)
-#ifndef GEANY_PRIVATE
-G_DEPRECATED_FOR(utils_get_real_path)
-#endif
-;
-
 #ifdef GEANY_PRIVATE
 
 const gchar *tm_source_file_get_lang_name(TMParserType lang);

--- a/src/utils.c
+++ b/src/utils.c
@@ -2436,7 +2436,17 @@ void utils_start_new_geany_instance(const gchar *doc_path)
 GEANY_API_SYMBOL
 gchar *utils_get_real_path(const gchar *file_name)
 {
-	return tm_get_real_path(file_name);
+	if (file_name)
+	{
+		gsize len = get_path_max(file_name) + 1;
+		gchar *path = g_malloc0(len);
+
+		if (realpath(file_name, path))
+			return path;
+		else
+			g_free(path);
+	}
+	return NULL;
 }
 
 


### PR DESCRIPTION
Remove deprecated symbol `tm_get_real_path()` from `tagmanager/tm_source_file.c`.  It is replaced with `utils_get_real_path()` in `utils.c`.  Not used by any known plugins.  See #3019.