### PR TITLE
Remove deprecated symbols from ui_utils.c

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1462,35 +1462,6 @@ void ui_update_view_editor_menu_items(void)
 }
 
 
-/** Creates a GNOME HIG-style frame (with no border and indented child alignment).
- * @param label_text The label text.
- * @param alignment An address to store the alignment widget pointer.
- *
- * @return @transfer{floating} The frame widget, setting the alignment container for
- * packing child widgets.
- *
- * @deprecated 1.29: Use GTK API directly
- **/
-GEANY_API_SYMBOL
-GtkWidget *ui_frame_new_with_alignment(const gchar *label_text, GtkWidget **alignment)
-{
-	GtkWidget *label, *align;
-	GtkWidget *frame = gtk_frame_new(NULL);
-
-	gtk_frame_set_shadow_type(GTK_FRAME(frame), GTK_SHADOW_NONE);
-
-	align = gtk_alignment_new(0.5, 0.5, 1, 1);
-	gtk_container_add(GTK_CONTAINER(frame), align);
-	gtk_alignment_set_padding(GTK_ALIGNMENT(align), 0, 0, 12, 0);
-
-	label = ui_label_new_bold(label_text);
-	gtk_frame_set_label_widget(GTK_FRAME(frame), label);
-
-	*alignment = align;
-	return frame;
-}
-
-
 /** Makes a fixed border for dialogs without increasing the button box border.
  * @param dialog The parent container for the @c GtkVBox.
  *
@@ -2710,22 +2681,6 @@ void ui_auto_separator_add_ref(GeanyAutoSeparator *autosep, GtkWidget *item)
 	g_signal_connect(item, "show", G_CALLBACK(on_auto_separator_item_show_hide), autosep);
 	g_signal_connect(item, "hide", G_CALLBACK(on_auto_separator_item_show_hide), autosep);
 	g_signal_connect(item, "destroy", G_CALLBACK(on_auto_separator_item_destroy), autosep);
-}
-
-
-/**
- * Sets @a text as the contents of the tooltip for @a widget.
- *
- * @param widget The widget the tooltip should be set for.
- * @param text The text for the tooltip.
- *
- * @since 0.16
- * @deprecated 0.21 use gtk_widget_set_tooltip_text() instead
- */
-GEANY_API_SYMBOL
-void ui_widget_set_tooltip_text(GtkWidget *widget, const gchar *text)
-{
-	gtk_widget_set_tooltip_text(widget, text);
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -21,7 +21,6 @@
 #ifndef GEANY_UI_UTILS_H
 #define GEANY_UI_UTILS_H 1
 
-#include "geany.h" /* for GEANY_DEPRECATED */
 #include "document.h"
 
 #include "gtkcompat.h"
@@ -139,13 +138,6 @@ void ui_combo_box_add_to_history(GtkComboBoxText *combo_entry,
 const gchar *ui_lookup_stock_label(const gchar *stock_id);
 
 void ui_tree_view_set_tooltip_text_column(GtkTreeView *tree_view, gint column);
-
-
-#ifndef GEANY_DISABLE_DEPRECATED
-GtkWidget *ui_frame_new_with_alignment(const gchar *label_text, GtkWidget **alignment) GEANY_DEPRECATED;
-
-void ui_widget_set_tooltip_text(GtkWidget *widget, const gchar *text) GEANY_DEPRECATED_FOR(gtk_widget_set_tooltip_text);
-#endif	/* GEANY_DISABLE_DEPRECATED */
 
 
 #ifdef GEANY_PRIVATE


### PR DESCRIPTION
This PR removes deprecated symbols: `ui_frame_new_with_alignment()` and `ui_widget_set_tooltip_text()` from `ui_utils.c`.

Affected plugins are geanypy and webhelper.  Both are currently broken because of GTK2 or other dependencies.

See #3019.