### PR TITLE
Make status bar thinner by using GtkBox instead of GtkStatusBar

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8455,18 +8455,32 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox1">
+          <object class="GtkHBox" id="statusbar_box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="spacing">4</property>
             <child>
-              <object class="GtkStatusbar" id="statusbar">
+              <object class="GtkLabel" id="statusbar_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="ypad">3</property>
+                <property name="single_line_mode">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkProgressBar" id="statusbar_progress">
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -205,7 +205,7 @@ static void apply_settings(void)
 	/* hide statusbar if desired */
 	if (! interface_prefs.statusbar_visible)
 	{
-		gtk_widget_hide(ui_widgets.statusbar);
+		gtk_widget_hide(ui_widgets.statusbar_box);
 	}
 
 	/* set the tab placements of the notebooks */

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -201,7 +201,8 @@ typedef struct UIWidgets
 	GtkWidget	*prefs_dialog;
 
 	/* other widgets not needed in GeanyMainWidgets */
-	GtkWidget	*statusbar;			/* use ui_set_statusbar() to set */
+	GtkWidget	*statusbar_box;
+	GtkWidget	*statusbar_label;	/* use ui_set_statusbar() to set */
 }
 UIWidgets;
 


### PR DESCRIPTION
I'm not sure how others but I personally just HATE the huge status bar
of GTK 3. It's such a colossal waste of precious vertical space and not
making the height adjustable is a terrible design choice IMO.

Anyway, end of ranting, the GTK status bar is just a GtkBox and a label
(plus some message stack that Geany doesn't even use) so it's no problem
to replace the statusbar with these and set the height to a sane amount
of pixels.

To me, the result is MUCH better and from the themes I tried, it looks
the same like the original status bar (apart from the height of course).

There might be a problem with plugins that try to access the status bar
directly and don't use msgwin_status_add(). The only plugin that seems
to do that (correctly) is the "web helper" plugin but from the code
it appears it falls back to creating a fake status bar if it doesn't
locate the one from Geany so it won't crash.

What do you think?