### PR TITLE
Use GDateTime for date and time formatting

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -5342,7 +5342,7 @@
                                   <object class="GtkEntry" id="entry_template_datetime">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Specify a format for the {datetime} wildcard. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
+                                    <property name="tooltip_text" translatable="yes">Specify a format for the {datetime} wildcard. For a list of available conversion specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.</property>
                                     <property name="primary_icon_activatable">False</property>
                                     <property name="secondary_icon_activatable">False</property>
                                     <property name="primary_icon_sensitive">True</property>
@@ -5360,7 +5360,7 @@
                                   <object class="GtkEntry" id="entry_template_year">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Specify a format for the {year} wildcard. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
+                                    <property name="tooltip_text" translatable="yes">Specify a format for the {year} wildcard. For a list of available conversion specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.</property>
                                     <property name="primary_icon_activatable">False</property>
                                     <property name="secondary_icon_activatable">False</property>
                                     <property name="primary_icon_sensitive">True</property>
@@ -5378,7 +5378,7 @@
                                   <object class="GtkEntry" id="entry_template_date">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Specify a format for the {date} wildcard. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
+                                    <property name="tooltip_text" translatable="yes">Specify a format for the {date} wildcard. For a list of available conversion specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.</property>
                                     <property name="primary_icon_activatable">False</property>
                                     <property name="secondary_icon_activatable">False</property>
                                     <property name="primary_icon_sensitive">True</property>
@@ -5755,7 +5755,7 @@
                                                       <object class="GtkEntry" id="entry_print_dateformat">
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">True</property>
-                                                        <property name="tooltip_text" translatable="yes">Specify a format for the date and time stamp which is added to the page header on each page. You can use any conversion specifiers which can be used with the ANSI C strftime function.</property>
+                                                        <property name="tooltip_text" translatable="yes">Specify a format for the date and time stamp which is added to the page header on each page. For a list of available conversion specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.</property>
                                                         <property name="invisible_char">●</property>
                                                         <property name="primary_icon_activatable">False</property>
                                                         <property name="secondary_icon_activatable">False</property>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2434,19 +2434,16 @@ Initial version
     The initial version of files you will be creating.
 
 Year
-    Specify a format for the {year} wildcard. You can use any conversion specifiers
-    which can be used with the ANSI C strftime function.  For details please see
-    http://man.cx/strftime.
+    Specify a format for the {year} wildcard. For a list of available conversion
+    specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.
 
 Date
-    Specify a format for the {date} wildcard. You can use any conversion specifiers
-    which can be used with the ANSI C strftime function.  For details please see
-    http://man.cx/strftime.
+    Specify a format for the {date} wildcard. For a list of available conversion
+    specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.
 
 Date & Time
-    Specify a format for the {datetime} wildcard. You can use any conversion specifiers
-    which can be used with the ANSI C strftime function.  For details please see
-    http://man.cx/strftime.
+    Specify a format for the {datetime} wildcard. For a list of available conversion
+    specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.
 
 
 Keybinding preferences
@@ -2485,9 +2482,8 @@ Use base name of the printed file
     Don't use the entire path for the header, only the filename.
 
 Date format
-    How the date should be printed. You can use the same format
-    specifiers as in the ANSI C function strftime(). For details please
-    see http://man.cx/strftime.
+    How the date should be printed. For a list of available conversion
+    specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.
 
 
 Various preferences
@@ -3213,8 +3209,8 @@ the date and time of printing. By default, the file name of the document
 with full path information is added to the header. If you prefer to add
 only the basename of the file(without any path information) you can set it
 in the preferences dialog. You can also adjust the format of the date and
-time added to the page header. The available conversion specifiers are the
-same as the ones which can be used with the ANSI C strftime function.
+time added to the page header. For a list of available conversion
+specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.
 
 All of these settings can also be changed in the print dialog just before
 actual printing is done.
@@ -4931,9 +4927,8 @@ version        The initial version of a new file.            file templates, fil
 **Date & time wildcards**
 
 The format for these wildcards can be changed in the preferences
-dialog, see `Template preferences`_. You can use any conversion
-specifiers which can be used with the ANSI C strftime function.
-For details please see http://man.cx/strftime.
+dialog, see `Template preferences`_. For a list of available conversion
+specifiers see https://docs.gtk.org/glib/method.DateTime.format.html.
 
 ============== ============================================= =======================================
 Wildcard       Description                                   Available in

--- a/plugins/saveactions.c
+++ b/plugins/saveactions.c
@@ -814,7 +814,7 @@ GtkWidget *plugin_configure(GtkDialog *dialog)
 		gtk_box_pack_start(GTK_BOX(inner_vbox), hbox, FALSE, FALSE, 0);
 
 		label = gtk_label_new_with_mnemonic(
-			_("Date/_Time format for backup files (\"man strftime\" for details):"));
+			_("Date/_Time format for backup files (for a list of available conversion specifiers see https://docs.gtk.org/glib/method.DateTime.format.html):"));
 		gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
 		gtk_box_pack_start(GTK_BOX(inner_vbox), label, FALSE, FALSE, 7);
 

--- a/src/printing.c
+++ b/src/printing.c
@@ -276,7 +276,7 @@ static GtkWidget *create_custom_widget(GtkPrintOperation *operation, gpointer us
 	w->entry_print_dateformat = gtk_entry_new();
 	ui_entry_add_clear_icon(GTK_ENTRY(w->entry_print_dateformat));
 	gtk_box_pack_start(GTK_BOX(hbox10), w->entry_print_dateformat, TRUE, TRUE, 0);
-	gtk_widget_set_tooltip_text(w->entry_print_dateformat, _("Specify a format for the date and time stamp which is added to the page header on each page. You can use any conversion specifiers which can be used with the ANSI C strftime function."));
+	gtk_widget_set_tooltip_text(w->entry_print_dateformat, _("Specify a format for the date and time stamp which is added to the page header on each page. For a list of available conversion specifiers see https://docs.gtk.org/glib/method.DateTime.format.html."));
 	gtk_entry_set_text(GTK_ENTRY(w->entry_print_dateformat), printing_prefs.page_header_datefmt);
 
 	on_page_header_toggled(GTK_TOGGLE_BUTTON(w->check_print_pageheader), w);

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -728,7 +728,7 @@ static void insert_date(GeanyDocument *doc, gint pos, const gchar *date_style)
 	{
 		gchar *str = dialogs_show_input(_("Custom Date Format"), GTK_WINDOW(main_widgets.window),
 				_("Enter here a custom date and time format. "
-				"You can use any conversion specifiers which can be used with the ANSI C strftime function."),
+				"For a list of available conversion specifiers see https://docs.gtk.org/glib/method.DateTime.format.html."),
 				ui_prefs.custom_date_format);
 		if (str)
 			SETPTR(ui_prefs.custom_date_format, str);


### PR DESCRIPTION
This replaces the use of the native strftime() function to use
GLib's GDateTime functions which should work more platform agnostic.

Fixes #2968.