### PR TITLE
update geany.glade to target gtk+ 3.20

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1,90 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="2.24"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkAccelGroup" id="accelgroup1"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="lower">3</property>
     <property name="upper">1000</property>
     <property name="value">72</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment10">
     <property name="lower">1</property>
     <property name="upper">99</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment11">
     <property name="upper">1000</property>
     <property name="value">72</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment12">
     <property name="upper">5000</property>
     <property name="value">500</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">158.44</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">158.44</property>
   </object>
   <object class="GtkAdjustment" id="adjustment13">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="lower">1</property>
     <property name="upper">99</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment3">
     <property name="lower">1</property>
     <property name="upper">99</property>
     <property name="value">9</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment4">
     <property name="lower">1</property>
     <property name="upper">99</property>
     <property name="value">9</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment5">
     <property name="lower">1</property>
     <property name="upper">10000</property>
     <property name="value">9</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment6">
     <property name="upper">10000</property>
     <property name="value">250</property>
-    <property name="step_increment">10</property>
-    <property name="page_increment">100</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">100</property>
   </object>
   <object class="GtkAdjustment" id="adjustment7">
     <property name="upper">1000</property>
     <property name="value">72</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment8">
     <property name="upper">50</property>
     <property name="value">4</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment9">
     <property name="upper">10000</property>
     <property name="value">30</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkListStore" id="eol_list">
     <columns>
@@ -94,122 +94,122 @@
   </object>
   <object class="GtkImage" id="image2">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-select-color</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image3">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-open</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image3192">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-preferences</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image3193">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-cancel</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkMenu" id="toolbar_popup_menu1">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkImageMenuItem" id="customize_toolbar1">
         <property name="label" translatable="yes">_Toolbar Preferences</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
         <property name="image">image3192</property>
-        <property name="use_stock">False</property>
+        <property name="use-stock">False</property>
         <signal name="activate" handler="on_customize_toolbar1_activate" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkSeparatorMenuItem" id="separator53">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
       </object>
     </child>
     <child>
       <object class="GtkImageMenuItem" id="hide_toolbar1">
         <property name="label" translatable="yes">_Hide Toolbar</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
         <property name="image">image3193</property>
-        <property name="use_stock">False</property>
+        <property name="use-stock">False</property>
         <signal name="activate" handler="on_hide_toolbar1_activate" swapped="no"/>
       </object>
     </child>
   </object>
   <object class="GtkImage" id="image3761">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-add</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image3762">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-add</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image3763">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-add</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image3764">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-open</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image3765">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-find</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image3766">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-find</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image3767">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-jump-to</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-save-as</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4055">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-add</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkMenu" id="edit_menu1">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkImageMenuItem" id="undo1">
         <property name="label">gtk-undo</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
-        <property name="use_stock">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
+        <property name="use-stock">True</property>
         <signal name="activate" handler="on_undo1_activate" swapped="no"/>
       </object>
     </child>
@@ -217,25 +217,25 @@
       <object class="GtkImageMenuItem" id="redo1">
         <property name="label">gtk-redo</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
-        <property name="use_stock">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
+        <property name="use-stock">True</property>
         <signal name="activate" handler="on_redo1_activate" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkSeparatorMenuItem" id="separator2">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
       </object>
     </child>
     <child>
       <object class="GtkImageMenuItem" id="cut1">
         <property name="label">gtk-cut</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
-        <property name="use_stock">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
+        <property name="use-stock">True</property>
         <signal name="activate" handler="on_cut1_activate" swapped="no"/>
       </object>
     </child>
@@ -243,9 +243,9 @@
       <object class="GtkImageMenuItem" id="copy1">
         <property name="label">gtk-copy</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
-        <property name="use_stock">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
+        <property name="use-stock">True</property>
         <signal name="activate" handler="on_copy1_activate" swapped="no"/>
       </object>
     </child>
@@ -253,9 +253,9 @@
       <object class="GtkImageMenuItem" id="paste1">
         <property name="label">gtk-paste</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
-        <property name="use_stock">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
+        <property name="use-stock">True</property>
         <signal name="activate" handler="on_paste1_activate" swapped="no"/>
       </object>
     </child>
@@ -263,85 +263,85 @@
       <object class="GtkImageMenuItem" id="delete1">
         <property name="label">gtk-delete</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
-        <property name="use_stock">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
+        <property name="use-stock">True</property>
         <signal name="activate" handler="on_delete1_activate" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkSeparatorMenuItem" id="separator3">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
       </object>
     </child>
     <child>
       <object class="GtkImageMenuItem" id="menu_select_all2">
         <property name="label">gtk-select-all</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
-        <property name="use_stock">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
+        <property name="use-stock">True</property>
         <signal name="activate" handler="on_menu_select_all1_activate" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkSeparatorMenuItem" id="separator26">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="commands1">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">_Edit</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="menu_format2">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">_Format</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkImageMenuItem" id="insert1">
         <property name="label" translatable="yes">I_nsert</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
         <property name="image">image4055</property>
-        <property name="use_stock">False</property>
+        <property name="use-stock">False</property>
         <child type="submenu">
           <object class="GtkMenu" id="insert1_menu">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkMenuItem" id="add_changelog_entry2">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Insert _ChangeLog Entry</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
                 <signal name="activate" handler="on_comments_changelog_activate" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="insert_function_description1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Insert _Function Description</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
                 <signal name="activate" handler="on_comments_function_activate" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="insert_multiline_comment1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Insert Mu_ltiline Comment</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
                 <signal name="activate" handler="on_comments_multiline_activate" swapped="no"/>
               </object>
             </child>
@@ -349,37 +349,37 @@
               <object class="GtkImageMenuItem" id="comments">
                 <property name="label" translatable="yes">_More</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">False</property>
+                <property name="use-underline">True</property>
                 <property name="image">image3761</property>
-                <property name="use_stock">False</property>
+                <property name="use-stock">False</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="comments_menu">
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkMenuItem" id="insert_file_header2">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Insert File _Header</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">True</property>
                         <signal name="activate" handler="on_comments_fileheader_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkMenuItem" id="insert_gpl_notice1">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Insert _GPL Notice</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">True</property>
                         <signal name="activate" handler="on_comments_gpl_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
                       <object class="GtkMenuItem" id="insert_bsd_license_notice1">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Insert _BSD License Notice</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">True</property>
                         <signal name="activate" handler="on_comments_bsd_activate" swapped="no"/>
                       </object>
                     </child>
@@ -390,25 +390,25 @@
             <child>
               <object class="GtkSeparatorMenuItem" id="separator57">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
               </object>
             </child>
             <child>
               <object class="GtkImageMenuItem" id="insert_date2">
                 <property name="label" translatable="yes">Insert Dat_e</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">False</property>
+                <property name="use-underline">True</property>
                 <property name="image">image3762</property>
-                <property name="use_stock">False</property>
+                <property name="use-stock">False</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="insert_date2_menu">
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkMenuItem" id="invisible10">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">invisible</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">True</property>
                       </object>
                     </child>
                   </object>
@@ -419,18 +419,18 @@
               <object class="GtkImageMenuItem" id="insert_include1">
                 <property name="label" translatable="yes">_Insert "include &lt;...&gt;"</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">False</property>
+                <property name="use-underline">True</property>
                 <property name="image">image3763</property>
-                <property name="use_stock">False</property>
+                <property name="use-stock">False</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="insert_include1_menu">
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkMenuItem" id="invisible3">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">invisible</property>
-                        <property name="use_underline">True</property>
+                        <property name="use-underline">True</property>
                       </object>
                     </child>
                   </object>
@@ -440,15 +440,15 @@
             <child>
               <object class="GtkSeparatorMenuItem" id="separator50">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
               </object>
             </child>
             <child>
               <object class="GtkMenuItem" id="insert_alternative_white_space2">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Insert Alternative _White Space</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
                 <signal name="activate" handler="on_insert_alternative_white_space1_activate" swapped="no"/>
               </object>
             </child>
@@ -459,25 +459,25 @@
     <child>
       <object class="GtkMenuItem" id="search2">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">_Search</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
       </object>
     </child>
     <child>
       <object class="GtkSeparatorMenuItem" id="separator7">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
       </object>
     </child>
     <child>
       <object class="GtkImageMenuItem" id="menu_open_selected_file2">
         <property name="label" translatable="yes">Open Selected F_ile</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
         <property name="image">image3764</property>
-        <property name="use_stock">False</property>
+        <property name="use-stock">False</property>
         <signal name="activate" handler="on_menu_open_selected_file1_activate" swapped="no"/>
       </object>
     </child>
@@ -485,10 +485,10 @@
       <object class="GtkImageMenuItem" id="find_usage2">
         <property name="label" translatable="yes">Find _Usage</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
         <property name="image">image3765</property>
-        <property name="use_stock">False</property>
+        <property name="use-stock">False</property>
         <signal name="activate" handler="on_find_usage1_activate" swapped="no"/>
       </object>
     </child>
@@ -496,10 +496,10 @@
       <object class="GtkImageMenuItem" id="find_document_usage2">
         <property name="label" translatable="yes">Find _Document Usage</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
         <property name="image">image3766</property>
-        <property name="use_stock">False</property>
+        <property name="use-stock">False</property>
         <signal name="activate" handler="on_find_document_usage1_activate" swapped="no"/>
       </object>
     </child>
@@ -507,202 +507,202 @@
       <object class="GtkImageMenuItem" id="goto_tag_definition2">
         <property name="label" translatable="yes">Go to Symbol Defini_tion</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="use_underline">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
         <property name="image">image3767</property>
-        <property name="use_stock">False</property>
+        <property name="use-stock">False</property>
         <signal name="activate" handler="on_goto_tag_definition1" swapped="no"/>
       </object>
     </child>
     <child>
       <object class="GtkMenuItem" id="context_action1">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="label" translatable="yes">Conte_xt Action</property>
-        <property name="use_underline">True</property>
+        <property name="use-underline">True</property>
         <signal name="activate" handler="on_context_action1_activate" swapped="no"/>
       </object>
     </child>
   </object>
   <object class="GtkImage" id="image4056">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-new</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4057">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">geany-save-all</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4058">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-revert-to-saved</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4059">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-revert-to-saved</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4060">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-close</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4061">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">geany-close-all</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4062">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-cut</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4063">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-copy</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4064">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-indent</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4065">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-unindent</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4066">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-add</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4067">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-add</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4068">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-add</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4069">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-preferences</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4070">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-preferences</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4071">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-find</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4072">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-find-and-replace</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4073">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-go-down</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4074">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-go-up</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4075">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-jump-to</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4076">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-select-font</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4077">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-new</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4078">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-open</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4079">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-close</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4080">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-refresh</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4081">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-file</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4082">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-select-color</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image4083">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-help</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image5">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-print</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkImage" id="image6">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-find</property>
-    <property name="icon-size">1</property>
+    <property name="icon_size">1</property>
   </object>
   <object class="GtkListStore" id="indent_mode_list">
     <columns>
@@ -745,29 +745,29 @@
     </data>
   </object>
   <object class="GtkDialog" id="prefs_dialog">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
     <property name="modal">True</property>
-    <property name="icon_name">geany</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_pager_hint">True</property>
+    <property name="icon-name">geany</property>
+    <property name="type-hint">dialog</property>
+    <property name="skip-pager-hint">True</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox3">
+      <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area3">
+          <object class="GtkButtonBox" id="dialog-action_area3">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button3">
                 <property name="label">gtk-apply</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -779,10 +779,10 @@
               <object class="GtkButton" id="button4">
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -794,11 +794,11 @@
               <object class="GtkButton" id="button5">
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -810,10 +810,10 @@
               <object class="GtkButton" id="button_help">
                 <property name="label">gtk-help</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -825,50 +825,50 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkNotebook" id="notebook2">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="tab_pos">left</property>
+            <property name="can-focus">True</property>
+            <property name="tab-pos">left</property>
             <child>
               <object class="GtkNotebook" id="notebook5">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <child>
                   <object class="GtkVBox" id="vbox20">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkFrame" id="frame10">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment13">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox4">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">2</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_load_session">
                                     <property name="label" translatable="yes">Load files from the last session</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Opens at startup the files from the last session</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Opens at startup the files from the last session</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -879,11 +879,11 @@
                                 <child>
                                   <object class="GtkCheckButton" id="check_vte">
                                     <property name="label" translatable="yes">Load virtual terminal support</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Whether the virtual terminal emulation (VTE) should be loaded at startup, disable it if you do not need it</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Whether the virtual terminal emulation (VTE) should be loaded at startup, disable it if you do not need it</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -895,10 +895,10 @@
                                   <object class="GtkCheckButton" id="check_plugins">
                                     <property name="label" translatable="yes">Enable plugin support</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -913,9 +913,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label162">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Startup&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -928,27 +928,27 @@
                     <child>
                       <object class="GtkFrame" id="frame34">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment37">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox34">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_save_win_geom">
                                     <property name="label" translatable="yes">Save window size</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Saves the window size and restores it at the start</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Saves the window size and restores it at the start</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -960,11 +960,11 @@
                                   <object class="GtkCheckButton" id="check_save_win_pos">
                                     <property name="label" translatable="yes">Save window position</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Saves the window position and restores it at the start</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Saves the window position and restores it at the start</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -976,11 +976,11 @@
                                   <object class="GtkCheckButton" id="check_ask_for_quit">
                                     <property name="label" translatable="yes">Confirm exit</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Shows a confirmation dialog on exit</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Shows a confirmation dialog on exit</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -995,9 +995,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label206">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Shutdown&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -1010,182 +1010,173 @@
                     <child>
                       <object class="GtkFrame" id="frame25">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment28">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkTable" id="table11">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="n_rows">3</property>
-                                <property name="n_columns">3</property>
-                                <property name="column_spacing">6</property>
-                                <property name="row_spacing">3</property>
+                                <property name="can-focus">False</property>
+                                <property name="n-rows">3</property>
+                                <property name="n-columns">3</property>
+                                <property name="column-spacing">6</property>
+                                <property name="row-spacing">3</property>
                                 <child>
                                   <object class="GtkLabel" id="label191">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Startup path:</property>
-                                    <property name="mnemonic_widget">startup_path_entry</property>
+                                    <property name="mnemonic-widget">startup_path_entry</property>
                                   </object>
                                   <packing>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="startup_path_entry">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Path to start in when opening or saving files. Must be an absolute path.</property>
-                                    <property name="invisible_char">•</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Path to start in when opening or saving files. Must be an absolute path.</property>
+                                    <property name="invisible-char">•</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="startup_path_button">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <child>
                                       <object class="GtkImage" id="image1741">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="stock">gtk-open</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label192">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Project files:</property>
-                                    <property name="mnemonic_widget">project_file_path_entry</property>
+                                    <property name="mnemonic-widget">project_file_path_entry</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="project_file_path_entry">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Path to start in when opening project files</property>
-                                    <property name="invisible_char">•</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Path to start in when opening project files</property>
+                                    <property name="invisible-char">•</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="project_file_path_button">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <child>
                                       <object class="GtkImage" id="image1775">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="stock">gtk-open</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label235">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Extra plugin path:</property>
-                                    <property name="mnemonic_widget">extra_plugin_path_entry</property>
+                                    <property name="mnemonic-widget">extra_plugin_path_entry</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="extra_plugin_path_entry">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Geany looks by default in the global installation path and in the configuration directory. The path entered here will be searched additionally for plugins. Leave blank to disable.</property>
-                                    <property name="invisible_char">•</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Geany looks by default in the global installation path and in the configuration directory. The path entered here will be searched additionally for plugins. Leave blank to disable.</property>
+                                    <property name="invisible-char">•</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="extra_plugin_path_button">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <child>
                                       <object class="GtkImage" id="image2852">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="stock">gtk-open</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                               </object>
@@ -1195,9 +1186,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label190">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Paths&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -1212,43 +1203,43 @@
                 <child type="tab">
                   <object class="GtkLabel" id="label233">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Startup</property>
                   </object>
                   <packing>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkVBox" id="vbox41">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkFrame" id="frame19">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment22">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox21">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_beep">
                                     <property name="label" translatable="yes">Beep on errors or when compilation has finished</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Whether to beep if an error occurred or when the compilation process has finished</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Whether to beep if an error occurred or when the compilation process has finished</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1260,11 +1251,11 @@
                                   <object class="GtkCheckButton" id="check_switch_pages">
                                     <property name="label" translatable="yes">Switch to status message list at new message</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Switch to the status message tab (in the notebook window at the bottom) if a new status message arrives</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Switch to the status message tab (in the notebook window at the bottom) if a new status message arrives</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1276,11 +1267,11 @@
                                   <object class="GtkCheckButton" id="check_suppress_status_msgs">
                                     <property name="label" translatable="yes">Suppress status messages in the status bar</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Removes all messages from the status bar. The messages are still displayed in the status messages window.</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Removes all messages from the status bar. The messages are still displayed in the status messages window.</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1292,11 +1283,11 @@
                                   <object class="GtkCheckButton" id="check_auto_focus">
                                     <property name="label" translatable="yes">Auto-focus widgets (focus follows mouse)</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Gives the focus automatically to widgets below the mouse cursor. Works for the main editor widget, the scribble, the toolbar search and goto line fields and the VTE.</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Gives the focus automatically to widgets below the mouse cursor. Works for the main editor widget, the scribble, the toolbar search and goto line fields and the VTE.</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1308,11 +1299,11 @@
                                   <object class="GtkCheckButton" id="check_native_windows_dialogs">
                                     <property name="label" translatable="yes">Use Windows native dialogs</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Defines whether to use the Windows native dialogs or whether to use the GTK default dialogs</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Defines whether to use the Windows native dialogs or whether to use the GTK default dialogs</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1327,9 +1318,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label199">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Miscellaneous&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -1342,27 +1333,27 @@
                     <child>
                       <object class="GtkFrame" id="frame36">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment39">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox36">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_always_wrap_search">
                                     <property name="label" translatable="yes">Always wrap search</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Always wrap search around the document</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Always wrap search around the document</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1374,11 +1365,11 @@
                                   <object class="GtkCheckButton" id="check_hide_find_dialog">
                                     <property name="label" translatable="yes">Hide the Find dialog</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Hide the Find dialog after clicking Find Next/Previous</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Hide the Find dialog after clicking Find Next/Previous</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1390,11 +1381,11 @@
                                   <object class="GtkCheckButton" id="check_search_use_current_word">
                                     <property name="label" translatable="yes">Use the current word under the cursor for Find dialogs</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Use current word under the cursor when opening the Find, Find in Files or Replace dialog and there is no selection</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Use current word under the cursor when opening the Find, Find in Files or Replace dialog and there is no selection</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1406,10 +1397,10 @@
                                   <object class="GtkCheckButton" id="check_fif_current_dir">
                                     <property name="label" translatable="yes">Use the current file's directory for Find in Files</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1424,9 +1415,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label215">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Search&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -1439,27 +1430,27 @@
                     <child>
                       <object class="GtkFrame" id="frame35">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment38">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox35">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_project_session">
                                     <property name="label" translatable="yes">Use project-based session files</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Whether to store a project's session files and open them when re-opening the project</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Whether to store a project's session files and open them when re-opening the project</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1471,11 +1462,11 @@
                                   <object class="GtkCheckButton" id="check_project_file_in_basedir">
                                     <property name="label" translatable="yes">Store project file inside the project base directory</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">When enabled, a project file is stored by default inside the project base directory when creating new projects instead of one directory above the base directory. You can still change the path of the project file in the New Project dialog.</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">When enabled, a project file is stored by default inside the project base directory when creating new projects instead of one directory above the base directory. You can still change the path of the project file in the New Project dialog.</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1490,9 +1481,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label207">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Projects&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -1510,12 +1501,12 @@
                 <child type="tab">
                   <object class="GtkLabel" id="label234">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Miscellaneous</property>
                   </object>
                   <packing>
                     <property name="position">1</property>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
               </object>
@@ -1523,62 +1514,62 @@
             <child type="tab">
               <object class="GtkLabel" id="label94">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">General</property>
               </object>
               <packing>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkNotebook" id="notebook6">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <child>
                   <object class="GtkVBox" id="vbox14">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkFrame" id="frame7">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment9">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox11">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkFrame" id="frame39">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label_xalign">0</property>
-                                    <property name="shadow_type">none</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label-xalign">0</property>
+                                    <property name="shadow-type">none</property>
                                     <child>
                                       <object class="GtkAlignment" id="alignment46">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="left_padding">12</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="left-padding">12</property>
                                         <child>
                                           <object class="GtkVBox" id="box_sidebar_visible_children">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkCheckButton" id="check_list_symbol">
                                                 <property name="label" translatable="yes">Show symbol list</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Toggle the symbol list on and off</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="tooltip-text" translatable="yes">Toggle the symbol list on and off</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <signal name="toggled" handler="on_show_symbol_list_toggled" swapped="no"/>
                                               </object>
                                               <packing>
@@ -1590,18 +1581,18 @@
                                             <child>
                                               <object class="GtkAlignment" id="alignment15">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="left_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="left-padding">12</property>
                                                 <child>
                                                   <object class="GtkHBox" id="box_show_symbol_list_children">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Default symbol sorting mode</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="tooltip-text" translatable="yes">Default symbol sorting mode</property>
                                                     <property name="spacing">12</property>
                                                     <child>
                                                       <object class="GtkLabel" id="label24">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="label" translatable="yes">Default sorting mode:</property>
                                                       </object>
                                                       <packing>
@@ -1614,10 +1605,10 @@
                                                       <object class="GtkRadioButton" id="radio_symbols_sort_by_name">
                                                         <property name="label" translatable="yes">Name</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">False</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
                                                         <property name="active">True</property>
-                                                        <property name="draw_indicator">True</property>
+                                                        <property name="draw-indicator">True</property>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>
@@ -1629,10 +1620,10 @@
                                                       <object class="GtkRadioButton" id="radio_symbols_sort_by_appearance">
                                                         <property name="label" translatable="yes">Appearance</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">False</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
                                                         <property name="active">True</property>
-                                                        <property name="draw_indicator">True</property>
+                                                        <property name="draw-indicator">True</property>
                                                         <property name="group">radio_symbols_sort_by_name</property>
                                                       </object>
                                                       <packing>
@@ -1654,11 +1645,11 @@
                                               <object class="GtkCheckButton" id="check_list_openfiles">
                                                 <property name="label" translatable="yes">Show documents list</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Toggle the documents list on and off</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="tooltip-text" translatable="yes">Toggle the documents list on and off</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -1674,10 +1665,10 @@
                                       <object class="GtkCheckButton" id="check_sidebar_visible">
                                         <property name="label" translatable="yes">Show sidebar</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                     </child>
                                   </object>
@@ -1690,12 +1681,12 @@
                                 <child>
                                   <object class="GtkHBox" id="hbox17">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="spacing">12</property>
                                     <child>
                                       <object class="GtkLabel" id="label237">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Position:</property>
                                       </object>
                                       <packing>
@@ -1708,11 +1699,11 @@
                                       <object class="GtkRadioButton" id="radio_sidebar_left">
                                         <property name="label" translatable="yes">Left</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
                                         <property name="active">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1724,10 +1715,10 @@
                                       <object class="GtkRadioButton" id="radio_sidebar_right">
                                         <property name="label" translatable="yes">Right</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <property name="group">radio_sidebar_left</property>
                                       </object>
                                       <packing>
@@ -1750,9 +1741,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label146">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Sidebar&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -1765,23 +1756,23 @@
                     <child>
                       <object class="GtkFrame" id="frame1">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment2">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkHBox" id="hbox2">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">12</property>
                                 <child>
                                   <object class="GtkLabel" id="label5">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Position:</property>
                                   </object>
                                   <packing>
@@ -1794,10 +1785,10 @@
                                   <object class="GtkRadioButton" id="radio_msgwin_vertical">
                                     <property name="label" translatable="yes">Bottom</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <property name="active">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1809,10 +1800,10 @@
                                   <object class="GtkRadioButton" id="radio_msgwin_horizontal">
                                     <property name="label" translatable="yes">Right</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <property name="active">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="draw-indicator">True</property>
                                     <property name="group">radio_msgwin_vertical</property>
                                   </object>
                                   <packing>
@@ -1828,9 +1819,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label4">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Message window&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -1843,111 +1834,111 @@
                     <child>
                       <object class="GtkFrame" id="frame4">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment5">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
-                            <property name="right_padding">6</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
+                            <property name="right-padding">6</property>
                             <child>
                               <object class="GtkTable" id="table2">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="n_rows">3</property>
-                                <property name="n_columns">2</property>
-                                <property name="column_spacing">24</property>
-                                <property name="row_spacing">3</property>
+                                <property name="can-focus">False</property>
+                                <property name="n-rows">3</property>
+                                <property name="n-columns">2</property>
+                                <property name="column-spacing">24</property>
+                                <property name="row-spacing">3</property>
                                 <child>
                                   <object class="GtkLabel" id="label100">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Symbol list:</property>
-                                    <property name="mnemonic_widget">tagbar_font</property>
+                                    <property name="mnemonic-widget">tagbar_font</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label101">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Message window:</property>
-                                    <property name="mnemonic_widget">msgwin_font</property>
+                                    <property name="mnemonic-widget">msgwin_font</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label103">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Editor:</property>
-                                    <property name="mnemonic_widget">editor_font</property>
+                                    <property name="mnemonic-widget">editor_font</property>
                                   </object>
                                   <packing>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkFontButton" id="msgwin_font">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Sets the font for the message window</property>
-                                    <property name="show_style">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Sets the font for the message window</property>
+                                    <property name="font">Sans 12</property>
+                                    <property name="show-style">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkFontButton" id="tagbar_font">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Sets the font for the symbol list</property>
-                                    <property name="show_style">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Sets the font for the symbol list</property>
+                                    <property name="font">Sans 12</property>
+                                    <property name="show-style">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkFontButton" id="editor_font">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Sets the editor font</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Sets the editor font</property>
+                                    <property name="font">Sans 12</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                               </object>
@@ -1957,9 +1948,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label99">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Fonts&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -1972,27 +1963,27 @@
                     <child>
                       <object class="GtkFrame" id="frame23">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment26">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox22">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_statusbar_visible">
                                     <property name="label" translatable="yes">Show status bar</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Whether to show the status bar at the bottom of the main window</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Whether to show the status bar at the bottom of the main window</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2007,9 +1998,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label187">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Miscellaneous&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -2024,42 +2015,42 @@
                 <child type="tab">
                   <object class="GtkLabel" id="label248">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Interface</property>
                   </object>
                   <packing>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkVBox" id="vbox54">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkFrame" id="frame29">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment32">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox26">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_show_notebook_tabs">
                                     <property name="label" translatable="yes">Show editor tabs</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2071,11 +2062,11 @@
                                   <object class="GtkCheckButton" id="check_show_tab_cross">
                                     <property name="label" translatable="yes">Show close buttons</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Shows a small cross button in the file tabs to easily close files when clicking on it (requires restart of Geany)</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Shows a small cross button in the file tabs to easily close files when clicking on it (requires restart of Geany)</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2086,39 +2077,38 @@
                                 <child>
                                   <object class="GtkTable" id="table21">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="n_rows">2</property>
-                                    <property name="n_columns">2</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">2</property>
+                                    <property name="n-columns">2</property>
                                     <child>
                                       <placeholder/>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label150">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Placement of new file tabs:</property>
                                       </object>
                                       <packing>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkHBox" id="hbox7">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="spacing">12</property>
                                         <child>
                                           <object class="GtkRadioButton" id="radio_tab_left">
                                             <property name="label" translatable="yes">Left</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text" translatable="yes">File tabs will be placed on the left of the notebook</property>
-                                            <property name="use_underline">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">File tabs will be placed on the left of the notebook</property>
+                                            <property name="use-underline">True</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2130,11 +2120,11 @@
                                           <object class="GtkRadioButton" id="radio_tab_right">
                                             <property name="label" translatable="yes">Right</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text" translatable="yes">File tabs will be placed on the right of the notebook</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">File tabs will be placed on the right of the notebook</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <property name="group">radio_tab_left</property>
                                           </object>
                                           <packing>
@@ -2145,28 +2135,28 @@
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="y_options">GTK_FILL</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkCheckButton" id="check_tab_beside">
                                         <property name="label" translatable="yes">Next to current</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Whether to place file tabs next to the current tab rather than at the edges of the notebook</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Whether to place file tabs next to the current tab rather than at the edges of the notebook</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                   </object>
@@ -2180,11 +2170,11 @@
                                   <object class="GtkCheckButton" id="check_double_click_hides_widgets">
                                     <property name="label" translatable="yes">Double-clicking hides all additional widgets</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Calls the View-&gt;Toggle All Additional Widgets command</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Calls the View-&gt;Toggle All Additional Widgets command</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2196,9 +2186,9 @@
                                   <object class="GtkCheckButton" id="check_tab_close_switch_to_mru">
                                     <property name="label" translatable="yes">Switch to last used document after closing a tab</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2213,9 +2203,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label197">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Editor tabs&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -2228,41 +2218,40 @@
                     <child>
                       <object class="GtkFrame" id="frame9">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment12">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkTable" id="table8">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="n_rows">3</property>
-                                <property name="n_columns">2</property>
-                                <property name="column_spacing">24</property>
-                                <property name="row_spacing">3</property>
+                                <property name="can-focus">False</property>
+                                <property name="n-rows">3</property>
+                                <property name="n-columns">2</property>
+                                <property name="column-spacing">24</property>
+                                <property name="row-spacing">3</property>
                                 <child>
                                   <object class="GtkLabel" id="label160">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Message window:</property>
-                                    <property name="mnemonic_widget">combo_tab_msgwin</property>
+                                    <property name="mnemonic-widget">combo_tab_msgwin</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkComboBox" id="combo_tab_msgwin">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="model">tab_pos_list</property>
                                     <child>
                                       <object class="GtkCellRendererText" id="cellrenderertext1"/>
@@ -2272,33 +2261,32 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options">GTK_FILL</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label161">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Sidebar:</property>
-                                    <property name="mnemonic_widget">combo_tab_sidebar</property>
+                                    <property name="mnemonic-widget">combo_tab_sidebar</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkComboBox" id="combo_tab_sidebar">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="model">tab_pos_list</property>
                                     <child>
                                       <object class="GtkCellRendererText" id="cellrenderertext2"/>
@@ -2308,31 +2296,30 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options">GTK_FILL</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label159">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Editor:</property>
-                                    <property name="mnemonic_widget">combo_tab_editor</property>
+                                    <property name="mnemonic-widget">combo_tab_editor</property>
                                   </object>
                                   <packing>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkComboBox" id="combo_tab_editor">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="model">tab_pos_list</property>
                                     <child>
                                       <object class="GtkCellRendererText" id="cellrenderertext3"/>
@@ -2342,10 +2329,10 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options">GTK_FILL</property>
                                   </packing>
                                 </child>
                               </object>
@@ -2355,9 +2342,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label158">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Tab positions&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -2375,53 +2362,53 @@
                 <child type="tab">
                   <object class="GtkLabel" id="label249">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Notebook tabs</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                   </object>
                   <packing>
                     <property name="position">1</property>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkVBox" id="vbox15">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkFrame" id="frame28">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment31">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox42">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">5</property>
                                 <child>
                                   <object class="GtkHBox" id="hbox18">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkVBox" id="vbox52">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkCheckButton" id="check_toolbar_show">
                                             <property name="label" translatable="yes">Show t_oolbar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2433,11 +2420,11 @@
                                           <object class="GtkCheckButton" id="check_toolbar_in_menu">
                                             <property name="label" translatable="yes">_Append toolbar to the menu</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text" translatable="yes">Pack the toolbar to the main menu to save vertical space</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">Pack the toolbar to the main menu to save vertical space</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2455,28 +2442,28 @@
                                     <child>
                                       <object class="GtkVBox" id="vbox53">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkButton" id="button_customize_toolbar">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <signal name="clicked" handler="on_button_customize_toolbar_clicked" swapped="no"/>
                                             <child>
                                               <object class="GtkAlignment" id="alignment45">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="xscale">0</property>
                                                 <property name="yscale">0</property>
                                                 <child>
                                                   <object class="GtkHBox" id="hbox16">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="spacing">2</property>
                                                     <child>
                                                       <object class="GtkImage" id="image2877">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="stock">gtk-properties</property>
                                                       </object>
                                                       <packing>
@@ -2488,9 +2475,9 @@
                                                     <child>
                                                       <object class="GtkLabel" id="label236">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="label" translatable="yes">Customize Toolbar</property>
-                                                        <property name="use_underline">True</property>
+                                                        <property name="use-underline">True</property>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>
@@ -2526,87 +2513,87 @@
                                 <child>
                                   <object class="GtkFrame" id="frame_toolbar_style">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label_xalign">0</property>
-                                    <property name="shadow_type">none</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label-xalign">0</property>
+                                    <property name="shadow-type">none</property>
                                     <child>
                                       <object class="GtkAlignment" id="alignment50">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="left_padding">12</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="left-padding">12</property>
                                         <child>
                                           <object class="GtkTable" id="table19">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="n_rows">2</property>
-                                            <property name="n_columns">2</property>
-                                            <property name="column_spacing">20</property>
-                                            <property name="row_spacing">3</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="n-rows">2</property>
+                                            <property name="n-columns">2</property>
+                                            <property name="column-spacing">20</property>
+                                            <property name="row-spacing">3</property>
                                             <child>
                                               <object class="GtkRadioButton" id="radio_toolbar_style_default">
                                                 <property name="label" translatable="yes">System _default</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
-                                                <property name="x_options">GTK_FILL</property>
-                                                <property name="y_options"/>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options"/>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkRadioButton" id="radio_toolbar_imagetext">
                                                 <property name="label" translatable="yes">Images _and text</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <property name="group">radio_toolbar_style_default</property>
                                               </object>
                                               <packing>
-                                                <property name="top_attach">1</property>
-                                                <property name="bottom_attach">2</property>
-                                                <property name="x_options">GTK_FILL</property>
-                                                <property name="y_options"/>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options"/>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkRadioButton" id="radio_toolbar_image">
                                                 <property name="label" translatable="yes">_Images only</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <property name="group">radio_toolbar_style_default</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="right_attach">2</property>
-                                                <property name="x_options">GTK_FILL</property>
-                                                <property name="y_options"/>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options"/>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkRadioButton" id="radio_toolbar_text">
                                                 <property name="label" translatable="yes">_Text only</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <property name="group">radio_toolbar_style_default</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="right_attach">2</property>
-                                                <property name="top_attach">1</property>
-                                                <property name="bottom_attach">2</property>
-                                                <property name="x_options">GTK_FILL</property>
-                                                <property name="y_options"/>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options"/>
                                               </packing>
                                             </child>
                                           </object>
@@ -2616,9 +2603,9 @@
                                     <child type="label">
                                       <object class="GtkLabel" id="label244">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">&lt;b&gt;Icon style&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
+                                        <property name="use-markup">True</property>
                                       </object>
                                     </child>
                                   </object>
@@ -2631,88 +2618,88 @@
                                 <child>
                                   <object class="GtkFrame" id="frame_toolbar_icon">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label_xalign">0</property>
-                                    <property name="shadow_type">none</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label-xalign">0</property>
+                                    <property name="shadow-type">none</property>
                                     <child>
                                       <object class="GtkAlignment" id="alignment51">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="left_padding">12</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="left-padding">12</property>
                                         <child>
                                           <object class="GtkTable" id="table20">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="n_rows">2</property>
-                                            <property name="n_columns">2</property>
-                                            <property name="column_spacing">20</property>
-                                            <property name="row_spacing">3</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="n-rows">2</property>
+                                            <property name="n-columns">2</property>
+                                            <property name="column-spacing">20</property>
+                                            <property name="row-spacing">3</property>
                                             <property name="homogeneous">True</property>
                                             <child>
                                               <object class="GtkRadioButton" id="radio_toolbar_icon_default">
                                                 <property name="label" translatable="yes">S_ystem default</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
-                                                <property name="x_options">GTK_FILL</property>
-                                                <property name="y_options"/>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options"/>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkRadioButton" id="radio_toolbar_small">
                                                 <property name="label" translatable="yes">_Small icons</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <property name="group">radio_toolbar_icon_default</property>
                                               </object>
                                               <packing>
-                                                <property name="top_attach">1</property>
-                                                <property name="bottom_attach">2</property>
-                                                <property name="x_options">GTK_FILL</property>
-                                                <property name="y_options"/>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options"/>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkRadioButton" id="radio_toolbar_verysmall">
                                                 <property name="label" translatable="yes">_Very small icons</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <property name="group">radio_toolbar_icon_default</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="right_attach">2</property>
-                                                <property name="x_options">GTK_FILL</property>
-                                                <property name="y_options"/>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options"/>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkRadioButton" id="radio_toolbar_large">
                                                 <property name="label" translatable="yes">_Large icons</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="use-underline">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <property name="group">radio_toolbar_icon_default</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="right_attach">2</property>
-                                                <property name="top_attach">1</property>
-                                                <property name="bottom_attach">2</property>
-                                                <property name="x_options">GTK_FILL</property>
-                                                <property name="y_options"/>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options"/>
                                               </packing>
                                             </child>
                                           </object>
@@ -2722,9 +2709,9 @@
                                     <child type="label">
                                       <object class="GtkLabel" id="label245">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">&lt;b&gt;Icon size&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
+                                        <property name="use-markup">True</property>
                                       </object>
                                     </child>
                                   </object>
@@ -2741,9 +2728,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label246">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Toolbar&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -2761,12 +2748,12 @@
                 <child type="tab">
                   <object class="GtkLabel" id="label164">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Toolbar</property>
                   </object>
                   <packing>
                     <property name="position">2</property>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
               </object>
@@ -2777,48 +2764,48 @@
             <child type="tab">
               <object class="GtkLabel" id="label157">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Interface</property>
               </object>
               <packing>
                 <property name="position">1</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkNotebook" id="notebook4">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <child>
                   <object class="GtkVBox" id="vbox5">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkFrame" id="frame14">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment17">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox17">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_line_wrapping">
                                     <property name="label" translatable="yes">Line wrapping</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Wrap the line at the window border and continue it on the next line. Note: line wrapping has a high performance cost for large documents so should be disabled on slow machines.</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Wrap the line at the window border and continue it on the next line. Note: line wrapping has a high performance cost for large documents so should be disabled on slow machines.</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2830,11 +2817,11 @@
                                   <object class="GtkCheckButton" id="check_smart_home">
                                     <property name="label" translatable="yes">"Smart" home key</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">When "smart" home is enabled, the HOME key will move the caret to the first non-blank character of the line, unless it is already there, it moves to the very beginning of the line. When this feature is disabled, the HOME key always moves the caret to the start of the current line, regardless of its current position.</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">When "smart" home is enabled, the HOME key will move the caret to the first non-blank character of the line, unless it is already there, it moves to the very beginning of the line. When this feature is disabled, the HOME key always moves the caret to the start of the current line, regardless of its current position.</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2846,11 +2833,11 @@
                                   <object class="GtkCheckButton" id="check_disable_dnd">
                                     <property name="label" translatable="yes">Disable Drag and Drop</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Disable drag and drop completely in the editor window so you can't drag and drop any selections within or outside of the editor window</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Disable drag and drop completely in the editor window so you can't drag and drop any selections within or outside of the editor window</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2862,10 +2849,10 @@
                                   <object class="GtkCheckButton" id="check_folding">
                                     <property name="label" translatable="yes">Code folding</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2877,11 +2864,11 @@
                                   <object class="GtkCheckButton" id="check_unfold_children">
                                     <property name="label" translatable="yes">Fold/unfold all children of a fold point</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Fold or unfold all children of a fold point. By pressing the Shift key while clicking on a fold symbol the contrary behavior is used.</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Fold or unfold all children of a fold point. By pressing the Shift key while clicking on a fold symbol the contrary behavior is used.</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2893,11 +2880,11 @@
                                   <object class="GtkCheckButton" id="check_indicators">
                                     <property name="label" translatable="yes">Use indicators to show compile errors</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Whether to use indicators (a squiggly underline) to highlight the lines where the compiler found a warning or an error</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Whether to use indicators (a squiggly underline) to highlight the lines where the compiler found a warning or an error</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2909,11 +2896,11 @@
                                   <object class="GtkCheckButton" id="check_newline_strip">
                                     <property name="label" translatable="yes">Newline strips trailing spaces</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Enable newline to strip the trailing spaces on the previous line</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enable newline to strip the trailing spaces on the previous line</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -2924,14 +2911,14 @@
                                 <child>
                                   <object class="GtkHBox" id="hbox11">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="spacing">12</property>
                                     <child>
                                       <object class="GtkLabel" id="label209">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Line breaking column:</property>
-                                        <property name="mnemonic_widget">spin_line_break</property>
+                                        <property name="mnemonic-widget">spin_line_break</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2942,13 +2929,11 @@
                                     <child>
                                       <object class="GtkSpinButton" id="spin_line_break">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
                                         <property name="adjustment">adjustment1</property>
-                                        <property name="climb_rate">1</property>
+                                        <property name="climb-rate">1</property>
                                         <property name="numeric">True</property>
                                       </object>
                                       <packing>
@@ -2967,14 +2952,14 @@
                                 <child>
                                   <object class="GtkHBox" id="hbox12">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="spacing">12</property>
                                     <child>
                                       <object class="GtkLabel" id="label220">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Comment toggle marker:</property>
-                                        <property name="mnemonic_widget">entry_toggle_mark</property>
+                                        <property name="mnemonic-widget">entry_toggle_mark</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2985,12 +2970,10 @@
                                     <child>
                                       <object class="GtkEntry" id="entry_toggle_mark">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">A string which is added when toggling a line comment in a source file, it is used to mark the comment as toggled.</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">A string which is added when toggling a line comment in a source file, it is used to mark the comment as toggled.</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3012,9 +2995,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label172">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Features&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -3029,23 +3012,23 @@
                 <child type="tab">
                   <object class="GtkLabel" id="label211">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Features</property>
                   </object>
                   <packing>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkVBox" id="vbox40">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkVBox" id="label_project_indent_warning">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <placeholder/>
                         </child>
@@ -3059,10 +3042,9 @@
                     <child>
                       <object class="GtkLabel" id="label247">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Note: To apply these settings to all currently open documents, use &lt;i&gt;Project-&gt;Apply Default Indentation&lt;/i&gt;.</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                         <property name="wrap">True</property>
                       </object>
                       <packing>
@@ -3074,26 +3056,26 @@
                     <child>
                       <object class="GtkFrame" id="frame27">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment30">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox25">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkTable" id="table13">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="n_rows">7</property>
-                                    <property name="n_columns">2</property>
-                                    <property name="column_spacing">24</property>
-                                    <property name="row_spacing">3</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">7</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">24</property>
+                                    <property name="row-spacing">3</property>
                                     <child>
                                       <placeholder/>
                                     </child>
@@ -3109,58 +3091,54 @@
                                     <child>
                                       <object class="GtkLabel" id="label222">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">_Width:</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="mnemonic_widget">spin_indent_width</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="mnemonic-widget">spin_indent_width</property>
                                       </object>
                                       <packing>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_indent_width">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">The width in chars of a single indent</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">The width in chars of a single indent</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
                                         <property name="adjustment">adjustment2</property>
-                                        <property name="climb_rate">1</property>
+                                        <property name="climb-rate">1</property>
                                         <property name="numeric">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="update_policy">if-valid</property>
+                                        <property name="update-policy">if-valid</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label183">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Auto-indent _mode:</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="mnemonic_widget">combo_auto_indent_mode</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="mnemonic-widget">combo_auto_indent_mode</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">6</property>
-                                        <property name="bottom_attach">7</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="top-attach">6</property>
+                                        <property name="bottom-attach">7</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkComboBox" id="combo_auto_indent_mode">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="model">indent_mode_list</property>
                                         <child>
                                           <object class="GtkCellRendererText" id="cellrenderertext4"/>
@@ -3170,123 +3148,122 @@
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">6</property>
-                                        <property name="bottom_attach">7</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">6</property>
+                                        <property name="bottom-attach">7</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkCheckButton" id="check_detect_indent_type">
                                         <property name="label" translatable="yes">Detect type from file</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Whether to detect the indentation type from file contents when a file is opened</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Whether to detect the indentation type from file contents when a file is opened</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">5</property>
-                                        <property name="bottom_attach">6</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">5</property>
+                                        <property name="bottom-attach">6</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkRadioButton" id="radio_indent_both">
                                         <property name="label" translatable="yes">T_abs and spaces</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Use spaces if the total indent is less than the tab width, otherwise use both</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Use spaces if the total indent is less than the tab width, otherwise use both</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">4</property>
-                                        <property name="bottom_attach">5</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="bottom-attach">5</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkRadioButton" id="radio_indent_spaces">
                                         <property name="label" translatable="yes">_Spaces</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Use spaces when inserting indentation</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Use spaces when inserting indentation</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <property name="group">radio_indent_both</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkRadioButton" id="radio_indent_tabs">
                                         <property name="label" translatable="yes">_Tabs</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Use one tab per indent</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Use one tab per indent</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <property name="group">radio_indent_both</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkCheckButton" id="check_detect_indent_width">
                                         <property name="label" translatable="yes">Detect width from file</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Whether to detect the indentation width from file contents when a file is opened</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Whether to detect the indentation width from file contents when a file is opened</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label200">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Type:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                   </object>
@@ -3300,11 +3277,11 @@
                                   <object class="GtkCheckButton" id="check_tab_key_indents">
                                     <property name="label" translatable="yes">Tab _key indents</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Pressing tab/shift-tab indents/unindents instead of inserting a tab character</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Pressing tab/shift-tab indents/unindents instead of inserting a tab character</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3319,9 +3296,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label195">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Indentation&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -3339,44 +3316,44 @@
                 <child type="tab">
                   <object class="GtkLabel" id="label232">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Indentation</property>
                   </object>
                   <packing>
                     <property name="position">1</property>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkVBox" id="vbox39">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkFrame" id="frame18">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment21">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox19">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_complete_snippets">
                                     <property name="label" translatable="yes">Snippet completion</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Type a defined short character sequence and complete it to a more complex string using a single keypress</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Type a defined short character sequence and complete it to a more complex string using a single keypress</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3388,11 +3365,11 @@
                                   <object class="GtkCheckButton" id="check_xmltag">
                                     <property name="label" translatable="yes">XML/HTML tag auto-closing</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Insert matching closing tag for XML/HTML</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Insert matching closing tag for XML/HTML</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3404,11 +3381,11 @@
                                   <object class="GtkCheckButton" id="check_auto_multiline">
                                     <property name="label" translatable="yes">Automatic continuation of multi-line comments</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Continue automatically multi-line comments in languages like C, C++ and Java when a new line is entered inside such a comment</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Continue automatically multi-line comments in languages like C, C++ and Java when a new line is entered inside such a comment</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3420,11 +3397,11 @@
                                   <object class="GtkCheckButton" id="check_symbol_auto_completion">
                                     <property name="label" translatable="yes">Autocomplete symbols</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Automatic completion of known symbols in open files (function names, global variables, ...)</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Automatic completion of known symbols in open files (function names, global variables, ...)</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3436,10 +3413,10 @@
                                   <object class="GtkCheckButton" id="check_autocomplete_doc_words">
                                     <property name="label" translatable="yes">Autocomplete all words in document</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3451,10 +3428,10 @@
                                   <object class="GtkCheckButton" id="check_completion_drops_rest_of_word">
                                     <property name="label" translatable="yes">Drop rest of word on completion</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3465,149 +3442,137 @@
                                 <child>
                                   <object class="GtkTable" id="table14">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="n_rows">4</property>
-                                    <property name="n_columns">2</property>
-                                    <property name="column_spacing">12</property>
-                                    <property name="row_spacing">3</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">4</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">12</property>
+                                    <property name="row-spacing">3</property>
                                     <child>
                                       <object class="GtkLabel" id="label223">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Max. symbol name suggestions:</property>
-                                        <property name="mnemonic_widget">spin_autocompletion_max_entries</property>
+                                        <property name="mnemonic-widget">spin_autocompletion_max_entries</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label173">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Completion list height:</property>
-                                        <property name="mnemonic_widget">spin_symbollistheight</property>
+                                        <property name="mnemonic-widget">spin_symbollistheight</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label205">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Characters to type for autocompletion:</property>
-                                        <property name="mnemonic_widget">spin_symbol_complete_chars</property>
+                                        <property name="mnemonic-widget">spin_symbol_complete_chars</property>
                                       </object>
                                       <packing>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_symbol_complete_chars">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">The amount of characters which are necessary to show the symbol autocompletion list</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">The amount of characters which are necessary to show the symbol autocompletion list</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
                                         <property name="adjustment">adjustment3</property>
-                                        <property name="climb_rate">1</property>
+                                        <property name="climb-rate">1</property>
                                         <property name="numeric">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_symbollistheight">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">Display height in rows for the autocompletion list</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Display height in rows for the autocompletion list</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
                                         <property name="adjustment">adjustment4</property>
-                                        <property name="climb_rate">1</property>
+                                        <property name="climb-rate">1</property>
                                         <property name="numeric">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_autocompletion_max_entries">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">Maximum number of entries to display in the autocompletion list</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Maximum number of entries to display in the autocompletion list</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
                                         <property name="adjustment">adjustment5</property>
-                                        <property name="climb_rate">1</property>
+                                        <property name="climb-rate">1</property>
                                         <property name="numeric">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label250">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Symbol list update frequency:</property>
-                                        <property name="mnemonic_widget">spin_symbol_update_freq</property>
+                                        <property name="mnemonic-widget">spin_symbol_update_freq</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_symbol_update_freq">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">Minimal delay (in milliseconds) between two automatic updates of the symbol list. Note that a too short delay may have performance impact, especially with large files. A delay of 0 disables real-time updates.</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Minimal delay (in milliseconds) between two automatic updates of the symbol list. Note that a too short delay may have performance impact, especially with large files. A delay of 0 disables real-time updates.</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
                                         <property name="adjustment">adjustment6</property>
-                                        <property name="climb_rate">1</property>
+                                        <property name="climb-rate">1</property>
                                         <property name="numeric">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="y_options"/>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                   </object>
@@ -3624,9 +3589,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label177">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Completions&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -3639,27 +3604,27 @@
                     <child>
                       <object class="GtkFrame" id="frame38">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment42">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox10">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_autoclose_parenthesis">
                                     <property name="label" translatable="yes">Parenthesis ( )</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close parenthesis when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Auto-close parenthesis when typing an opening one</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">True</property>
@@ -3671,11 +3636,11 @@
                                   <object class="GtkCheckButton" id="check_autoclose_cbracket">
                                     <property name="label" translatable="yes">Curly brackets { }</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close curly bracket when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Auto-close curly bracket when typing an opening one</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">True</property>
@@ -3687,11 +3652,11 @@
                                   <object class="GtkCheckButton" id="check_autoclose_sbracket">
                                     <property name="label" translatable="yes">Square brackets [ ]</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close square-bracket when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Auto-close square-bracket when typing an opening one</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">True</property>
@@ -3703,11 +3668,11 @@
                                   <object class="GtkCheckButton" id="check_autoclose_squote">
                                     <property name="label" translatable="yes">Single quotes ' '</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close single quote when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Auto-close single quote when typing an opening one</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">True</property>
@@ -3719,11 +3684,11 @@
                                   <object class="GtkCheckButton" id="check_autoclose_dquote">
                                     <property name="label" translatable="yes">Double quotes " "</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Auto-close double quote when typing an opening one</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Auto-close double quote when typing an opening one</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">True</property>
@@ -3738,9 +3703,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label225">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Auto-close quotes and brackets&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -3758,46 +3723,46 @@
                 <child type="tab">
                   <object class="GtkLabel" id="label226">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Completions</property>
                   </object>
                   <packing>
                     <property name="position">2</property>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkVBox" id="vbox24">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="border_width">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkFrame" id="frame5">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment6">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="bottom_padding">5</property>
-                            <property name="left_padding">12</property>
-                            <property name="right_padding">6</property>
+                            <property name="can-focus">False</property>
+                            <property name="bottom-padding">5</property>
+                            <property name="left-padding">12</property>
+                            <property name="right-padding">6</property>
                             <child>
                               <object class="GtkVBox" id="vbox12">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_highlighting_invert">
                                     <property name="label" translatable="yes">Invert syntax highlighting colors</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Invert all colors, by default using white text on a black background</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Invert all colors, by default using white text on a black background</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3809,11 +3774,11 @@
                                   <object class="GtkCheckButton" id="check_indent">
                                     <property name="label" translatable="yes">Show indentation guides</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Shows small dotted lines to help you to use the right indentation</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Shows small dotted lines to help you to use the right indentation</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3825,11 +3790,11 @@
                                   <object class="GtkCheckButton" id="check_white_space">
                                     <property name="label" translatable="yes">Show white space</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Marks spaces with dots and tabs with arrows</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Marks spaces with dots and tabs with arrows</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3841,11 +3806,11 @@
                                   <object class="GtkCheckButton" id="check_line_end">
                                     <property name="label" translatable="yes">Show line endings</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Shows the line ending character</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Shows the line ending character</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3857,11 +3822,11 @@
                                   <object class="GtkCheckButton" id="check_line_numbers">
                                     <property name="label" translatable="yes">Show line numbers</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Shows or hides the Line Number margin</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Shows or hides the Line Number margin</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3873,11 +3838,11 @@
                                   <object class="GtkCheckButton" id="check_markers_margin">
                                     <property name="label" translatable="yes">Show markers margin</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Shows or hides the small margin right of the line numbers, which is used to mark lines</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Shows or hides the small margin right of the line numbers, which is used to mark lines</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3889,11 +3854,11 @@
                                   <object class="GtkCheckButton" id="check_scroll_stop_at_last_line">
                                     <property name="label" translatable="yes">Stop scrolling at last line</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Whether to stop scrolling one page past the last line of a document</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Whether to stop scrolling one page past the last line of a document</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -3904,16 +3869,16 @@
                                 <child>
                                   <object class="GtkHBox" id="hbox4">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="tooltip_markup">Number of lines to maintain between the cursor and the top and bottom edges of the view. This allows some lines of context around the cursor to always be visible. If &lt;i&gt;Stop scrolling at last line&lt;/i&gt; is &lt;b&gt;disabled&lt;/b&gt;, the cursor will never reach the bottom edge when this value is greater than 0.</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="tooltip-markup">Number of lines to maintain between the cursor and the top and bottom edges of the view. This allows some lines of context around the cursor to always be visible. If &lt;i&gt;Stop scrolling at last line&lt;/i&gt; is &lt;b&gt;disabled&lt;/b&gt;, the cursor will never reach the bottom edge when this value is greater than 0.</property>
                                     <property name="spacing">6</property>
                                     <child>
                                       <object class="GtkLabel" id="label25">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Lines visible _around the cursor:</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="mnemonic_widget">spin_scroll_lines_around_cursor</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="mnemonic-widget">spin_scroll_lines_around_cursor</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3924,11 +3889,9 @@
                                     <child>
                                       <object class="GtkSpinButton" id="spin_scroll_lines_around_cursor">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
                                         <property name="adjustment">adjustment13</property>
                                       </object>
                                       <packing>
@@ -3951,9 +3914,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label102">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Display&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -3966,121 +3929,116 @@
                     <child>
                       <object class="GtkFrame" id="frame8">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment11">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkTable" id="table7">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="n_rows">4</property>
-                                <property name="n_columns">2</property>
-                                <property name="column_spacing">24</property>
-                                <property name="row_spacing">3</property>
+                                <property name="can-focus">False</property>
+                                <property name="n-rows">4</property>
+                                <property name="n-columns">2</property>
+                                <property name="column-spacing">24</property>
+                                <property name="row-spacing">3</property>
                                 <child>
                                   <object class="GtkLabel" id="label133">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Column:</property>
-                                    <property name="mnemonic_widget">spin_long_line</property>
+                                    <property name="mnemonic-widget">spin_long_line</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label134">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Color:</property>
-                                    <property name="mnemonic_widget">long_line_color</property>
+                                    <property name="mnemonic-widget">long_line_color</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">3</property>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label156">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Type:</property>
-                                    <property name="mnemonic_widget">hbox5</property>
+                                    <property name="mnemonic-widget">hbox5</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkColorButton" id="long_line_color">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Sets the color of the long line marker</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Sets the color of the long line marker</property>
                                     <property name="title" translatable="yes">Color Chooser</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">3</property>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkSpinButton" id="spin_long_line">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">The long line marker is a thin vertical line in the editor, it helps to mark long lines, or as a hint to break the line. Set this value to a value greater than 0 to specify the column where it should appear.</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">The long line marker is a thin vertical line in the editor, it helps to mark long lines, or as a hint to break the line. Set this value to a value greater than 0 to specify the column where it should appear.</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                     <property name="adjustment">adjustment7</property>
-                                    <property name="climb_rate">1</property>
+                                    <property name="climb-rate">1</property>
                                     <property name="numeric">True</property>
                                     <property name="wrap">True</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkHBox" id="hbox5">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="spacing">12</property>
                                     <child>
                                       <object class="GtkRadioButton" id="radio_long_line_line">
                                         <property name="label" translatable="yes">Line</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Prints a vertical line in the editor window at the given cursor position (see below)</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Prints a vertical line in the editor window at the given cursor position (see below)</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -4092,11 +4050,11 @@
                                       <object class="GtkRadioButton" id="radio_long_line_background">
                                         <property name="label" translatable="yes">Background</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">The background color of characters after the given cursor position (see below) changed to the color set below, (this is recommended if you use proportional fonts)</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">The background color of characters after the given cursor position (see below) changed to the color set below, (this is recommended if you use proportional fonts)</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <property name="group">radio_long_line_line</property>
                                       </object>
                                       <packing>
@@ -4107,27 +4065,27 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options">GTK_FILL</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkCheckButton" id="check_long_line">
                                     <property name="label" translatable="yes">Enabled</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
-                                    <property name="right_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="right-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                               </object>
@@ -4137,9 +4095,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label242">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Long line marker&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -4152,27 +4110,27 @@
                     <child>
                       <object class="GtkFrame" id="frame40">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment47">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox48">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkRadioButton" id="radio_virtualspace_disabled">
                                     <property name="label" translatable="yes">Disabled</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Do not show virtual spaces</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Do not show virtual spaces</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -4184,11 +4142,11 @@
                                   <object class="GtkRadioButton" id="radio_virtualspace_selection">
                                     <property name="label" translatable="yes">Only for rectangular selections</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Only show virtual spaces beyond the end of lines when drawing a rectangular selection</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Only show virtual spaces beyond the end of lines when drawing a rectangular selection</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                     <property name="group">radio_virtualspace_disabled</property>
                                   </object>
                                   <packing>
@@ -4201,11 +4159,11 @@
                                   <object class="GtkRadioButton" id="radio_virtualspace_always">
                                     <property name="label" translatable="yes">Always</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Always show virtual spaces beyond the end of lines</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Always show virtual spaces beyond the end of lines</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                     <property name="group">radio_virtualspace_disabled</property>
                                   </object>
                                   <packing>
@@ -4221,9 +4179,9 @@
                         <child type="label">
                           <object class="GtkLabel" id="label238">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Virtual spaces&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -4241,12 +4199,12 @@
                 <child type="tab">
                   <object class="GtkLabel" id="label213">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Display</property>
                   </object>
                   <packing>
                     <property name="position">3</property>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
               </object>
@@ -4257,49 +4215,49 @@
             <child type="tab">
               <object class="GtkLabel" id="label95">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Editor</property>
               </object>
               <packing>
                 <property name="position">2</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkVBox" id="vbox18">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">5</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkFrame" id="frame6">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment7">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkVBox" id="vbox8">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">3</property>
                             <child>
                               <object class="GtkVBox" id="vbox38">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="check_cmdline_new_files">
                                     <property name="label" translatable="yes">Open new documents from the command-line</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Create a new file for each command-line filename that doesn't exist</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Create a new file for each command-line filename that doesn't exist</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -4310,14 +4268,14 @@
                                 <child>
                                   <object class="GtkTable" id="table15">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="n_columns">2</property>
-                                    <property name="column_spacing">24</property>
-                                    <property name="row_spacing">3</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-columns">2</property>
+                                    <property name="column-spacing">24</property>
+                                    <property name="row-spacing">3</property>
                                     <child>
                                       <object class="GtkComboBox" id="combo_eol">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="model">eol_list</property>
                                         <child>
                                           <object class="GtkCellRendererText" id="cellrenderertext5"/>
@@ -4327,23 +4285,22 @@
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options">GTK_FILL</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label210">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Default end of line characters:</property>
-                                        <property name="mnemonic_widget">combo_eol</property>
+                                        <property name="mnemonic-widget">combo_eol</property>
                                       </object>
                                       <packing>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options"/>
+                                        <property name="x-options">GTK_FILL</property>
+                                        <property name="y-options"/>
                                       </packing>
                                     </child>
                                   </object>
@@ -4367,9 +4324,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label109">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;New files&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -4382,30 +4339,29 @@
                 <child>
                   <object class="GtkFrame" id="frame37">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment40">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkVBox" id="vbox43">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">6</property>
                             <child>
                               <object class="GtkVBox" id="vbox44">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkLabel" id="label153">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Default encoding (new files):</property>
-                                    <property name="mnemonic_widget">combo_new_encoding</property>
+                                    <property name="mnemonic-widget">combo_new_encoding</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -4416,12 +4372,12 @@
                                 <child>
                                   <object class="GtkEventBox" id="eventbox1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="tooltip_text" translatable="yes">Sets the default encoding for newly created files</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="tooltip-text" translatable="yes">Sets the default encoding for newly created files</property>
                                     <child>
                                       <object class="GtkComboBox" id="combo_new_encoding">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkCellRendererText" id="combo_new_encoding_renderer"/>
                                         </child>
@@ -4445,11 +4401,11 @@
                               <object class="GtkCheckButton" id="check_open_encoding">
                                 <property name="label" translatable="yes">Use fixed encoding when opening non-Unicode files</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">This option disables the automatic detection of the file encoding when opening non-Unicode files and opens the file with the specified encoding (usually not needed)</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">This option disables the automatic detection of the file encoding when opening non-Unicode files and opens the file with the specified encoding (usually not needed)</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -4460,14 +4416,13 @@
                             <child>
                               <object class="GtkVBox" id="vbox45">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkLabel" id="label_open_encoding">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Default encoding (existing non-Unicode files):</property>
-                                    <property name="mnemonic_widget">combo_open_encoding</property>
+                                    <property name="mnemonic-widget">combo_open_encoding</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -4478,12 +4433,12 @@
                                 <child>
                                   <object class="GtkEventBox" id="eventbox3">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="tooltip_text" translatable="yes">Sets the default encoding for opening existing non-Unicode files</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="tooltip-text" translatable="yes">Sets the default encoding for opening existing non-Unicode files</property>
                                     <child>
                                       <object class="GtkComboBox" id="combo_open_encoding">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkCellRendererText" id="combo_open_encoding_renderer"/>
                                         </child>
@@ -4510,9 +4465,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label219">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Encodings&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -4525,27 +4480,27 @@
                 <child>
                   <object class="GtkFrame" id="frame2">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment3">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkVBox" id="vbox6">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkCheckButton" id="check_new_line">
                                 <property name="label" translatable="yes">Ensure new line at file end</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Ensures that at the end of the file is a new line</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Ensures that at the end of the file is a new line</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -4557,11 +4512,11 @@
                               <object class="GtkCheckButton" id="check_ensure_convert_new_lines">
                                 <property name="label" translatable="yes">Ensure consistent line endings</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Ensures that newline characters always get converted before saving, avoiding mixed line endings in the same file</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Ensures that newline characters always get converted before saving, avoiding mixed line endings in the same file</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -4573,11 +4528,11 @@
                               <object class="GtkCheckButton" id="check_trailing_spaces">
                                 <property name="label" translatable="yes">Strip trailing spaces and tabs</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Removes trailing spaces and tabs at the end of lines</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Removes trailing spaces and tabs at the end of lines</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -4589,11 +4544,11 @@
                               <object class="GtkCheckButton" id="check_replace_tabs">
                                 <property name="label" translatable="yes">Replace tabs with space</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Replaces all tabs in document with spaces</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Replaces all tabs in document with spaces</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -4608,9 +4563,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label19">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Saving files&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -4623,97 +4578,91 @@
                 <child>
                   <object class="GtkFrame" id="frame17">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment20">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkVBox" id="vbox37">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkTable" id="table10">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="n_rows">2</property>
-                                <property name="n_columns">2</property>
-                                <property name="column_spacing">24</property>
-                                <property name="row_spacing">3</property>
+                                <property name="can-focus">False</property>
+                                <property name="n-rows">2</property>
+                                <property name="n-columns">2</property>
+                                <property name="column-spacing">24</property>
+                                <property name="row-spacing">3</property>
                                 <child>
                                   <object class="GtkLabel" id="label147">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="ypad">7</property>
                                     <property name="label" translatable="yes">Recent files list length:</property>
-                                    <property name="mnemonic_widget">spin_mru</property>
+                                    <property name="mnemonic-widget">spin_mru</property>
                                   </object>
                                   <packing>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkSpinButton" id="spin_mru">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Specifies the number of files which are stored in the Recent files list</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Specifies the number of files which are stored in the Recent files list</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                     <property name="adjustment">adjustment8</property>
-                                    <property name="climb_rate">1</property>
+                                    <property name="climb-rate">1</property>
                                     <property name="numeric">True</property>
                                     <property name="wrap">True</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label208">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Disk check timeout:</property>
-                                    <property name="mnemonic_widget">spin_disk_check</property>
+                                    <property name="mnemonic-widget">spin_disk_check</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkSpinButton" id="spin_disk_check">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">How often to check for changes to document files on disk, in seconds. Zero disables checking.</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">How often to check for changes to document files on disk, in seconds. Zero disables checking.</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                     <property name="adjustment">adjustment9</property>
-                                    <property name="climb_rate">1</property>
+                                    <property name="climb-rate">1</property>
                                     <property name="numeric">True</property>
                                     <property name="wrap">True</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                               </object>
@@ -4730,9 +4679,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label198">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Miscellaneous&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -4750,40 +4699,40 @@
             <child type="tab">
               <object class="GtkLabel" id="label174">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Files</property>
               </object>
               <packing>
                 <property name="position">3</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkVBox" id="vbox23">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">5</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkFrame" id="frame20">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment23">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkVBox" id="vbox2">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox33">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <placeholder/>
                                 </child>
@@ -4797,167 +4746,158 @@
                             <child>
                               <object class="GtkTable" id="table1">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="n_rows">3</property>
-                                <property name="n_columns">3</property>
-                                <property name="column_spacing">6</property>
-                                <property name="row_spacing">3</property>
+                                <property name="can-focus">False</property>
+                                <property name="n-rows">3</property>
+                                <property name="n-columns">3</property>
+                                <property name="column-spacing">6</property>
+                                <property name="row-spacing">3</property>
                                 <child>
                                   <object class="GtkLabel" id="label97">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Terminal:</property>
-                                    <property name="mnemonic_widget">entry_com_term</property>
+                                    <property name="mnemonic-widget">entry_com_term</property>
                                   </object>
                                   <packing>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label117">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Browser:</property>
-                                    <property name="mnemonic_widget">entry_browser</property>
+                                    <property name="mnemonic-widget">entry_browser</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_com_term">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">A terminal emulator command (%c is substituted with the Geany run script filename)</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">A terminal emulator command (%c is substituted with the Geany run script filename)</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_browser">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Path (and possibly additional arguments) to your favorite browser</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Path (and possibly additional arguments) to your favorite browser</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="button_term">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <child>
                                       <object class="GtkImage" id="image286">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="stock">gtk-open</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="button_browser">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <child>
                                       <object class="GtkImage" id="image287">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="stock">gtk-open</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label171">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Grep:</property>
-                                    <property name="mnemonic_widget">entry_grep</property>
+                                    <property name="mnemonic-widget">entry_grep</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_grep">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="button_grep">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <child>
                                       <object class="GtkImage" id="image808">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="stock">gtk-open</property>
                                       </object>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                               </object>
@@ -4974,9 +4914,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label179">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Tool paths&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -4989,68 +4929,66 @@
                 <child>
                   <object class="GtkFrame" id="frame26">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment29">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkTable" id="table12">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="n_columns">3</property>
-                            <property name="column_spacing">6</property>
-                            <property name="row_spacing">3</property>
+                            <property name="can-focus">False</property>
+                            <property name="n-columns">3</property>
+                            <property name="column-spacing">6</property>
+                            <property name="row-spacing">3</property>
                             <child>
                               <object class="GtkLabel" id="label189">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Context action:</property>
-                                <property name="mnemonic_widget">entry_contextaction</property>
+                                <property name="mnemonic-widget">entry_contextaction</property>
                               </object>
                               <packing>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkEntry" id="entry_contextaction">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="tooltip_text" translatable="yes">Context action command. The currently selected word can be used with %s. It can appear anywhere in the given command and will be replaced before execution.</property>
-                                <property name="invisible_char">●</property>
-                                <property name="primary_icon_activatable">False</property>
-                                <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="tooltip-text" translatable="yes">Context action command. The currently selected word can be used with %s. It can appear anywhere in the given command and will be replaced before execution.</property>
+                                <property name="invisible-char">●</property>
+                                <property name="primary-icon-activatable">False</property>
+                                <property name="secondary-icon-activatable">False</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="y_options"/>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="button_contextaction">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <child>
                                   <object class="GtkImage" id="image1919">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="stock">gtk-open</property>
                                   </object>
                                 </child>
                               </object>
                               <packing>
-                                <property name="left_attach">2</property>
-                                <property name="right_attach">3</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
+                                <property name="left-attach">2</property>
+                                <property name="right-attach">3</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                           </object>
@@ -5060,9 +4998,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label193">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Commands&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -5080,40 +5018,40 @@
             <child type="tab">
               <object class="GtkLabel" id="label96">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Tools</property>
               </object>
               <packing>
                 <property name="position">4</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkVBox" id="vbox49">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">5</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkFrame" id="frame21">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment24">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkVBox" id="vbox9">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">12</property>
                             <child>
                               <object class="GtkVBox" id="vbox31">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <placeholder/>
                                 </child>
@@ -5127,269 +5065,245 @@
                             <child>
                               <object class="GtkTable" id="table6">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="n_rows">8</property>
-                                <property name="n_columns">2</property>
-                                <property name="column_spacing">6</property>
-                                <property name="row_spacing">6</property>
+                                <property name="can-focus">False</property>
+                                <property name="n-rows">8</property>
+                                <property name="n-columns">2</property>
+                                <property name="column-spacing">6</property>
+                                <property name="row-spacing">6</property>
                                 <child>
                                   <object class="GtkEntry" id="entry_template_mail">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Email address of the developer</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Email address of the developer</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_template_initial">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Initials of the developer name</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Initials of the developer name</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label126">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Initial version:</property>
-                                    <property name="mnemonic_widget">entry_template_version</property>
+                                    <property name="mnemonic-widget">entry_template_version</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">4</property>
-                                    <property name="bottom_attach">5</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">4</property>
+                                    <property name="bottom-attach">5</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_template_version">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Version number, which a new file initially has</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Version number, which a new file initially has</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">4</property>
-                                    <property name="bottom_attach">5</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">4</property>
+                                    <property name="bottom-attach">5</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_template_company">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Company name</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Company name</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">3</property>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label129">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Developer:</property>
-                                    <property name="mnemonic_widget">entry_template_developer</property>
+                                    <property name="mnemonic-widget">entry_template_developer</property>
                                   </object>
                                   <packing>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label123">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Company:</property>
-                                    <property name="mnemonic_widget">entry_template_company</property>
+                                    <property name="mnemonic-widget">entry_template_company</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">3</property>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label130">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Mail address:</property>
-                                    <property name="mnemonic_widget">entry_template_mail</property>
+                                    <property name="mnemonic-widget">entry_template_mail</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label131">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Initials:</property>
-                                    <property name="mnemonic_widget">entry_template_initial</property>
+                                    <property name="mnemonic-widget">entry_template_initial</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_template_developer">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">The name of the developer</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">The name of the developer</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label216">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Year:</property>
-                                    <property name="mnemonic_widget">entry_template_year</property>
+                                    <property name="mnemonic-widget">entry_template_year</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">5</property>
-                                    <property name="bottom_attach">6</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">5</property>
+                                    <property name="bottom-attach">6</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label217">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Date:</property>
-                                    <property name="mnemonic_widget">entry_template_date</property>
+                                    <property name="mnemonic-widget">entry_template_date</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">6</property>
-                                    <property name="bottom_attach">7</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">6</property>
+                                    <property name="bottom-attach">7</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="label218">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Date &amp; time:</property>
-                                    <property name="mnemonic_widget">entry_template_datetime</property>
+                                    <property name="mnemonic-widget">entry_template_datetime</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">7</property>
-                                    <property name="bottom_attach">8</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="top-attach">7</property>
+                                    <property name="bottom-attach">8</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_template_datetime">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Specify a format for the {datetime} wildcard. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Specify a format for the {datetime} wildcard. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">7</property>
-                                    <property name="bottom_attach">8</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">7</property>
+                                    <property name="bottom-attach">8</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_template_year">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Specify a format for the {year} wildcard. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Specify a format for the {year} wildcard. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">5</property>
-                                    <property name="bottom_attach">6</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">5</property>
+                                    <property name="bottom-attach">6</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkEntry" id="entry_template_date">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Specify a format for the {date} wildcard. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Specify a format for the {date} wildcard. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">6</property>
-                                    <property name="bottom_attach">7</property>
-                                    <property name="y_options"/>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">6</property>
+                                    <property name="bottom-attach">7</property>
+                                    <property name="y-options"/>
                                   </packing>
                                 </child>
                               </object>
@@ -5406,9 +5320,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label180">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Template data&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -5426,35 +5340,35 @@
             <child type="tab">
               <object class="GtkLabel" id="label119">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Templates</property>
               </object>
               <packing>
                 <property name="position">5</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkFrame" id="frame22">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">5</property>
-                <property name="label_xalign">0</property>
-                <property name="shadow_type">none</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
+                <property name="label-xalign">0</property>
+                <property name="shadow-type">none</property>
                 <child>
                   <object class="GtkAlignment" id="alignment25">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="left-padding">12</property>
                     <child>
                       <object class="GtkVBox" id="vbox13">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">5</property>
                         <child>
                           <object class="GtkVBox" id="vbox32">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <placeholder/>
                             </child>
@@ -5468,13 +5382,16 @@
                         <child>
                           <object class="GtkScrolledWindow" id="scrolledwindow8">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="shadow_type">in</property>
+                            <property name="can-focus">True</property>
+                            <property name="shadow-type">in</property>
                             <child>
                               <object class="GtkTreeView" id="treeview7">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="rules_hint">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="rules-hint">True</property>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection"/>
+                                </child>
                               </object>
                             </child>
                           </object>
@@ -5487,16 +5404,16 @@
                         <child>
                           <object class="GtkAlignment" id="alignment10">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="xscale">0.30000001192092896</property>
-                            <property name="bottom_padding">5</property>
+                            <property name="bottom-padding">5</property>
                             <child>
                               <object class="GtkButton" id="button2">
                                 <property name="label" translatable="yes">C_hange</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
                               </object>
                             </child>
                           </object>
@@ -5513,9 +5430,9 @@
                 <child type="label">
                   <object class="GtkLabel" id="label181">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Keyboard shortcuts&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                 </child>
               </object>
@@ -5526,53 +5443,53 @@
             <child type="tab">
               <object class="GtkLabel" id="label151">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Keybindings</property>
               </object>
               <packing>
                 <property name="position">6</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkFrame" id="frame41">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">5</property>
-                <property name="label_xalign">0</property>
-                <property name="shadow_type">none</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
+                <property name="label-xalign">0</property>
+                <property name="shadow-type">none</property>
                 <child>
                   <object class="GtkAlignment" id="alignment49">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="left-padding">12</property>
                     <child>
                       <object class="GtkVBox" id="vbox27">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">10</property>
                         <child>
                           <object class="GtkFrame" id="frame32">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">none</property>
+                            <property name="can-focus">False</property>
+                            <property name="label-xalign">0</property>
+                            <property name="shadow-type">none</property>
                             <child>
                               <object class="GtkAlignment" id="alignment35">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="left_padding">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
                                 <child>
                                   <object class="GtkHBox" id="hbox9">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="spacing">5</property>
                                     <child>
                                       <object class="GtkLabel" id="label202">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Command:</property>
-                                        <property name="mnemonic_widget">entry_print_external_cmd</property>
+                                        <property name="mnemonic-widget">entry_print_external_cmd</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5583,12 +5500,10 @@
                                     <child>
                                       <object class="GtkEntry" id="entry_print_external_cmd">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">Path to the command for printing files (use %f for the filename)</property>
-                                        <property name="primary_icon_activatable">False</property>
-                                        <property name="secondary_icon_activatable">False</property>
-                                        <property name="primary_icon_sensitive">True</property>
-                                        <property name="secondary_icon_sensitive">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Path to the command for printing files (use %f for the filename)</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">True</property>
@@ -5599,12 +5514,12 @@
                                     <child>
                                       <object class="GtkButton" id="button_print_external_cmd">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
                                         <child>
                                           <object class="GtkImage" id="image763">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="stock">gtk-open</property>
                                           </object>
                                         </child>
@@ -5623,10 +5538,10 @@
                               <object class="GtkRadioButton" id="radio_print_external">
                                 <property name="label" translatable="yes">Use an external command for printing</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                             </child>
                           </object>
@@ -5639,27 +5554,27 @@
                         <child>
                           <object class="GtkFrame" id="frame31">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">none</property>
+                            <property name="can-focus">False</property>
+                            <property name="label-xalign">0</property>
+                            <property name="shadow-type">none</property>
                             <child>
                               <object class="GtkAlignment" id="alignment34">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="left_padding">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
                                 <child>
                                   <object class="GtkVBox" id="vbox29">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkCheckButton" id="check_print_linenumbers">
                                         <property name="label" translatable="yes">Print line numbers</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Add line numbers to the printed page</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Add line numbers to the printed page</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5671,11 +5586,11 @@
                                       <object class="GtkCheckButton" id="check_print_pagenumbers">
                                         <property name="label" translatable="yes">Print page numbers</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Add page numbers at the bottom of each page. It takes 2 lines of the page.</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Add page numbers at the bottom of each page. It takes 2 lines of the page.</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5687,11 +5602,11 @@
                                       <object class="GtkCheckButton" id="check_print_pageheader">
                                         <property name="label" translatable="yes">Print page header</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="tooltip_text" translatable="yes">Add a little header to every page containing the page number, the filename and the current date (see below). It takes 3 lines of the page.</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Add a little header to every page containing the page number, the filename and the current date (see below). It takes 3 lines of the page.</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5702,30 +5617,29 @@
                                     <child>
                                       <object class="GtkFrame" id="frame33">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label_xalign">0</property>
-                                        <property name="label_yalign">0</property>
-                                        <property name="shadow_type">none</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label-xalign">0</property>
+                                        <property name="label-yalign">0</property>
+                                        <property name="shadow-type">none</property>
                                         <child>
                                           <object class="GtkAlignment" id="alignment36">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="left_padding">12</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="left-padding">12</property>
                                             <child>
                                               <object class="GtkVBox" id="vbox30">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="spacing">1</property>
                                                 <child>
                                                   <object class="GtkCheckButton" id="check_print_basename">
                                                     <property name="label" translatable="yes">Use the basename of the printed file</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Print only the basename (without the path) of the printed file</property>
-                                                    <property name="use_underline">True</property>
-                                                    <property name="draw_indicator">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="tooltip-text" translatable="yes">Print only the basename (without the path) of the printed file</property>
+                                                    <property name="use-underline">True</property>
+                                                    <property name="draw-indicator">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -5736,14 +5650,14 @@
                                                 <child>
                                                   <object class="GtkHBox" id="hbox10">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="spacing">5</property>
                                                     <child>
                                                       <object class="GtkLabel" id="label203">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="label" translatable="yes">Date format:</property>
-                                                        <property name="mnemonic_widget">entry_print_dateformat</property>
+                                                        <property name="mnemonic-widget">entry_print_dateformat</property>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>
@@ -5754,13 +5668,11 @@
                                                     <child>
                                                       <object class="GtkEntry" id="entry_print_dateformat">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="tooltip_text" translatable="yes">Specify a format for the date and time stamp which is added to the page header on each page. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
-                                                        <property name="invisible_char">●</property>
-                                                        <property name="primary_icon_activatable">False</property>
-                                                        <property name="secondary_icon_activatable">False</property>
-                                                        <property name="primary_icon_sensitive">True</property>
-                                                        <property name="secondary_icon_sensitive">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="tooltip-text" translatable="yes">Specify a format for the date and time stamp which is added to the page header on each page. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
+                                                        <property name="invisible-char">●</property>
+                                                        <property name="primary-icon-activatable">False</property>
+                                                        <property name="secondary-icon-activatable">False</property>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">True</property>
@@ -5794,10 +5706,10 @@
                               <object class="GtkRadioButton" id="radio_print_gtk">
                                 <property name="label" translatable="yes">Use native GTK printing</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                                 <property name="group">radio_print_external</property>
                               </object>
                             </child>
@@ -5815,9 +5727,9 @@
                 <child type="label">
                   <object class="GtkLabel" id="label243">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Printing&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                 </child>
               </object>
@@ -5828,221 +5740,213 @@
             <child type="tab">
               <object class="GtkLabel" id="label201">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Printing</property>
               </object>
               <packing>
                 <property name="position">7</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkFrame" id="frame_term">
-                <property name="can_focus">False</property>
-                <property name="border_width">6</property>
-                <property name="label_xalign">0</property>
-                <property name="shadow_type">none</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">6</property>
+                <property name="label-xalign">0</property>
+                <property name="shadow-type">none</property>
                 <child>
                   <object class="GtkAlignment" id="alignment1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="left-padding">12</property>
                     <child>
                       <object class="GtkVBox" id="vbox_terminal">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">12</property>
                         <child>
                           <object class="GtkTable" id="table_terminal1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="n_rows">5</property>
-                            <property name="n_columns">3</property>
-                            <property name="column_spacing">6</property>
-                            <property name="row_spacing">6</property>
+                            <property name="can-focus">False</property>
+                            <property name="n-rows">5</property>
+                            <property name="n-columns">3</property>
+                            <property name="column-spacing">6</property>
+                            <property name="row-spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="terminal_font_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Font:</property>
-                                <property name="mnemonic_widget">font_term</property>
+                                <property name="mnemonic-widget">font_term</property>
                               </object>
                               <packing>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkFontButton" id="font_term">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes">Sets the font for the terminal widget</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes">Sets the font for the terminal widget</property>
+                                <property name="font">Sans 12</property>
                                 <property name="title" translatable="yes">Choose Terminal Font</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">3</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">3</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="terminal_fg_color_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Foreground color:</property>
-                                <property name="mnemonic_widget">color_fore</property>
+                                <property name="mnemonic-widget">color_fore</property>
                               </object>
                               <packing>
-                                <property name="top_attach">1</property>
-                                <property name="bottom_attach">2</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="top-attach">1</property>
+                                <property name="bottom-attach">2</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="terminal_bg_color_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Background color:</property>
-                                <property name="mnemonic_widget">color_back</property>
+                                <property name="mnemonic-widget">color_back</property>
                               </object>
                               <packing>
-                                <property name="top_attach">2</property>
-                                <property name="bottom_attach">3</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="top-attach">2</property>
+                                <property name="bottom-attach">3</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="terminal_scrollback_lines_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Scrollback lines:</property>
-                                <property name="mnemonic_widget">spin_scrollback</property>
+                                <property name="mnemonic-widget">spin_scrollback</property>
                               </object>
                               <packing>
-                                <property name="top_attach">3</property>
-                                <property name="bottom_attach">4</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="top-attach">3</property>
+                                <property name="bottom-attach">4</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="terminal_shell_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Shell:</property>
-                                <property name="mnemonic_widget">entry_shell</property>
+                                <property name="mnemonic-widget">entry_shell</property>
                               </object>
                               <packing>
-                                <property name="top_attach">4</property>
-                                <property name="bottom_attach">5</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="top-attach">4</property>
+                                <property name="bottom-attach">5</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkColorButton" id="color_fore">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes">Sets the foreground color of the text in the terminal widget</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes">Sets the foreground color of the text in the terminal widget</property>
                                 <property name="title" translatable="yes">Color Chooser</property>
                                 <property name="color">#000000000000</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">3</property>
-                                <property name="top_attach">1</property>
-                                <property name="bottom_attach">2</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">3</property>
+                                <property name="top-attach">1</property>
+                                <property name="bottom-attach">2</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkColorButton" id="color_back">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes">Sets the background color of the text in the terminal widget</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="tooltip-text" translatable="yes">Sets the background color of the text in the terminal widget</property>
                                 <property name="title" translatable="yes">Color Chooser</property>
                                 <property name="color">#000000000000</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">3</property>
-                                <property name="top_attach">2</property>
-                                <property name="bottom_attach">3</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">3</property>
+                                <property name="top-attach">2</property>
+                                <property name="bottom-attach">3</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkSpinButton" id="spin_scrollback">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="tooltip_text" translatable="yes">Specifies the history in lines, which you can scroll back in the terminal widget</property>
-                                <property name="invisible_char">•</property>
-                                <property name="primary_icon_activatable">False</property>
-                                <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="tooltip-text" translatable="yes">Specifies the history in lines, which you can scroll back in the terminal widget</property>
+                                <property name="invisible-char">•</property>
+                                <property name="primary-icon-activatable">False</property>
+                                <property name="secondary-icon-activatable">False</property>
                                 <property name="adjustment">adjustment12</property>
                                 <property name="numeric">True</property>
                                 <property name="wrap">True</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">3</property>
-                                <property name="top_attach">3</property>
-                                <property name="bottom_attach">4</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">3</property>
+                                <property name="top-attach">3</property>
+                                <property name="bottom-attach">4</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkEntry" id="entry_shell">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="tooltip_text" translatable="yes">Sets the path to the shell which should be started inside the terminal emulation</property>
-                                <property name="invisible_char">•</property>
-                                <property name="primary_icon_activatable">False</property>
-                                <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="tooltip-text" translatable="yes">Sets the path to the shell which should be started inside the terminal emulation</property>
+                                <property name="invisible-char">•</property>
+                                <property name="primary-icon-activatable">False</property>
+                                <property name="secondary-icon-activatable">False</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="top_attach">4</property>
-                                <property name="bottom_attach">5</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="top-attach">4</property>
+                                <property name="bottom-attach">5</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkButton" id="button_term_shell">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
                                 <child>
                                   <object class="GtkImage" id="image1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="stock">gtk-open</property>
-                                    <property name="icon-size">1</property>
+                                    <property name="icon_size">1</property>
                                   </object>
                                 </child>
                               </object>
                               <packing>
-                                <property name="left_attach">2</property>
-                                <property name="right_attach">3</property>
-                                <property name="top_attach">4</property>
-                                <property name="bottom_attach">5</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options">GTK_FILL</property>
+                                <property name="left-attach">2</property>
+                                <property name="right-attach">3</property>
+                                <property name="top-attach">4</property>
+                                <property name="bottom-attach">5</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options">GTK_FILL</property>
                               </packing>
                             </child>
                           </object>
@@ -6055,15 +5959,15 @@
                         <child>
                           <object class="GtkVBox" id="vbox16">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkCheckButton" id="check_scroll_key">
                                 <property name="label" translatable="yes">Scroll on keystroke</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Whether to scroll to the bottom if a key was pressed</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Whether to scroll to the bottom if a key was pressed</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -6075,10 +5979,10 @@
                               <object class="GtkCheckButton" id="check_scroll_out">
                                 <property name="label" translatable="yes">Scroll on output</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Whether to scroll to the bottom when output is generated</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Whether to scroll to the bottom when output is generated</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -6090,10 +5994,10 @@
                               <object class="GtkCheckButton" id="check_cursor_blinks">
                                 <property name="label" translatable="yes">Cursor blinks</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Whether to blink the cursor</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Whether to blink the cursor</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -6105,10 +6009,10 @@
                               <object class="GtkCheckButton" id="check_enable_bash_keys">
                                 <property name="label" translatable="yes">Override Geany keybindings</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Allows the VTE to receive keyboard shortcuts (apart from focus commands)</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Allows the VTE to receive keyboard shortcuts (apart from focus commands)</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -6120,10 +6024,10 @@
                               <object class="GtkCheckButton" id="check_ignore_menu_key">
                                 <property name="label" translatable="yes">Disable menu shortcut key (F10 by default)</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">This option disables the keybinding to popup the menu bar (default is F10). Disabling it can be useful if you use, for example, Midnight Commander within the VTE.</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">This option disables the keybinding to popup the menu bar (default is F10). Disabling it can be useful if you use, for example, Midnight Commander within the VTE.</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -6135,10 +6039,10 @@
                               <object class="GtkCheckButton" id="check_follow_path">
                                 <property name="label" translatable="yes">Follow path of the current file</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Whether to execute "cd $path" when you switch between opened files</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Whether to execute "cd $path" when you switch between opened files</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -6150,10 +6054,10 @@
                               <object class="GtkCheckButton" id="check_run_in_vte">
                                 <property name="label" translatable="yes">Execute programs in the VTE</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Run programs in VTE instead of opening a terminal emulation window. Please note, programs executed in VTE cannot be stopped</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Run programs in VTE instead of opening a terminal emulation window. Please note, programs executed in VTE cannot be stopped</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -6166,10 +6070,10 @@
                                 <property name="label" translatable="yes">Don't use run script</property>
                                 <property name="visible">True</property>
                                 <property name="sensitive">False</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Don't use the simple run script which is usually used to display the exit status of the executed program</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Don't use the simple run script which is usually used to display the exit status of the executed program</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -6191,9 +6095,9 @@
                 <child type="label">
                   <object class="GtkLabel" id="label2">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Terminal&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                 </child>
               </object>
@@ -6204,35 +6108,35 @@
             <child type="tab">
               <object class="GtkLabel" id="label138">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Terminal</property>
               </object>
               <packing>
                 <property name="position">8</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkFrame" id="frame24">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">5</property>
-                <property name="label_xalign">0</property>
-                <property name="shadow_type">none</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
+                <property name="label-xalign">0</property>
+                <property name="shadow-type">none</property>
                 <child>
                   <object class="GtkAlignment" id="alignment14">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="left_padding">12</property>
+                    <property name="can-focus">False</property>
+                    <property name="left-padding">12</property>
                     <child>
                       <object class="GtkVBox" id="vbox50">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">5</property>
                         <child>
                           <object class="GtkVBox" id="vbox51">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <placeholder/>
                             </child>
@@ -6246,15 +6150,16 @@
                         <child>
                           <object class="GtkScrolledWindow" id="scrolledwindow9">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">automatic</property>
-                            <property name="vscrollbar_policy">automatic</property>
-                            <property name="shadow_type">in</property>
+                            <property name="can-focus">True</property>
+                            <property name="shadow-type">in</property>
                             <child>
                               <object class="GtkTreeView" id="various_treeview">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="rules_hint">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="rules-hint">True</property>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection"/>
+                                </child>
                               </object>
                             </child>
                           </object>
@@ -6267,7 +6172,7 @@
                         <child>
                           <object class="GtkVBox" id="vbox28">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <placeholder/>
                             </child>
@@ -6281,20 +6186,19 @@
                         <child>
                           <object class="GtkAlignment" id="alignment16">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="bottom_padding">5</property>
+                            <property name="can-focus">False</property>
+                            <property name="bottom-padding">5</property>
                             <child>
                               <object class="GtkHBox" id="hbox15">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">5</property>
                                 <child>
                                   <object class="GtkLabel" id="label140">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">&lt;i&gt;Warning: read the manual before changing these preferences.&lt;/i&gt;</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -6318,9 +6222,9 @@
                 <child type="label">
                   <object class="GtkLabel" id="label139">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Various preferences&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                 </child>
               </object>
@@ -6331,12 +6235,12 @@
             <child type="tab">
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Various</property>
               </object>
               <packing>
                 <property name="position">9</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>
@@ -6358,43 +6262,43 @@
   </object>
   <object class="GtkTextBuffer" id="textbuffer1"/>
   <object class="GtkWindow" id="window1">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Geany</property>
-    <property name="icon_name">geany</property>
+    <property name="icon-name">geany</property>
     <accel-groups>
       <group name="accelgroup1"/>
     </accel-groups>
-    <signal name="window-state-event" handler="on_window_state_event" swapped="no"/>
     <signal name="delete-event" handler="on_window_delete_event" swapped="no"/>
+    <signal name="window-state-event" handler="on_window_state_event" swapped="no"/>
     <child>
       <object class="GtkVBox" id="vbox1">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkHBox" id="hbox_menubar">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkMenuBar" id="menubar1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <child>
                   <object class="GtkMenuItem" id="file1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_File</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <signal name="activate" handler="on_file1_activate" swapped="no"/>
                     <child type="submenu">
                       <object class="GtkMenu" id="file1_menu">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_new1">
                             <property name="label">gtk-new</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_new1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6402,59 +6306,59 @@
                           <object class="GtkImageMenuItem" id="menu_new_with_template1">
                             <property name="label" translatable="yes">New (with _Template)</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4056</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator12">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_open1">
                             <property name="label" translatable="yes">_Open...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image3</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_open1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menu_open_selected_file1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Open Selected F_ile</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_menu_open_selected_file1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="recent_files1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Recent _Files</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator13">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_save1">
                             <property name="label">gtk-save</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_save1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6462,10 +6366,10 @@
                           <object class="GtkImageMenuItem" id="menu_save_as1">
                             <property name="label" translatable="yes">Save _As...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_save_as1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6473,10 +6377,10 @@
                           <object class="GtkImageMenuItem" id="menu_save_all1">
                             <property name="label" translatable="yes">Sa_ve All</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4057</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_save_all1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6484,10 +6388,10 @@
                           <object class="GtkImageMenuItem" id="menu_reload1">
                             <property name="label" translatable="yes">_Reload</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4058</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_toolbutton_reload_clicked" swapped="no"/>
                           </object>
                         </child>
@@ -6495,18 +6399,18 @@
                           <object class="GtkImageMenuItem" id="menu_reload_as1">
                             <property name="label" translatable="yes">R_eload As</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4059</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="menu_reload_as1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="invisible7">
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">invisible</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -6516,31 +6420,31 @@
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator21">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="properties1">
                             <property name="label">gtk-properties</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_file_properties_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator24">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="page_setup1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Page Set_up</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_page_setup1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6548,26 +6452,26 @@
                           <object class="GtkImageMenuItem" id="print1">
                             <property name="label" translatable="yes">_Print...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image5</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_print1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator14">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_close1">
                             <property name="label">gtk-close</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_close1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6575,10 +6479,10 @@
                           <object class="GtkImageMenuItem" id="close_other_documents1">
                             <property name="label" translatable="yes">Close Ot_her Documents</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4060</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_close_other_documents1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6586,26 +6490,26 @@
                           <object class="GtkImageMenuItem" id="menu_close_all1">
                             <property name="label" translatable="yes">C_lose All</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4061</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_close_all1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="menu_separatormenuitem1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_quit1">
                             <property name="label">gtk-quit</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_quit1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6616,21 +6520,21 @@
                 <child>
                   <object class="GtkMenuItem" id="edit1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Edit</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <signal name="deselect" handler="on_edit1_deselect" swapped="no"/>
                     <signal name="select" handler="on_edit1_select" swapped="no"/>
                     <child type="submenu">
                       <object class="GtkMenu" id="edit1_menu">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_undo2">
                             <property name="label">gtk-undo</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_undo1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6638,25 +6542,25 @@
                           <object class="GtkImageMenuItem" id="menu_redo2">
                             <property name="label">gtk-redo</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_redo1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="menu_seperator1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_cut1">
                             <property name="label">gtk-cut</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_cut1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6664,9 +6568,9 @@
                           <object class="GtkImageMenuItem" id="menu_copy1">
                             <property name="label">gtk-copy</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_copy1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6674,9 +6578,9 @@
                           <object class="GtkImageMenuItem" id="menu_paste1">
                             <property name="label">gtk-paste</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_paste1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -6684,51 +6588,51 @@
                           <object class="GtkImageMenuItem" id="menu_delete1">
                             <property name="label">gtk-delete</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_delete1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="menu_seperator2">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_select_all1">
                             <property name="label">gtk-select-all</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_menu_select_all1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator25">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="commands2">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Co_mmands</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="commands2_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkImageMenuItem" id="cut_current_lines1">
                                     <property name="label" translatable="yes">Cu_t Current Line(s)</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="image">image4062</property>
-                                    <property name="use_stock">False</property>
+                                    <property name="use-stock">False</property>
                                     <signal name="activate" handler="on_cut_current_lines1_activate" swapped="no"/>
                                   </object>
                                 </child>
@@ -6736,91 +6640,91 @@
                                   <object class="GtkImageMenuItem" id="copy_current_lines1">
                                     <property name="label" translatable="yes">_Copy Current Line(s)</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="image">image4063</property>
-                                    <property name="use_stock">False</property>
+                                    <property name="use-stock">False</property>
                                     <signal name="activate" handler="on_copy_current_lines1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="delete_current_lines1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Delete Current Line(s)</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_delete_current_lines1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="duplicate_line_or_selection1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">D_uplicate Line or Selection</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_duplicate_line_or_selection1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator49">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="select_current_lines1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">S_elect Current Line(s)</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_select_current_lines1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="select_current_paragraph1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Se_lect Current Paragraph</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_select_current_paragraph1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator63">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="move_lines_up1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Move Line(s) Up</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_move_lines_up1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="move_lines_down1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">M_ove Line(s) Down</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_move_lines_down1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator52">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="send_selection_to_vte1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Send Selection to Terminal</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_send_selection_to_vte1_activate" swapped="no"/>
                                   </object>
                                 </child>
@@ -6831,77 +6735,77 @@
                         <child>
                           <object class="GtkMenuItem" id="menu_format1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Format</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="menu_format1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="reflow_lines_block1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Reflow Lines/Block</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_reflow_lines_block1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="menu_toggle_case2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">T_oggle Case of Selection</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_toggle_case1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator28">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="menu_comment_line1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Comment Line(s)</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_menu_comment_line1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="menu_uncomment_line1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">U_ncomment Line(s)</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_menu_uncomment_line1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="menu_toggle_line_commentation1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Toggle Line Commentation</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_menu_toggle_line_commentation1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator29">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkImageMenuItem" id="menu_increase_indent1">
                                     <property name="label" translatable="yes">_Increase Indent</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="image">image4064</property>
-                                    <property name="use_stock">False</property>
+                                    <property name="use-stock">False</property>
                                     <signal name="activate" handler="on_menu_increase_indent1_activate" swapped="no"/>
                                   </object>
                                 </child>
@@ -6909,42 +6813,42 @@
                                   <object class="GtkImageMenuItem" id="menu_decrease_indent1">
                                     <property name="label" translatable="yes">_Decrease Indent</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="use-underline">True</property>
                                     <property name="image">image4065</property>
-                                    <property name="use_stock">False</property>
+                                    <property name="use-stock">False</property>
                                     <signal name="activate" handler="on_menu_decrease_indent1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="smart_line_indent1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">S_mart Line Indent</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_smart_line_indent1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator37">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="send_selection_to2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Send Selection to</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <child type="submenu">
                                       <object class="GtkMenu" id="send_selection_to2_menu">
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkMenuItem" id="invisible13">
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">invisible</property>
-                                            <property name="use_underline">True</property>
+                                            <property name="use-underline">True</property>
                                           </object>
                                         </child>
                                       </object>
@@ -6958,77 +6862,77 @@
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator18">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="add_comments1">
                             <property name="label" translatable="yes">I_nsert Comments</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4066</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="add_comments1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="menu_add_changelog_entry1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Insert _ChangeLog Entry</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_comments_changelog_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="insert_function_description2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Insert _Function Description</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_comments_function_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="insert_multiline_comment2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Insert Mu_ltiline Comment</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_menu_comments_multiline_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator58">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="insert_file_header1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Insert File _Header</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_comments_fileheader_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="insert_gpl_notice2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Insert _GPL Notice</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_menu_comments_gpl_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="insert_bsd_license_notice2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Insert _BSD License Notice</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_menu_comments_bsd_activate" swapped="no"/>
                                   </object>
                                 </child>
@@ -7040,18 +6944,18 @@
                           <object class="GtkImageMenuItem" id="insert_date1">
                             <property name="label" translatable="yes">Insert Dat_e</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4067</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="insert_date1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="invisible8">
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">invisible</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -7062,18 +6966,18 @@
                           <object class="GtkImageMenuItem" id="insert_include2">
                             <property name="label" translatable="yes">_Insert "include &lt;...&gt;"</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4068</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="insert_include2_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="invisible4">
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">invisible</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -7083,26 +6987,26 @@
                         <child>
                           <object class="GtkMenuItem" id="insert_alternative_white_space1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Insert Alternative _White Space</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_insert_alternative_white_space1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator9">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="preferences1">
                             <property name="label" translatable="yes">Preference_s</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4069</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_preferences1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7110,10 +7014,10 @@
                           <object class="GtkImageMenuItem" id="plugin_preferences1">
                             <property name="label" translatable="yes">P_lugin Preferences</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4070</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_plugin_preferences1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7124,56 +7028,56 @@
                 <child>
                   <object class="GtkMenuItem" id="search1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Search</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <signal name="activate" handler="on_search1_activate" swapped="no"/>
                     <child type="submenu">
                       <object class="GtkMenu" id="search1_menu">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="find1">
                             <property name="label" translatable="yes">_Find...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image6</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_find1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="find_next1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Find _Next</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_find_next1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="find_previous1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Find _Previous</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_find_previous1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator54">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="find_in_files1">
                             <property name="label" translatable="yes">Find in F_iles...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4071</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_find_in_files1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7181,27 +7085,27 @@
                           <object class="GtkImageMenuItem" id="replace1">
                             <property name="label" translatable="yes">_Replace...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4072</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_replace1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator35">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="next_message1">
                             <property name="label" translatable="yes">Next Me_ssage</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4073</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_next_message1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7209,141 +7113,141 @@
                           <object class="GtkImageMenuItem" id="previous_message1">
                             <property name="label" translatable="yes">Pr_evious Message</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4074</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_previous_message1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator51">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="go_to_next_marker1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Go to Ne_xt Marker</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_go_to_next_marker1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="go_to_previous_marker1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Go to Pre_vious Marker</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_go_to_previous_marker1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator32">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="go_to_line1">
                             <property name="label" translatable="yes">_Go to Line...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4075</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_go_to_line_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="more1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_More</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="more1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="find_nextsel1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Find Next _Selection</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_find_nextsel1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="find_prevsel1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Find Pre_vious Selection</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_find_prevsel1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator33">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="find_usage1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Find _Usage</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_find_usage1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="find_document_usage1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Find _Document Usage</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_find_document_usage1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator55">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="mark_all1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Mark All</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_mark_all1_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator60">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="goto_tag_definition1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Go to Symbol Defini_tion</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_goto_tag_definition1" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="goto_tag_declaration1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Go to Symbol Decl_aration</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_goto_tag_declaration1" swapped="no"/>
                                   </object>
                                 </child>
@@ -7358,20 +7262,20 @@
                 <child>
                   <object class="GtkMenuItem" id="menu_view1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_View</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu_view1_menu">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_change_font1">
                             <property name="label" translatable="yes">Change _Font...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4076</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_change_font1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7379,25 +7283,25 @@
                           <object class="GtkImageMenuItem" id="menu_color_schemes">
                             <property name="label" translatable="yes">Change _Color Scheme...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image2</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_menu_color_schemes_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separatormenuitem1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_markers_margin1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Show _Markers Margin</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <property name="active">True</property>
                             <signal name="toggled" handler="on_markers_margin1_toggled" swapped="no"/>
                           </object>
@@ -7405,9 +7309,9 @@
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_linenumber_margin1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Show _Line Numbers</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <property name="active">True</property>
                             <signal name="toggled" handler="on_show_line_numbers1_toggled" swapped="no"/>
                           </object>
@@ -7415,60 +7319,60 @@
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_show_white_space1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Show White S_pace</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="toggled" handler="on_menu_show_white_space1_toggled" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_show_line_endings1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Show Line _Endings</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="toggled" handler="on_menu_show_line_endings1_toggled" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_show_indentation_guides1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Show Indentation _Guides</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="toggled" handler="on_menu_show_indentation_guides1_toggled" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="menu_separator4">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_fullscreen1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Full_screen</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="toggled" handler="on_fullscreen1_toggled" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menu_toggle_all_additional_widgets1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Toggle All _Additional Widgets</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_menu_toggle_all_additional_widgets1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_show_messages_window1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Show Message _Window</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <property name="active">True</property>
                             <signal name="toggled" handler="on_show_messages_window1_toggled" swapped="no"/>
                           </object>
@@ -7476,9 +7380,9 @@
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_show_toolbar1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Show _Toolbar</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <property name="active">True</property>
                             <signal name="toggled" handler="on_show_toolbar1_toggled" swapped="no"/>
                           </object>
@@ -7486,9 +7390,9 @@
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_show_sidebar1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Show Side_bar</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <property name="active">True</property>
                             <signal name="toggled" handler="on_menu_show_sidebar1_toggled" swapped="no"/>
                           </object>
@@ -7496,16 +7400,16 @@
                         <child>
                           <object class="GtkSeparatorMenuItem" id="menu_separator5">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_zoom_in1">
                             <property name="label">gtk-zoom-in</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_zoom_in1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7513,9 +7417,9 @@
                           <object class="GtkImageMenuItem" id="menu_zoom_out1">
                             <property name="label">gtk-zoom-out</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_zoom_out1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7523,9 +7427,9 @@
                           <object class="GtkImageMenuItem" id="normal_size1">
                             <property name="label">gtk-zoom-100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_normal_size1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7536,18 +7440,18 @@
                 <child>
                   <object class="GtkMenuItem" id="menu_document1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Document</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu_document1_menu">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_line_wrapping1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Line Wrapping</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <property name="active">True</property>
                             <signal name="toggled" handler="on_line_wrapping1_toggled" swapped="no"/>
                           </object>
@@ -7555,18 +7459,18 @@
                         <child>
                           <object class="GtkCheckMenuItem" id="line_breaking1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Line _Breaking</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="toggled" handler="on_line_breaking1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_use_auto_indentation1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Auto-indentation</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <property name="active">True</property>
                             <signal name="toggled" handler="on_use_auto_indentation1_toggled" swapped="no"/>
                           </object>
@@ -7574,33 +7478,33 @@
                         <child>
                           <object class="GtkMenuItem" id="indent_type1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">In_dent Type</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="indent_type1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="detect_type_from_file">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Detect from Content</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_detect_type_from_file_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator61">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkRadioMenuItem" id="tabs1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Tabs</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
                                     <signal name="activate" handler="on_tabs1_activate" swapped="no"/>
                                   </object>
@@ -7608,9 +7512,9 @@
                                 <child>
                                   <object class="GtkRadioMenuItem" id="spaces1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Spaces</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="group">tabs1</property>
                                     <signal name="activate" handler="on_spaces1_activate" swapped="no"/>
                                   </object>
@@ -7618,9 +7522,9 @@
                                 <child>
                                   <object class="GtkRadioMenuItem" id="tabs_and_spaces1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">T_abs and Spaces</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="group">tabs1</property>
                                     <signal name="activate" handler="on_tabs_and_spaces1_activate" swapped="no"/>
                                   </object>
@@ -7632,42 +7536,42 @@
                         <child>
                           <object class="GtkMenuItem" id="indent_width1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Indent Widt_h</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="indent_width1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="detect_width_from_file">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_Detect from Content</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_detect_width_from_file_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separator62">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkRadioMenuItem" id="indent_width_1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_1</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_indent_width_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkRadioMenuItem" id="indent_width_2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_2</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="group">indent_width_1</property>
                                     <signal name="activate" handler="on_indent_width_activate" swapped="no"/>
                                   </object>
@@ -7675,9 +7579,9 @@
                                 <child>
                                   <object class="GtkRadioMenuItem" id="indent_width_3">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_3</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="group">indent_width_1</property>
                                     <signal name="activate" handler="on_indent_width_activate" swapped="no"/>
                                   </object>
@@ -7685,9 +7589,9 @@
                                 <child>
                                   <object class="GtkRadioMenuItem" id="indent_width_4">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_4</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
                                     <property name="group">indent_width_1</property>
                                     <signal name="activate" handler="on_indent_width_activate" swapped="no"/>
@@ -7696,9 +7600,9 @@
                                 <child>
                                   <object class="GtkRadioMenuItem" id="indent_width_5">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_5</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="group">indent_width_1</property>
                                     <signal name="activate" handler="on_indent_width_activate" swapped="no"/>
                                   </object>
@@ -7706,9 +7610,9 @@
                                 <child>
                                   <object class="GtkRadioMenuItem" id="indent_width_6">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_6</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="group">indent_width_1</property>
                                     <signal name="activate" handler="on_indent_width_activate" swapped="no"/>
                                   </object>
@@ -7716,9 +7620,9 @@
                                 <child>
                                   <object class="GtkRadioMenuItem" id="indent_width_7">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_7</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="group">indent_width_1</property>
                                     <signal name="activate" handler="on_indent_width_activate" swapped="no"/>
                                   </object>
@@ -7726,9 +7630,9 @@
                                 <child>
                                   <object class="GtkRadioMenuItem" id="indent_width_8">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">_8</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="group">indent_width_1</property>
                                     <signal name="activate" handler="on_indent_width_activate" swapped="no"/>
                                   </object>
@@ -7740,47 +7644,47 @@
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator45">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="set_file_readonly1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Read _Only</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="toggled" handler="on_set_file_readonly1_toggled" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menu_write_unicode_bom1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Write Unicode BOM</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="toggled" handler="on_menu_write_unicode_bom1_toggled" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator46">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="set_filetype1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Set File_type</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="set_filetype1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="invisible1">
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">invisible</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -7790,17 +7694,17 @@
                         <child>
                           <object class="GtkMenuItem" id="set_encoding1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Set _Encoding</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="set_encoding1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="invisible6">
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">invisible</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -7810,27 +7714,27 @@
                         <child>
                           <object class="GtkMenuItem" id="menu_line_endings1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Set Line E_ndings</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="menu_line_endings1_menu">
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkRadioMenuItem" id="crlf">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Convert and Set to _CR/LF (Windows)</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="activate" handler="on_crlf_activate" swapped="no"/>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkRadioMenuItem" id="lf">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Convert and Set to _LF (Unix)</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="active">True</property>
                                     <property name="group">crlf</property>
                                     <signal name="activate" handler="on_lf_activate" swapped="no"/>
@@ -7839,9 +7743,9 @@
                                 <child>
                                   <object class="GtkRadioMenuItem" id="cr">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Convert and Set to CR (Classic _Mac)</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <property name="group">crlf</property>
                                     <signal name="activate" handler="on_cr_activate" swapped="no"/>
                                   </object>
@@ -7853,90 +7757,90 @@
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator8">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="clone1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Clone</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_clone1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="strip_trailing_spaces1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Strip Trailing Spaces</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_strip_trailing_spaces1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menu_replace_tabs">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Replace Tabs with S_paces</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_replace_tabs_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menu_replace_spaces">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Replace Spaces with Tabs...</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_replace_spaces_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator22">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menu_fold_all1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Fold All</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_menu_fold_all1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menu_unfold_all1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Unfold All</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_menu_unfold_all1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator23">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="remove_markers1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Remove _Markers</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_remove_markers1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menu_remove_indicators1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Remove Error _Indicators</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_menu_remove_indicators1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7947,21 +7851,21 @@
                 <child>
                   <object class="GtkMenuItem" id="menu_project1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Project</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <signal name="activate" handler="on_menu_project1_activate" swapped="no"/>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu_project1_menu">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="project_new1">
                             <property name="label" translatable="yes">_New...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4077</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_project_new1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -7969,61 +7873,61 @@
                           <object class="GtkImageMenuItem" id="project_open1">
                             <property name="label" translatable="yes">_Open...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4078</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_project_open1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="recent_projects1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Recent Projects</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="project_close1">
                             <property name="label" translatable="yes">_Close</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4079</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_project_close1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator34">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="reset_indentation1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">Apply the default indentation settings to all documents</property>
+                            <property name="can-focus">False</property>
+                            <property name="tooltip-text" translatable="yes">Apply the default indentation settings to all documents</property>
                             <property name="label" translatable="yes">_Apply Default Indentation</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_reset_indentation1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator59">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="project_properties1">
                             <property name="label">gtk-properties</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_project_properties1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -8034,28 +7938,28 @@
                 <child>
                   <object class="GtkMenuItem" id="menu_build1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Build</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                   </object>
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="tools1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Tools</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="tools1_menu">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_reload_configuration1">
                             <property name="label" translatable="yes">_Reload Configuration</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4080</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_menu_reload_configuration1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -8063,44 +7967,44 @@
                           <object class="GtkImageMenuItem" id="configuration_files1">
                             <property name="label" translatable="yes">C_onfiguration Files</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4081</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator47">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_choose_color1">
                             <property name="label" translatable="yes">_Color Chooser</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4082</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_show_color_chooser1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menu_count_words1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Word Count</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_count_words1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="load_tags1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Load Ta_gs File...</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_load_tags1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -8111,96 +8015,96 @@
                 <child>
                   <object class="GtkMenuItem" id="menu_help1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Help</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menu_help1_menu">
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="help1">
                             <property name="label" translatable="yes">_Help</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image4083</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_help1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="keyboard_shortcuts1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Keyboard _Shortcuts</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_help_shortcuts1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="debug_messages1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Debug _Messages</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_debug_messages1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="help_menu_sep1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="website1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Website</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_website1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="help_menu_item_wiki">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Wi_ki</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_help_menu_item_wiki_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="help_menu_item_bug_report">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Report a _Bug...</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_help_menu_item_bug_report_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="help_menu_item_donate">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">_Donate...</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
                             <signal name="activate" handler="on_help_menu_item_donate_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>
                           <object class="GtkSeparatorMenuItem" id="separator16">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menu_info1">
                             <property name="label">gtk-about</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
-                            <property name="use_stock">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <property name="use-stock">True</property>
                             <signal name="activate" handler="on_info1_activate" swapped="no"/>
                           </object>
                         </child>
@@ -8228,33 +8132,34 @@
         <child>
           <object class="GtkVPaned" id="vpaned1">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
             <property name="position">400</property>
             <child>
               <object class="GtkHPaned" id="hpaned1">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="position">167</property>
                 <child>
                   <object class="GtkNotebook" id="notebook3">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="scrollable">True</property>
-                    <property name="enable_popup">True</property>
+                    <property name="enable-popup">True</property>
                     <signal name="key-press-event" handler="on_escape_key_press_event" swapped="no"/>
                     <signal name="switch-page" handler="on_tv_notebook_switch_page" swapped="no"/>
                     <signal name="switch-page" handler="on_tv_notebook_switch_page_after" after="yes" swapped="no"/>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow2">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="hscrollbar_policy">automatic</property>
-                        <property name="vscrollbar_policy">automatic</property>
+                        <property name="can-focus">True</property>
                         <child>
                           <object class="GtkTreeView" id="treeview2">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="enable_search">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="enable-search">False</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
+                            </child>
                           </object>
                         </child>
                       </object>
@@ -8262,21 +8167,24 @@
                     <child type="tab">
                       <object class="GtkLabel" id="label135">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Symbols</property>
                       </object>
                       <packing>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow7">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <child>
                           <object class="GtkTreeView" id="treeview6">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="can-focus">True</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
+                            </child>
                           </object>
                         </child>
                       </object>
@@ -8287,12 +8195,12 @@
                     <child type="tab">
                       <object class="GtkLabel" id="label136">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Documents</property>
                       </object>
                       <packing>
                         <property name="position">1</property>
-                        <property name="tab_fill">False</property>
+                        <property name="tab-fill">False</property>
                       </packing>
                     </child>
                   </object>
@@ -8304,7 +8212,7 @@
                 <child>
                   <object class="GtkNotebook" id="notebook1">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="scrollable">True</property>
                     <signal name="switch-page" handler="on_notebook1_switch_page_after" after="yes" swapped="no"/>
                   </object>
@@ -8322,22 +8230,23 @@
             <child>
               <object class="GtkNotebook" id="notebook_info">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tab_pos">left</property>
+                <property name="can-focus">True</property>
+                <property name="tab-pos">left</property>
                 <property name="scrollable">True</property>
-                <property name="enable_popup">True</property>
+                <property name="enable-popup">True</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow4">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkTreeView" id="treeview3">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="headers_visible">False</property>
-                        <property name="rules_hint">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <property name="rules-hint">True</property>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -8345,24 +8254,25 @@
                 <child type="tab">
                   <object class="GtkLabel" id="notebook_info_label_status">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Status</property>
                   </object>
                   <packing>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow3">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkTreeView" id="treeview5">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="headers_visible">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -8373,26 +8283,27 @@
                 <child type="tab">
                   <object class="GtkLabel" id="notebook_info_label_compiler">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Compiler</property>
                   </object>
                   <packing>
                     <property name="position">1</property>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow5">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkTreeView" id="treeview4">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="headers_visible">False</property>
-                        <property name="rules_hint">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <property name="rules-hint">True</property>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -8403,24 +8314,22 @@
                 <child type="tab">
                   <object class="GtkLabel" id="notebook_info_label_msg">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Messages</property>
                   </object>
                   <packing>
                     <property name="position">2</property>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow6">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkTextView" id="textview_scribble">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="buffer">textbuffer1</property>
                         <signal name="motion-notify-event" handler="on_motion_event" swapped="no"/>
                       </object>
@@ -8433,12 +8342,12 @@
                 <child type="tab">
                   <object class="GtkLabel" id="notebook_info_label_scribble">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Scribble</property>
                   </object>
                   <packing>
                     <property name="position">3</property>
-                    <property name="tab_fill">False</property>
+                    <property name="tab-fill">False</property>
                   </packing>
                 </child>
               </object>
@@ -8457,11 +8366,11 @@
         <child>
           <object class="GtkHBox" id="hbox1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkStatusbar" id="statusbar">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -8480,29 +8389,29 @@
     </child>
   </object>
   <object class="GtkDialog" id="project_dialog">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Project Properties</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon_name">geany</property>
-    <property name="type_hint">dialog</property>
-    <property name="transient_for">window1</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="icon-name">geany</property>
+    <property name="type-hint">dialog</property>
+    <property name="transient-for">window1</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="project_dialog_vbox">
+      <object class="GtkBox" id="project_dialog_vbox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area4">
+          <object class="GtkButtonBox" id="dialog-action_area4">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="cancelbutton1">
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -8514,10 +8423,10 @@
               <object class="GtkButton" id="okbutton1">
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -8529,199 +8438,181 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkNotebook" id="project_notebook">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="border_width">6</property>
+            <property name="can-focus">True</property>
+            <property name="border-width">6</property>
             <child>
               <object class="GtkTable" id="table_project_dialog_project">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">6</property>
-                <property name="n_rows">5</property>
-                <property name="n_columns">2</property>
-                <property name="column_spacing">6</property>
-                <property name="row_spacing">6</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">6</property>
+                <property name="n-rows">5</property>
+                <property name="n-columns">2</property>
+                <property name="column-spacing">6</property>
+                <property name="row-spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label_project_dialog_filename0">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Filename:</property>
-                    <property name="mnemonic_widget">label_project_dialog_filename</property>
+                    <property name="mnemonic-widget">label_project_dialog_filename</property>
                   </object>
                   <packing>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label_project_dialog_name">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Name:</property>
-                    <property name="use_underline">True</property>
-                    <property name="mnemonic_widget">entry_project_dialog_name</property>
+                    <property name="use-underline">True</property>
+                    <property name="mnemonic-widget">entry_project_dialog_name</property>
                   </object>
                   <packing>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="top-attach">1</property>
+                    <property name="bottom-attach">2</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label_project_dialog_description">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="yalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Description:</property>
-                    <property name="use_underline">True</property>
-                    <property name="mnemonic_widget">textview_project_dialog_description</property>
+                    <property name="use-underline">True</property>
+                    <property name="mnemonic-widget">textview_project_dialog_description</property>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="top-attach">2</property>
+                    <property name="bottom-attach">3</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label_project_dialog_base_path">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Base path:</property>
-                    <property name="use_underline">True</property>
-                    <property name="mnemonic_widget">entry_project_dialog_base_path</property>
+                    <property name="use-underline">True</property>
+                    <property name="mnemonic-widget">entry_project_dialog_base_path</property>
                   </object>
                   <packing>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label_project_dialog_file_patterns">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">File _patterns:</property>
-                    <property name="use_underline">True</property>
-                    <property name="mnemonic_widget">entry_project_dialog_file_patterns</property>
+                    <property name="use-underline">True</property>
+                    <property name="mnemonic-widget">entry_project_dialog_file_patterns</property>
                   </object>
                   <packing>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="top-attach">4</property>
+                    <property name="bottom-attach">5</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkEntry" id="entry_project_dialog_name">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="invisible_char">•</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">True</property>
-                    <property name="primary_icon_sensitive">True</property>
-                    <property name="secondary_icon_sensitive">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="invisible-char">•</property>
+                    <property name="primary-icon-activatable">False</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">1</property>
+                    <property name="bottom-attach">2</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow_project_dialog_description">
-                    <property name="width_request">250</property>
-                    <property name="height_request">80</property>
+                    <property name="width-request">250</property>
+                    <property name="height-request">80</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
-                    <property name="shadow_type">in</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
                     <child>
                       <object class="GtkViewport" id="viewport_project_dialog_description">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkTextView" id="textview_project_dialog_description">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="wrap_mode">word</property>
+                            <property name="can-focus">True</property>
+                            <property name="wrap-mode">word</property>
                           </object>
                         </child>
                       </object>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">2</property>
+                    <property name="bottom-attach">3</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkEntry" id="entry_project_dialog_file_patterns">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">Space separated list of file patterns used for the find in files dialog (e.g. *.c *.h)</property>
-                    <property name="invisible_char">•</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">True</property>
-                    <property name="primary_icon_sensitive">True</property>
-                    <property name="secondary_icon_sensitive">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes">Space separated list of file patterns used for the find in files dialog (e.g. *.c *.h)</property>
+                    <property name="invisible-char">•</property>
+                    <property name="primary-icon-activatable">False</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">4</property>
+                    <property name="bottom-attach">5</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label_project_dialog_filename">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkHBox" id="hbox_project_dialog_base_path_entry">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkEntry" id="entry_project_dialog_base_path">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Base directory of all files that make up the project. This can be a new path, or an existing directory tree. You can use paths relative to the project filename.</property>
-                        <property name="invisible_char">•</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="secondary_icon_activatable">True</property>
-                        <property name="primary_icon_sensitive">True</property>
-                        <property name="secondary_icon_sensitive">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Base directory of all files that make up the project. This can be a new path, or an existing directory tree. You can use paths relative to the project filename.</property>
+                        <property name="invisible-char">•</property>
+                        <property name="primary-icon-activatable">False</property>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -8732,12 +8623,12 @@
                     <child>
                       <object class="GtkButton" id="button_project_dialog_base_path">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <child>
                           <object class="GtkImage" id="image_project_dialog_base_path">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="stock">gtk-open</property>
                           </object>
                         </child>
@@ -8750,11 +8641,11 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
               </object>
@@ -8762,22 +8653,22 @@
             <child type="tab">
               <object class="GtkLabel" id="project_tab_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Project</property>
               </object>
               <packing>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkTable" id="table17">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">6</property>
-                <property name="n_rows">8</property>
-                <property name="n_columns">2</property>
-                <property name="column_spacing">24</property>
-                <property name="row_spacing">3</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">6</property>
+                <property name="n-rows">8</property>
+                <property name="n-columns">2</property>
+                <property name="column-spacing">24</property>
+                <property name="row-spacing">3</property>
                 <child>
                   <placeholder/>
                 </child>
@@ -8793,78 +8684,73 @@
                 <child>
                   <object class="GtkLabel" id="label26">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Note: To apply these settings to all currently open documents, use &lt;i&gt;Project-&gt;Apply Default Indentation&lt;/i&gt;.</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                     <property name="wrap">True</property>
-                    <property name="width_chars">64</property>
+                    <property name="width-chars">64</property>
                   </object>
                   <packing>
-                    <property name="right_attach">2</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"/>
+                    <property name="right-attach">2</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label230">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">_Width:</property>
-                    <property name="use_underline">True</property>
-                    <property name="mnemonic_widget">spin_indent_width_project</property>
+                    <property name="use-underline">True</property>
+                    <property name="mnemonic-widget">spin_indent_width_project</property>
                   </object>
                   <packing>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"/>
+                    <property name="top-attach">1</property>
+                    <property name="bottom-attach">2</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkSpinButton" id="spin_indent_width_project">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">The width in chars of a single indent</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
-                    <property name="primary_icon_sensitive">True</property>
-                    <property name="secondary_icon_sensitive">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes">The width in chars of a single indent</property>
+                    <property name="primary-icon-activatable">False</property>
+                    <property name="secondary-icon-activatable">False</property>
                     <property name="adjustment">adjustment10</property>
-                    <property name="climb_rate">1</property>
+                    <property name="climb-rate">1</property>
                     <property name="numeric">True</property>
                     <property name="wrap">True</property>
-                    <property name="update_policy">if-valid</property>
+                    <property name="update-policy">if-valid</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                    <property name="y_options"/>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">1</property>
+                    <property name="bottom-attach">2</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label228">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Auto-indent _mode:</property>
-                    <property name="use_underline">True</property>
-                    <property name="mnemonic_widget">combo_auto_indent_mode_project</property>
+                    <property name="use-underline">True</property>
+                    <property name="mnemonic-widget">combo_auto_indent_mode_project</property>
                   </object>
                   <packing>
-                    <property name="top_attach">7</property>
-                    <property name="bottom_attach">8</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"/>
+                    <property name="top-attach">7</property>
+                    <property name="bottom-attach">8</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkComboBox" id="combo_auto_indent_mode_project">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="model">indent_mode_list</property>
                     <child>
                       <object class="GtkCellRendererText" id="cellrenderertext1_project"/>
@@ -8874,123 +8760,122 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">7</property>
-                    <property name="bottom_attach">8</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options">GTK_FILL</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">7</property>
+                    <property name="bottom-attach">8</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options">GTK_FILL</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="check_detect_indent_type_project">
                     <property name="label" translatable="yes">Detect type from file</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Whether to detect the indentation type from file contents when a file is opened</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text" translatable="yes">Whether to detect the indentation type from file contents when a file is opened</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">6</property>
-                    <property name="bottom_attach">7</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"/>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">6</property>
+                    <property name="bottom-attach">7</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="radio_indent_both_project">
                     <property name="label" translatable="yes">T_abs and spaces</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Use spaces if the total indent is less than the tab width, otherwise use both</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text" translatable="yes">Use spaces if the total indent is less than the tab width, otherwise use both</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">5</property>
-                    <property name="bottom_attach">6</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"/>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">5</property>
+                    <property name="bottom-attach">6</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="radio_indent_spaces_project">
                     <property name="label" translatable="yes">_Spaces</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Use spaces when inserting indentation</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text" translatable="yes">Use spaces when inserting indentation</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
                     <property name="group">radio_indent_both_project</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"/>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">4</property>
+                    <property name="bottom-attach">5</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="radio_indent_tabs_project">
                     <property name="label" translatable="yes">_Tabs</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Use one tab per indent</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text" translatable="yes">Use one tab per indent</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
                     <property name="group">radio_indent_both_project</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"/>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label229">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Type:</property>
                   </object>
                   <packing>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"/>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="check_detect_indent_width_project">
                     <property name="label" translatable="yes">Detect width from file</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Whether to detect the indentation width from file contents when a file is opened</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text" translatable="yes">Whether to detect the indentation width from file contents when a file is opened</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"/>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">2</property>
+                    <property name="bottom-attach">3</property>
+                    <property name="x-options">GTK_FILL</property>
+                    <property name="y-options"/>
                   </packing>
                 </child>
               </object>
@@ -9001,44 +8886,44 @@
             <child type="tab">
               <object class="GtkLabel" id="label227">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Indentation</property>
               </object>
               <packing>
                 <property name="position">1</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkVBox" id="vbox_project_dialog_editor">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">5</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkFrame" id="frame11p">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment8p">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkVBox" id="vbox56p">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkCheckButton" id="check_line_wrapping1">
                                 <property name="label" translatable="yes">Line wrapping</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Wrap the line at the window border and continue it on the next line. Note: line wrapping has a high performance cost for large documents so should be disabled on slow machines.</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Wrap the line at the window border and continue it on the next line. Note: line wrapping has a high performance cost for large documents so should be disabled on slow machines.</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -9049,14 +8934,14 @@
                             <child>
                               <object class="GtkHBox" id="hbox11p">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">12</property>
                                 <child>
                                   <object class="GtkLabel" id="label209p">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Line breaking column:</property>
-                                    <property name="mnemonic_widget">spin_line_break1</property>
+                                    <property name="mnemonic-widget">spin_line_break1</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -9067,13 +8952,11 @@
                                 <child>
                                   <object class="GtkSpinButton" id="spin_line_break1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="primary_icon_activatable">False</property>
-                                    <property name="secondary_icon_activatable">False</property>
-                                    <property name="primary_icon_sensitive">True</property>
-                                    <property name="secondary_icon_sensitive">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
                                     <property name="adjustment">adjustment1</property>
-                                    <property name="climb_rate">1</property>
+                                    <property name="climb-rate">1</property>
                                     <property name="numeric">True</property>
                                   </object>
                                   <packing>
@@ -9099,9 +8982,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label8p">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Features&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -9114,23 +8997,23 @@
                 <child>
                   <object class="GtkFrame" id="frame3">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment4">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkCheckButton" id="check_auto_multiline1">
                             <property name="label" translatable="yes">Automatic continuation of multi-line comments</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="tooltip_text" translatable="yes">Continue automatically multi-line comments in languages like C, C++ and Java when a new line is entered inside such a comment</property>
-                            <property name="use_underline">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="tooltip-text" translatable="yes">Continue automatically multi-line comments in languages like C, C++ and Java when a new line is entered inside such a comment</property>
+                            <property name="use-underline">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                         </child>
                       </object>
@@ -9138,9 +9021,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label23">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Completions&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -9153,22 +9036,22 @@
                 <child>
                   <object class="GtkFrame" id="frame40_project">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment48">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkTable" id="table18">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="n_rows">4</property>
-                            <property name="n_columns">2</property>
-                            <property name="column_spacing">12</property>
-                            <property name="row_spacing">3</property>
+                            <property name="can-focus">False</property>
+                            <property name="n-rows">4</property>
+                            <property name="n-columns">2</property>
+                            <property name="column-spacing">12</property>
+                            <property name="row-spacing">3</property>
                             <child>
                               <placeholder/>
                             </child>
@@ -9178,104 +9061,100 @@
                             <child>
                               <object class="GtkLabel" id="label241">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Display:</property>
                               </object>
                               <packing>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="label240">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Column:</property>
-                                <property name="mnemonic_widget">spin_long_line_project</property>
+                                <property name="mnemonic-widget">spin_long_line_project</property>
                               </object>
                               <packing>
-                                <property name="top_attach">3</property>
-                                <property name="bottom_attach">4</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
+                                <property name="top-attach">3</property>
+                                <property name="bottom-attach">4</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkRadioButton" id="radio_long_line_disabled_project">
                                 <property name="label" translatable="yes">Disabled</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkRadioButton" id="radio_long_line_custom_project">
                                 <property name="label" translatable="yes">Custom</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                                 <property name="group">radio_long_line_disabled_project</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="top_attach">2</property>
-                                <property name="bottom_attach">3</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="top-attach">2</property>
+                                <property name="bottom-attach">3</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkRadioButton" id="radio_long_line_default_project">
                                 <property name="label" translatable="yes">Use global settings</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                                 <property name="group">radio_long_line_disabled_project</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="top_attach">1</property>
-                                <property name="bottom_attach">2</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="top-attach">1</property>
+                                <property name="bottom-attach">2</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkSpinButton" id="spin_long_line_project">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="primary_icon_activatable">False</property>
-                                <property name="secondary_icon_activatable">False</property>
-                                <property name="primary_icon_sensitive">True</property>
-                                <property name="secondary_icon_sensitive">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="primary-icon-activatable">False</property>
+                                <property name="secondary-icon-activatable">False</property>
                                 <property name="adjustment">adjustment11</property>
-                                <property name="climb_rate">1</property>
+                                <property name="climb-rate">1</property>
                                 <property name="numeric">True</property>
                                 <property name="wrap">True</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="top_attach">3</property>
-                                <property name="bottom_attach">4</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
+                                <property name="left-attach">1</property>
+                                <property name="right-attach">2</property>
+                                <property name="top-attach">3</property>
+                                <property name="bottom-attach">4</property>
+                                <property name="x-options">GTK_FILL</property>
+                                <property name="y-options"/>
                               </packing>
                             </child>
                           </object>
@@ -9285,9 +9164,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label239">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Long line marker&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -9305,43 +9184,43 @@
             <child type="tab">
               <object class="GtkLabel" id="label238_project">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Editor</property>
               </object>
               <packing>
                 <property name="position">2</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkVBox" id="vbox3">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">5</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkFrame" id="frame11">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">none</property>
                     <child>
                       <object class="GtkAlignment" id="alignment8">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="left_padding">12</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
                         <child>
                           <object class="GtkVBox" id="vbox56">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkCheckButton" id="check_new_line1">
                                 <property name="label" translatable="yes">Ensure new line at file end</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -9353,10 +9232,10 @@
                               <object class="GtkCheckButton" id="check_ensure_convert_new_lines1">
                                 <property name="label" translatable="yes">Ensure consistent line endings</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -9368,10 +9247,10 @@
                               <object class="GtkCheckButton" id="check_trailing_spaces1">
                                 <property name="label" translatable="yes">Strip trailing spaces and tabs</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -9383,10 +9262,10 @@
                               <object class="GtkCheckButton" id="check_replace_tabs1">
                                 <property name="label" translatable="yes">Replace tabs with space</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="use-underline">True</property>
+                                <property name="draw-indicator">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -9401,9 +9280,9 @@
                     <child type="label">
                       <object class="GtkLabel" id="label8">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Saving files&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -9421,12 +9300,12 @@
             <child type="tab">
               <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Files</property>
               </object>
               <packing>
                 <property name="position">3</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>
@@ -9444,30 +9323,30 @@
     </action-widgets>
   </object>
   <object class="GtkDialog" id="properties_dialog">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="default_width">300</property>
-    <property name="type_hint">dialog</property>
-    <property name="transient_for">window1</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
+    <property name="default-width">300</property>
+    <property name="type-hint">dialog</property>
+    <property name="transient-for">window1</property>
     <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
     <signal name="response" handler="gtk_widget_hide" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox4">
+      <object class="GtkBox" id="dialog-vbox4">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area5">
+          <object class="GtkButtonBox" id="dialog-action_area5">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button1">
                 <property name="label">gtk-close</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -9479,26 +9358,25 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkVBox" id="vbox7">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="border_width">6</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">6</property>
             <property name="spacing">12</property>
             <child>
               <object class="GtkHBox" id="hbox3">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkImage" id="file_type_image">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="stock">gtk-file</property>
                   </object>
                   <packing>
@@ -9510,8 +9388,7 @@
                 <child>
                   <object class="GtkLabel" id="file_name_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label">file name</property>
                     <property name="selectable">True</property>
                     <attributes>
@@ -9534,18 +9411,17 @@
             <child>
               <object class="GtkTable" id="table3">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="n_rows">8</property>
-                <property name="n_columns">2</property>
-                <property name="column_spacing">10</property>
-                <property name="row_spacing">10</property>
+                <property name="can-focus">False</property>
+                <property name="n-rows">8</property>
+                <property name="n-columns">2</property>
+                <property name="column-spacing">10</property>
+                <property name="row-spacing">10</property>
                 <child>
                   <object class="GtkLabel" id="label6">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Type:</property>
-                    <property name="mnemonic_widget">file_type_label</property>
+                    <property name="mnemonic-widget">file_type_label</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9554,156 +9430,146 @@
                 <child>
                   <object class="GtkLabel" id="file_type_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label">file type</property>
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label7">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Size:</property>
-                    <property name="mnemonic_widget">file_size_label</property>
+                    <property name="mnemonic-widget">file_size_label</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
+                    <property name="top-attach">1</property>
+                    <property name="bottom-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label9">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Location:</property>
-                    <property name="mnemonic_widget">file_location_label</property>
+                    <property name="mnemonic-widget">file_location_label</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="top-attach">2</property>
+                    <property name="bottom-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label10">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Read-only:</property>
-                    <property name="mnemonic_widget">file_read_only_check</property>
+                    <property name="mnemonic-widget">file_read_only_check</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label11">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Encoding:</property>
-                    <property name="mnemonic_widget">file_encoding_label</property>
+                    <property name="mnemonic-widget">file_encoding_label</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top-attach">4</property>
+                    <property name="bottom-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label12">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Modified:</property>
-                    <property name="mnemonic_widget">file_modified_label</property>
+                    <property name="mnemonic-widget">file_modified_label</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="top_attach">5</property>
-                    <property name="bottom_attach">6</property>
+                    <property name="top-attach">5</property>
+                    <property name="bottom-attach">6</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label13">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Changed:</property>
-                    <property name="mnemonic_widget">file_changed_label</property>
+                    <property name="mnemonic-widget">file_changed_label</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="top_attach">6</property>
-                    <property name="bottom_attach">7</property>
+                    <property name="top-attach">6</property>
+                    <property name="bottom-attach">7</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label14">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Accessed:</property>
-                    <property name="mnemonic_widget">file_accessed_label</property>
+                    <property name="mnemonic-widget">file_accessed_label</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="top_attach">7</property>
-                    <property name="bottom_attach">8</property>
+                    <property name="top-attach">7</property>
+                    <property name="bottom-attach">8</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="file_size_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label">file size</property>
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">1</property>
+                    <property name="bottom-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="file_location_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label">file path</property>
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">2</property>
+                    <property name="bottom-attach">3</property>
                   </packing>
                 </child>
                 <child>
@@ -9711,77 +9577,71 @@
                     <property name="label" translatable="yes">(only inside Geany)</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">False</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="xalign">0</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="file_encoding_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label">file encoding</property>
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">4</property>
+                    <property name="bottom-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="file_modified_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label">file mdate</property>
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">5</property>
-                    <property name="bottom_attach">6</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">5</property>
+                    <property name="bottom-attach">6</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="file_changed_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label">file cdate</property>
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">6</property>
-                    <property name="bottom_attach">7</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">6</property>
+                    <property name="bottom-attach">7</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="file_accessed_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label">file adate</property>
                     <property name="selectable">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">7</property>
-                    <property name="bottom_attach">8</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">7</property>
+                    <property name="bottom-attach">8</property>
                   </packing>
                 </child>
               </object>
@@ -9794,11 +9654,11 @@
             <child>
               <object class="GtkTable" id="table5">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="n_rows">5</property>
-                <property name="n_columns">4</property>
-                <property name="column_spacing">5</property>
-                <property name="row_spacing">5</property>
+                <property name="can-focus">False</property>
+                <property name="n-rows">5</property>
+                <property name="n-columns">4</property>
+                <property name="column-spacing">5</property>
+                <property name="row-spacing">5</property>
                 <property name="homogeneous">True</property>
                 <child>
                   <placeholder/>
@@ -9806,237 +9666,221 @@
                 <child>
                   <object class="GtkLabel" id="label15">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Permissions:</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="right_attach">4</property>
+                    <property name="right-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label16">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Read:</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">1</property>
+                    <property name="bottom-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label17">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Write:</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="right_attach">3</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
+                    <property name="left-attach">2</property>
+                    <property name="right-attach">3</property>
+                    <property name="top-attach">1</property>
+                    <property name="bottom-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label18">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Execute:</property>
                   </object>
                   <packing>
-                    <property name="left_attach">3</property>
-                    <property name="right_attach">4</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
+                    <property name="left-attach">3</property>
+                    <property name="right-attach">4</property>
+                    <property name="top-attach">1</property>
+                    <property name="bottom-attach">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label20">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Owner:</property>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="top-attach">2</property>
+                    <property name="bottom-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label21">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Group:</property>
                   </object>
                   <packing>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label22">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">1</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Other:</property>
                   </object>
                   <packing>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top-attach">4</property>
+                    <property name="bottom-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="file_perm_owner_r_check">
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">2</property>
+                    <property name="bottom-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="file_perm_owner_w_check">
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="right_attach">3</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="left-attach">2</property>
+                    <property name="right-attach">3</property>
+                    <property name="top-attach">2</property>
+                    <property name="bottom-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="file_perm_owner_x_check">
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">3</property>
-                    <property name="right_attach">4</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="left-attach">3</property>
+                    <property name="right-attach">4</property>
+                    <property name="top-attach">2</property>
+                    <property name="bottom-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="file_perm_group_r_check">
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="file_perm_group_w_check">
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="right_attach">3</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="left-attach">2</property>
+                    <property name="right-attach">3</property>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="file_perm_group_x_check">
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">3</property>
-                    <property name="right_attach">4</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="left-attach">3</property>
+                    <property name="right-attach">4</property>
+                    <property name="top-attach">3</property>
+                    <property name="bottom-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="file_perm_other_r_check">
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="left-attach">1</property>
+                    <property name="right-attach">2</property>
+                    <property name="top-attach">4</property>
+                    <property name="bottom-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="file_perm_other_w_check">
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="right_attach">3</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="left-attach">2</property>
+                    <property name="right-attach">3</property>
+                    <property name="top-attach">4</property>
+                    <property name="bottom-attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="file_perm_other_x_check">
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">3</property>
-                    <property name="right_attach">4</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="left-attach">3</property>
+                    <property name="right-attach">4</property>
+                    <property name="top-attach">4</property>
+                    <property name="bottom-attach">5</property>
                   </packing>
                 </child>
               </object>

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1032,6 +1032,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Startup path:</property>
                                     <property name="mnemonic-widget">startup_path_entry</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="x-options">GTK_FILL</property>
@@ -1079,6 +1080,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Project files:</property>
                                     <property name="mnemonic-widget">project_file_path_entry</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">1</property>
@@ -1132,6 +1134,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Extra plugin path:</property>
                                     <property name="mnemonic-widget">extra_plugin_path_entry</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">2</property>
@@ -1857,6 +1860,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Symbol list:</property>
                                     <property name="mnemonic-widget">tagbar_font</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">1</property>
@@ -1871,6 +1875,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Message window:</property>
                                     <property name="mnemonic-widget">msgwin_font</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">2</property>
@@ -1885,6 +1890,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Editor:</property>
                                     <property name="mnemonic-widget">editor_font</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="x-options">GTK_FILL</property>
@@ -2088,6 +2094,7 @@
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Placement of new file tabs:</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                       <packing>
                                         <property name="x-options">GTK_FILL</property>
@@ -2240,6 +2247,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Message window:</property>
                                     <property name="mnemonic-widget">combo_tab_msgwin</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">2</property>
@@ -2275,6 +2283,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Sidebar:</property>
                                     <property name="mnemonic-widget">combo_tab_sidebar</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">1</property>
@@ -2310,6 +2319,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Editor:</property>
                                     <property name="mnemonic-widget">combo_tab_editor</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="x-options">GTK_FILL</property>
@@ -3046,6 +3056,7 @@
                         <property name="label" translatable="yes">Note: To apply these settings to all currently open documents, use &lt;i&gt;Project-&gt;Apply Default Indentation&lt;/i&gt;.</property>
                         <property name="use-markup">True</property>
                         <property name="wrap">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -3095,6 +3106,7 @@
                                         <property name="label" translatable="yes">_Width:</property>
                                         <property name="use-underline">True</property>
                                         <property name="mnemonic-widget">spin_indent_width</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                       <packing>
                                         <property name="x-options">GTK_FILL</property>
@@ -3127,6 +3139,7 @@
                                         <property name="label" translatable="yes">Auto-indent _mode:</property>
                                         <property name="use-underline">True</property>
                                         <property name="mnemonic-widget">combo_auto_indent_mode</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                       <packing>
                                         <property name="top-attach">6</property>
@@ -3258,6 +3271,7 @@
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Type:</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                       <packing>
                                         <property name="top-attach">2</property>
@@ -3453,6 +3467,7 @@
                                         <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Max. symbol name suggestions:</property>
                                         <property name="mnemonic-widget">spin_autocompletion_max_entries</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                       <packing>
                                         <property name="top-attach">2</property>
@@ -3467,6 +3482,7 @@
                                         <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Completion list height:</property>
                                         <property name="mnemonic-widget">spin_symbollistheight</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                       <packing>
                                         <property name="top-attach">1</property>
@@ -3481,6 +3497,7 @@
                                         <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Characters to type for autocompletion:</property>
                                         <property name="mnemonic-widget">spin_symbol_complete_chars</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                       <packing>
                                         <property name="x-options">GTK_FILL</property>
@@ -3548,6 +3565,7 @@
                                         <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Symbol list update frequency:</property>
                                         <property name="mnemonic-widget">spin_symbol_update_freq</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                       <packing>
                                         <property name="top-attach">3</property>
@@ -3951,6 +3969,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Column:</property>
                                     <property name="mnemonic-widget">spin_long_line</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">2</property>
@@ -3965,6 +3984,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Color:</property>
                                     <property name="mnemonic-widget">long_line_color</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">3</property>
@@ -3979,6 +3999,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Type:</property>
                                     <property name="mnemonic-widget">hbox5</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">1</property>
@@ -4297,6 +4318,7 @@
                                         <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">Default end of line characters:</property>
                                         <property name="mnemonic-widget">combo_eol</property>
+                                        <property name="xalign">0</property>
                                       </object>
                                       <packing>
                                         <property name="x-options">GTK_FILL</property>
@@ -4362,6 +4384,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Default encoding (new files):</property>
                                     <property name="mnemonic-widget">combo_new_encoding</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -4423,6 +4446,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Default encoding (existing non-Unicode files):</property>
                                     <property name="mnemonic-widget">combo_open_encoding</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -4605,6 +4629,7 @@
                                     <property name="ypad">7</property>
                                     <property name="label" translatable="yes">Recent files list length:</property>
                                     <property name="mnemonic-widget">spin_mru</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="x-options">GTK_FILL</property>
@@ -4636,6 +4661,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Disk check timeout:</property>
                                     <property name="mnemonic-widget">spin_disk_check</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">1</property>
@@ -4757,6 +4783,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Terminal:</property>
                                     <property name="mnemonic-widget">entry_com_term</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="x-options">GTK_FILL</property>
@@ -4769,6 +4796,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Browser:</property>
                                     <property name="mnemonic-widget">entry_browser</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">1</property>
@@ -4855,6 +4883,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Grep:</property>
                                     <property name="mnemonic-widget">entry_grep</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">2</property>
@@ -5108,6 +5137,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Initial version:</property>
                                     <property name="mnemonic-widget">entry_template_version</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">4</property>
@@ -5154,6 +5184,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Developer:</property>
                                     <property name="mnemonic-widget">entry_template_developer</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="x-options">GTK_FILL</property>
@@ -5166,6 +5197,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Company:</property>
                                     <property name="mnemonic-widget">entry_template_company</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">3</property>
@@ -5180,6 +5212,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Mail address:</property>
                                     <property name="mnemonic-widget">entry_template_mail</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">2</property>
@@ -5194,6 +5227,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Initials:</property>
                                     <property name="mnemonic-widget">entry_template_initial</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">1</property>
@@ -5222,6 +5256,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Year:</property>
                                     <property name="mnemonic-widget">entry_template_year</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">5</property>
@@ -5236,6 +5271,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Date:</property>
                                     <property name="mnemonic-widget">entry_template_date</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">6</property>
@@ -5250,6 +5286,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Date &amp; time:</property>
                                     <property name="mnemonic-widget">entry_template_datetime</property>
+                                    <property name="xalign">0</property>
                                   </object>
                                   <packing>
                                     <property name="top-attach">7</property>
@@ -5625,6 +5662,7 @@
                                           <object class="GtkAlignment" id="alignment36">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="xalign">0</property>
                                             <property name="left-padding">12</property>
                                             <child>
                                               <object class="GtkVBox" id="vbox30">
@@ -5778,6 +5816,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Font:</property>
                                 <property name="mnemonic-widget">font_term</property>
+                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="x-options">GTK_FILL</property>
@@ -5805,6 +5844,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Foreground color:</property>
                                 <property name="mnemonic-widget">color_fore</property>
+                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="top-attach">1</property>
@@ -5819,6 +5859,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Background color:</property>
                                 <property name="mnemonic-widget">color_back</property>
+                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="top-attach">2</property>
@@ -5833,6 +5874,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Scrollback lines:</property>
                                 <property name="mnemonic-widget">spin_scrollback</property>
+                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="top-attach">3</property>
@@ -5847,6 +5889,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Shell:</property>
                                 <property name="mnemonic-widget">entry_shell</property>
+                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="top-attach">4</property>
@@ -6187,6 +6230,7 @@
                           <object class="GtkAlignment" id="alignment16">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
+                            <property name="xalign">0</property>
                             <property name="bottom-padding">5</property>
                             <child>
                               <object class="GtkHBox" id="hbox15">
@@ -8462,6 +8506,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Filename:</property>
                     <property name="mnemonic-widget">label_project_dialog_filename</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="x-options">GTK_FILL</property>
@@ -8475,6 +8520,7 @@
                     <property name="label" translatable="yes">_Name:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">entry_project_dialog_name</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="top-attach">1</property>
@@ -8490,6 +8536,8 @@
                     <property name="label" translatable="yes">_Description:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">textview_project_dialog_description</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0</property>
                   </object>
                   <packing>
                     <property name="top-attach">2</property>
@@ -8505,6 +8553,7 @@
                     <property name="label" translatable="yes">_Base path:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">entry_project_dialog_base_path</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="top-attach">3</property>
@@ -8520,6 +8569,7 @@
                     <property name="label" translatable="yes">File _patterns:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">entry_project_dialog_file_patterns</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="top-attach">4</property>
@@ -8594,6 +8644,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -8689,6 +8740,7 @@
                     <property name="use-markup">True</property>
                     <property name="wrap">True</property>
                     <property name="width-chars">64</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="right-attach">2</property>
@@ -8703,6 +8755,7 @@
                     <property name="label" translatable="yes">_Width:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">spin_indent_width_project</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="top-attach">1</property>
@@ -8739,6 +8792,7 @@
                     <property name="label" translatable="yes">Auto-indent _mode:</property>
                     <property name="use-underline">True</property>
                     <property name="mnemonic-widget">combo_auto_indent_mode_project</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="top-attach">7</property>
@@ -8851,6 +8905,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Type:</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="top-attach">3</property>
@@ -9063,6 +9118,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Display:</property>
+                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="x-options">GTK_FILL</property>
@@ -9075,6 +9131,7 @@
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Column:</property>
                                 <property name="mnemonic-widget">spin_long_line_project</property>
+                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="top-attach">3</property>
@@ -9377,6 +9434,7 @@
                   <object class="GtkImage" id="file_type_image">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="xalign">1</property>
                     <property name="stock">gtk-file</property>
                   </object>
                   <packing>
@@ -9391,6 +9449,7 @@
                     <property name="can-focus">False</property>
                     <property name="label">file name</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9422,6 +9481,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Type:</property>
                     <property name="mnemonic-widget">file_type_label</property>
+                    <property name="xalign">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9433,6 +9493,7 @@
                     <property name="can-focus">False</property>
                     <property name="label">file type</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -9445,6 +9506,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Size:</property>
                     <property name="mnemonic-widget">file_size_label</property>
+                    <property name="xalign">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9460,6 +9522,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Location:</property>
                     <property name="mnemonic-widget">file_location_label</property>
+                    <property name="xalign">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9475,6 +9538,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Read-only:</property>
                     <property name="mnemonic-widget">file_read_only_check</property>
+                    <property name="xalign">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9490,6 +9554,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Encoding:</property>
                     <property name="mnemonic-widget">file_encoding_label</property>
+                    <property name="xalign">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9505,6 +9570,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Modified:</property>
                     <property name="mnemonic-widget">file_modified_label</property>
+                    <property name="xalign">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9520,6 +9586,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Changed:</property>
                     <property name="mnemonic-widget">file_changed_label</property>
+                    <property name="xalign">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9535,6 +9602,7 @@
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Accessed:</property>
                     <property name="mnemonic-widget">file_accessed_label</property>
+                    <property name="xalign">1</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9550,6 +9618,7 @@
                     <property name="can-focus">False</property>
                     <property name="label">file size</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -9564,6 +9633,7 @@
                     <property name="can-focus">False</property>
                     <property name="label">file path</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -9578,7 +9648,9 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">False</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
+                    <property name="xalign">0</property>
                     <property name="draw-indicator">True</property>
                   </object>
                   <packing>
@@ -9594,6 +9666,7 @@
                     <property name="can-focus">False</property>
                     <property name="label">file encoding</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -9608,6 +9681,7 @@
                     <property name="can-focus">False</property>
                     <property name="label">file mdate</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -9622,6 +9696,7 @@
                     <property name="can-focus">False</property>
                     <property name="label">file cdate</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -9636,6 +9711,7 @@
                     <property name="can-focus">False</property>
                     <property name="label">file adate</property>
                     <property name="selectable">True</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -9668,6 +9744,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Permissions:</property>
+                    <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -9681,6 +9758,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Read:</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -9694,6 +9772,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Write:</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">2</property>
@@ -9707,6 +9786,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Execute:</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left-attach">3</property>
@@ -9720,6 +9800,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Owner:</property>
+                    <property name="xalign">1</property>
                   </object>
                   <packing>
                     <property name="top-attach">2</property>
@@ -9731,6 +9812,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Group:</property>
+                    <property name="xalign">1</property>
                   </object>
                   <packing>
                     <property name="top-attach">3</property>
@@ -9742,6 +9824,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Other:</property>
+                    <property name="xalign">1</property>
                   </object>
                   <packing>
                     <property name="top-attach">4</property>
@@ -9753,6 +9836,7 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -9768,6 +9852,7 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -9783,6 +9868,7 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -9798,6 +9884,7 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -9813,6 +9900,7 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -9828,6 +9916,7 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -9843,6 +9932,7 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -9858,6 +9948,7 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -9873,6 +9964,7 @@
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
+                    <property name="focus-on-click">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.20"/>
   <object class="GtkAccelGroup" id="accelgroup1"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="lower">3</property>


### PR DESCRIPTION
This PR updates `geany.glade` to target gtk+ ~3.0~ 3.20.  Resolves #2860.

* Glade 3.8.6 reports: Project geany.glade has no deprecated widgets or version mismatches.
* Used Glade 3.38.2 to resave geany.glade with target set to gtk+ ~3.0~ 3.20
* ~Removed the following properties to prevent warnings:~
  + ~Property 'Focus on click' of object class 'Widget' was introduced in gtk+ 3.20~
    - ~all were set to False.~
  + ~Property 'X align' of object class 'Label' was introduced in gtk+ 3.16~
    - ~all were set to 0 or 1.~
  + ~Property 'Y align' of object class 'Label' was introduced in gtk+ 3.16~
    - ~only one instance, was set to 0.~

Here is a list of the deprecated items (specific instances removed to keep the list manageable):

* Object class 'Alignment' from gtk+ 3.20 is deprecated
* Object class 'Horizontal Box' from gtk+ 3.20 is deprecated
* Object class 'Horizontal Panes' from gtk+ 3.20 is deprecated
* Object class 'Image Menu Item' from gtk+ 3.20 is deprecated
* Object class 'Table' from gtk+ 3.20 is deprecated
* Object class 'Vertical Box' from gtk+ 3.20 is deprecated
* Object class 'Vertical Panes' from gtk+ 3.20 is deprecated
* Property 'Current Color' of object class 'Color Button' is deprecated
* Property 'Horizontal alignment for child' of object class 'Button' is deprecated
* Property 'Rules Hint' of object class 'Tree View' is deprecated
* Property 'Stock ID' of object class 'Image' is deprecated
* Property 'Use stock' of object class 'Button' is deprecated