### PR TITLE
Resolve symlink before the path is tidied (#1567)

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1311,7 +1311,7 @@ GeanyDocument *document_open_file_full(GeanyDocument *doc, const gchar *filename
 		/* if filename is a shortcut, try to resolve it */
 		locale_filename = win32_get_shortcut_target(filename);
 #else
-		locale_filename = g_strdup(filename);
+		locale_filename = utils_get_real_path(filename);
 #endif
 		/* remove relative junk */
 		utils_tidy_path(locale_filename);


### PR DESCRIPTION
The filename from commandline argument is being processed directly, without first resolving symlinks. This leads to bug #1567, where Geany fails to open existing file, if it is being opened using path containing symlink and relative directories.

Windows counterpart of this code actually resolves the links, I have just corrected the non-win branch. This fixes the bug described in the bug report and should not have any unwanted side-effects.

Similar problem might (or might not) be also present in two other functions that use utils_tidy_path, without resolving the symlinks first:
 - in `document_new_file` at [src/document.c:832](https://github.com/geany/geany/blob/b524a58e12e85c94a32f64fb72615978b2628af1/src/document.c#L832)
 - in `get_custom_plugin_path` at [src/plugins.c:1009](https://github.com/geany/geany/blob/b524a58e12e85c94a32f64fb72615978b2628af1/src/plugins.c#L1009)
 
I'm not sure if it is appropriate to check and possibly fix those in the same PR.