### PR TITLE
Remove deprecated symbol: GEANY_KEYS_EDITOR_MACROLIST

### DIFF
--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -168,8 +168,7 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_FORMAT_SENDTOVTE,				/**< Keybinding. */
 	GEANY_KEYS_PROJECT_PROPERTIES,				/**< Keybinding. */
 	GEANY_KEYS_DOCUMENT_LINEWRAP,				/**< Keybinding. */
-	GEANY_KEYS_EDITOR_MACROLIST,				/**< Keybinding.
-												 * @deprecated 1.25, it doesn't do anything anymore */
+	_GEANY_KEYS_UNUSED_,	/* placeholder to preserve ABI */
 	GEANY_KEYS_EDITOR_SUPPRESSSNIPPETCOMPLETION, /**< Keybinding. */
 	GEANY_KEYS_FOCUS_SIDEBAR_SYMBOL_LIST,		/**< Keybinding. */
 	GEANY_KEYS_GOTO_LINESTART,					/**< Keybinding. */


### PR DESCRIPTION
"Removed" deprecated symbol `GEANY_KEYS_EDITOR_MACROLIST` by replacing it with `_GEANY_KEYS_UNUSED_` to preserve ABI.  Not used by any known plugins.  See #3019.