### PR TITLE
Open folders

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -7977,11 +7977,29 @@
                           </object>
                         </child>
                         <child>
+                          <object class="GtkImageMenuItem" id="project_open_folder1">
+                            <property name="label" translatable="yes">Open _Folder...</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <signal name="activate" handler="on_project_open_folder1_activate" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
                           <object class="GtkMenuItem" id="recent_projects1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Recent Projects</property>
                             <property name="use_underline">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkImageMenuItem" id="project_save_as1">
+                            <property name="label" translatable="yes">Save _As...</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
+                            <signal name="activate" handler="on_project_save_as1_activate" swapped="no"/>
                           </object>
                         </child>
                         <child>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1340,13 +1340,25 @@ void on_previous_message1_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 void on_project_new1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	project_new();
+	project_new_with_dialog();
 }
 
 
 void on_project_open1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	project_open();
+}
+
+
+void on_project_open_folder1_activate(GtkMenuItem *menuitem, gpointer user_data)
+{
+	project_open_folder();
+}
+
+
+void on_project_save_as1_activate(GtkMenuItem *menuitem, gpointer user_data)
+{
+	project_save_as();
 }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -76,6 +76,8 @@ void main_load_project_from_command_line(const gchar *locale_filename, gboolean 
 
 gint main_lib(gint argc, gchar **argv);
 
+gboolean open_folder(gchar *folder_name);
+
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS

--- a/src/project.h
+++ b/src/project.h
@@ -67,9 +67,15 @@ void project_init(void);
 void project_finalize(void);
 
 
-void project_new(void);
+void project_new_with_dialog(void);
+
+gboolean project_new(gchar const *name, gchar const *file_name, gchar const *base_path);
 
 void project_open(void);
+
+void project_open_folder(void);
+
+void project_save_as(void);
 
 gboolean project_close(gboolean open_default);
 


### PR DESCRIPTION
This PR enables opening folders with Geany.  Resolves #1171, others.

* Folders are turned into projects.
  + Project name is set to the basename of the folder.  May be changed from *Project / Properties*.
  + When the  `project_file_in_basedir` option is set, the `.geany` file is created inside the folder with name `[basename].geany`.
  + Otherwise, `.geany` files are stored in `~/.cache/geany/folders/` with name `[basename]_[path-md5].geany`.
* If the folder already has a project file (as noted above), the project file is opened.
* Folders to open may be specified at the command line.  Any filenames following the folder name are added to the project.
* New menu items:
   + *Project / Open Folder...*
   + *Project / Save As...* – to resave temporary project file to permanent location or to fork existing project to a different file.
* Does *not* interfere with existing method of project creation.
