### PR TITLE
Remove deprecated symbols: sciwrappers

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -2155,13 +2155,13 @@ gboolean document_save_file(GeanyDocument *doc, gboolean force)
 		data[0] = (gchar) 0xef;
 		data[1] = (gchar) 0xbb;
 		data[2] = (gchar) 0xbf;
-		sci_get_text(doc->editor->sci, len, data + 3);
+		SSM(doc->editor->sci, SCI_GETTEXT, (uptr_t) len, (sptr_t) data + 3);
 		len += 3;
 	}
 	else
 	{
 		data = (gchar*) g_malloc(len);
-		sci_get_text(doc->editor->sci, len, data);
+		SSM(doc->editor->sci, SCI_GETTEXT, (uptr_t) len, (sptr_t) data);
 	}
 
 	/* save in original encoding, skip when it is already UTF-8 or has the encoding "None" */

--- a/src/document.c
+++ b/src/document.c
@@ -1888,12 +1888,13 @@ _("An error occurred while converting the file from UTF-8 in \"%s\". The file re
 		if (conv_error->code == G_CONVERT_ERROR_ILLEGAL_SEQUENCE)
 		{
 			gint line, column;
-			gint context_len;
+			gint context_len, max_len;
 			gunichar unic;
+			gchar *context;
+
 			/* don't read over the doc length */
-			gint max_len = MIN((gint)bytes_read + 6, (gint)*len - 1);
-			gchar context[7]; /* read 6 bytes from Sci + '\0' */
-			sci_get_text_range(doc->editor->sci, bytes_read, max_len, context);
+			max_len = MIN((gint)bytes_read + 6, (gint)*len - 1);
+			context = sci_get_contents_range(doc->editor->sci, bytes_read, max_len);
 
 			/* take only one valid Unicode character from the context and discard the leftover */
 			unic = g_utf8_get_char_validated(context, -1);
@@ -1904,6 +1905,7 @@ _("An error occurred while converting the file from UTF-8 in \"%s\". The file re
 			error_text = g_strdup_printf(
 				_("Error message: %s\nThe error occurred at \"%s\" (line: %d, column: %d)."),
 				conv_error->message, context, line + 1, column);
+			g_free(context);
 		}
 		else
 			error_text = g_strdup_printf(_("Error message: %s."), conv_error->message);

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -1050,25 +1050,6 @@ void sci_clear_cmdkey(ScintillaObject *sci, gint key)
 
 
 /** Gets text between @a start and @a end.
- * @deprecated sci_get_text_range is deprecated and should not be used in newly-written code.
- * Use sci_get_contents_range() instead.
- *
- * @param sci Scintilla widget.
- * @param start Start.
- * @param end End.
- * @param text Text will be zero terminated and must be allocated (end - start + 1) bytes. */
-GEANY_API_SYMBOL
-void sci_get_text_range(ScintillaObject *sci, gint start, gint end, gchar *text)
-{
-	struct Sci_TextRange tr;
-	tr.chrg.cpMin = start;
-	tr.chrg.cpMax = end;
-	tr.lpstrText = text;
-	SSM(sci, SCI_GETTEXTRANGE, 0, (sptr_t) &tr);
-}
-
-
-/** Gets text between @a start and @a end.
  * @param sci Scintilla widget.
  * @param start Start position.
  * @param end End position.
@@ -1080,11 +1061,18 @@ GEANY_API_SYMBOL
 gchar *sci_get_contents_range(ScintillaObject *sci, gint start, gint end)
 {
 	gchar *text;
+	struct Sci_TextRange tr;
 
 	g_return_val_if_fail(start < end, NULL);
 
 	text = g_malloc((gsize) (end - start) + 1);
-	sci_get_text_range(sci, start, end, text);
+
+	tr.chrg.cpMin = start;
+	tr.chrg.cpMax = end;
+	tr.lpstrText = text;
+
+	SSM(sci, SCI_GETTEXTRANGE, 0, (sptr_t) &tr);
+
 	return text;
 }
 

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -744,20 +744,6 @@ gchar *sci_get_contents(ScintillaObject *sci, gint buffer_len)
 
 
 /** Gets selected text.
- * @deprecated sci_get_selected_text is deprecated and should not be used in newly-written code.
- * Use sci_get_selection_contents() instead.
- *
- * @param sci Scintilla widget.
- * @param text Text buffer; must be allocated sci_get_selected_text_length() + 1 bytes
- * for null-termination. */
-GEANY_API_SYMBOL
-void sci_get_selected_text(ScintillaObject *sci, gchar *text)
-{
-	SSM(sci, SCI_GETSELTEXT, 0, (sptr_t) text);
-}
-
-
-/** Gets selected text.
  * @param sci Scintilla widget.
  *
  * @return The selected text. Should be freed when no longer needed.

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -720,20 +720,6 @@ gchar *sci_get_line(ScintillaObject *sci, gint line_num)
 }
 
 
-/** Gets all text.
- * @deprecated sci_get_text is deprecated and should not be used in newly-written code.
- * Use sci_get_contents() instead.
- *
- * @param sci Scintilla widget.
- * @param len Length of @a text buffer, usually sci_get_length() + 1.
- * @param text Text buffer; must be allocated @a len + 1 bytes for null-termination. */
-GEANY_API_SYMBOL
-void sci_get_text(ScintillaObject *sci, gint len, gchar *text)
-{
-	SSM(sci, SCI_GETTEXT, (uptr_t) len, (sptr_t) text);
-}
-
-
 /** Allocates and fills a buffer with text from the start of the document.
  * @param sci Scintilla widget.
  * @param buffer_len Buffer length to allocate, including the terminating

--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -102,10 +102,6 @@ void				sci_set_line_indentation	(ScintillaObject *sci, gint line, gint indent);
 gint				sci_get_line_indentation	(ScintillaObject *sci, gint line);
 gint				sci_find_matching_brace		(ScintillaObject *sci, gint pos);
 
-#ifndef GEANY_DISABLE_DEPRECATED
-void				sci_get_text_range			(ScintillaObject *sci, gint start, gint end, gchar *text) GEANY_DEPRECATED_FOR(sci_get_contents_range);
-#endif	/* GEANY_DISABLE_DEPRECATED */
-
 #ifdef GEANY_PRIVATE
 
 gchar*				sci_get_string				(ScintillaObject *sci, guint msg, gulong wParam);

--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -103,7 +103,6 @@ gint				sci_get_line_indentation	(ScintillaObject *sci, gint line);
 gint				sci_find_matching_brace		(ScintillaObject *sci, gint pos);
 
 #ifndef GEANY_DISABLE_DEPRECATED
-void				sci_get_text				(ScintillaObject *sci, gint len, gchar *text) GEANY_DEPRECATED_FOR(sci_get_contents);
 void				sci_get_selected_text		(ScintillaObject *sci, gchar *text) GEANY_DEPRECATED_FOR(sci_get_selection_contents);
 void				sci_get_text_range			(ScintillaObject *sci, gint start, gint end, gchar *text) GEANY_DEPRECATED_FOR(sci_get_contents_range);
 #endif	/* GEANY_DISABLE_DEPRECATED */

--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -103,7 +103,6 @@ gint				sci_get_line_indentation	(ScintillaObject *sci, gint line);
 gint				sci_find_matching_brace		(ScintillaObject *sci, gint pos);
 
 #ifndef GEANY_DISABLE_DEPRECATED
-void				sci_get_selected_text		(ScintillaObject *sci, gchar *text) GEANY_DEPRECATED_FOR(sci_get_selection_contents);
 void				sci_get_text_range			(ScintillaObject *sci, gint start, gint end, gchar *text) GEANY_DEPRECATED_FOR(sci_get_contents_range);
 #endif	/* GEANY_DISABLE_DEPRECATED */
 


### PR DESCRIPTION
Removes deprecated symbols `sci_get_text`, `sci_get_selected_text`, `sci_get_text_range`.  Internal use has rewritten.  No known plugins use any of these functions.  There are some false positives when grepping because they are referenced in comments.  (geanygendoc, geanyctags)  See #3019.