### PR TITLE
Move language-specific parts to tm_parser.c

### DIFF
--- a/src/editor.h
+++ b/src/editor.h
@@ -325,8 +325,6 @@ void editor_set_indentation_guides(GeanyEditor *editor);
 
 void editor_apply_update_prefs(GeanyEditor *editor);
 
-gchar *editor_get_calltip_text(GeanyEditor *editor, const TMTag *tag);
-
 void editor_toggle_fold(GeanyEditor *editor, gint line, gint modifiers);
 
 #endif /* GEANY_PRIVATE */

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -946,18 +946,13 @@ static const gchar *get_symbol_name(GeanyDocument *doc, const TMTag *tag, gboole
 
 static gchar *get_symbol_tooltip(GeanyDocument *doc, const TMTag *tag)
 {
-	gchar *utf8_name = editor_get_calltip_text(doc->editor, tag);
+	gchar *utf8_name = tm_parser_format_function(tag->lang, tag->name,
+		tag->arglist, tag->var_type, tag->scope);
 
 	if (!utf8_name && tag->var_type &&
 		tag->type & (tm_tag_field_t | tm_tag_member_t | tm_tag_variable_t | tm_tag_externvar_t))
 	{
-		if (tag->lang != TM_PARSER_PASCAL && tag->lang != TM_PARSER_GO)
-			utf8_name = g_strconcat(tag->var_type, " ", tag->name, NULL);
-		else
-		{
-			const gchar *sep = tag->lang == TM_PARSER_PASCAL ? " : " : " ";
-			utf8_name = g_strconcat(tag->name, sep, tag->var_type, NULL);
-		}
+		utf8_name = tm_parser_format_variable(tag->lang, tag->name, tag->var_type);
 	}
 
 	/* encodings_convert_to_utf8_from_charset() fails with charset "None", so skip conversion

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -2511,11 +2511,7 @@ gint symbols_get_current_function(GeanyDocument *doc, const gchar **tagname)
 gint symbols_get_current_scope(GeanyDocument *doc, const gchar **tagname)
 {
 	TMTagType tag_types = (tm_tag_function_t | tm_tag_method_t | tm_tag_class_t |
-			tm_tag_struct_t | tm_tag_enum_t | tm_tag_union_t);
-
-	/* Python parser reports imports as namespaces which confuses the scope detection */
-	if (doc && doc->file_type->lang != filetypes[GEANY_FILETYPES_PYTHON]->lang)
-		tag_types |= tm_tag_namespace_t;
+			tm_tag_struct_t | tm_tag_enum_t | tm_tag_union_t | tm_tag_namespace_t);
 
 	return get_current_tag_name_cached(doc, tagname, tag_types);
 }

--- a/src/tagmanager/tm_ctags.c
+++ b/src/tagmanager/tm_ctags.c
@@ -154,36 +154,6 @@ static gboolean init_tag(TMTag *tag, TMSourceFile *file, const tagEntryInfo *tag
 }
 
 
-/* add argument list of __init__() Python methods to the class tag */
-static void update_python_arglist(const TMTag *tag, TMSourceFile *source_file)
-{
-	guint i;
-	const gchar *parent_tag_name;
-
-	if (tag->type != tm_tag_method_t || tag->scope == NULL ||
-		g_strcmp0(tag->name, "__init__") != 0)
-		return;
-
-	parent_tag_name = strrchr(tag->scope, '.');
-	if (parent_tag_name)
-		parent_tag_name++;
-	else
-		parent_tag_name = tag->scope;
-
-	/* going in reverse order because the tag was added recently */
-	for (i = source_file->tags_array->len; i > 0; i--)
-	{
-		TMTag *prev_tag = (TMTag *) source_file->tags_array->pdata[i - 1];
-		if (g_strcmp0(prev_tag->name, parent_tag_name) == 0)
-		{
-			g_free(prev_tag->arglist);
-			prev_tag->arglist = g_strdup(tag->arglist);
-			break;
-		}
-	}
-}
-
-
 static gint write_entry(tagWriter *writer, MIO * mio, const tagEntryInfo *const tag, void *user_data)
 {
 	TMSourceFile *source_file = user_data;
@@ -196,9 +166,6 @@ static gint write_entry(tagWriter *writer, MIO * mio, const tagEntryInfo *const 
 		tm_tag_unref(tm_tag);
 		return 0;
 	}
-
-	if (tm_tag->lang == TM_PARSER_PYTHON)
-		update_python_arglist(tm_tag, source_file);
 
 	g_ptr_array_add(source_file->tags_array, tm_tag);
 

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -818,6 +818,33 @@ void tm_parser_verify_type_mappings(void)
 }
 
 
+/* When the suffix of 'str' is an operator that should trigger scope
+ * autocompletion, this function should return the length of the operator,
+ * zero otherwise. */
+gint tm_parser_scope_autocomplete_suffix(TMParserType lang, const gchar *str)
+{
+	const gchar *sep = tm_parser_context_separator(lang);
+
+	if (g_str_has_suffix(str, sep))
+		return strlen(sep);
+
+	switch (lang)
+	{
+		case TM_PARSER_C:
+		case TM_PARSER_CPP:
+			if (g_str_has_suffix(str, "."))
+				return 1;
+			else if (g_str_has_suffix(str, "->"))
+				return 2;
+			else if (lang == TM_PARSER_CPP && g_str_has_suffix(str, "->*"))
+				return 3;
+		default:
+			break;
+	}
+	return 0;
+}
+
+
 /* Get the name of constructor method. Arguments of this method will be used
  * for calltips when creating an object using the class name
  * (e.g. after the opening brace in 'c = MyClass()' in Python) */

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -882,6 +882,76 @@ gboolean tm_parser_enable_kind(TMParserType lang, gchar kind)
 }
 
 
+gchar *tm_parser_format_variable(TMParserType lang, const gchar *name, const gchar *type)
+{
+	if (!type)
+		return NULL;
+
+	switch (lang)
+	{
+		case TM_PARSER_PASCAL:
+			return g_strconcat(name, " : ", type, NULL);
+		case TM_PARSER_GO:
+			return g_strconcat(name, " ", type, NULL);
+		default:
+			return g_strconcat(type, " ", name, NULL);
+	}
+}
+
+
+gchar *tm_parser_format_function(TMParserType lang, const gchar *fname, const gchar *args,
+	const gchar *retval, const gchar *scope)
+{
+	GString *str;
+
+	if (!args)  /* not a function */
+		return NULL;
+
+	str = g_string_new(NULL);
+
+	if (scope)
+	{
+		g_string_append(str, scope);
+		g_string_append(str, tm_parser_context_separator(lang));
+	}
+	g_string_append(str, fname);
+	g_string_append_c(str, ' ');
+	g_string_append(str, args);
+
+	if (retval)
+	{
+		switch (lang)
+		{
+			case TM_PARSER_PASCAL:
+			case TM_PARSER_GO:
+			{
+				/* retval after function */
+				const gchar *sep;
+				switch (lang)
+				{
+					case TM_PARSER_PASCAL:
+						sep = " : ";
+						break;
+					default:
+						sep = " ";
+						break;
+				}
+				g_string_append(str, sep);
+				g_string_append(str, retval);
+				break;
+			}
+			default:
+				/* retval before function */
+				g_string_prepend_c(str, ' ');
+				g_string_prepend(str, retval);
+				break;
+		}
+	}
+
+	return g_string_free(str, FALSE);
+}
+
+
 const gchar *tm_parser_context_separator(TMParserType lang)
 {
 	switch (lang)

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -933,10 +933,11 @@ gchar *tm_parser_format_variable(TMParserType lang, const gchar *name, const gch
 
 	switch (lang)
 	{
-		case TM_PARSER_PASCAL:
-			return g_strconcat(name, " : ", type, NULL);
 		case TM_PARSER_GO:
 			return g_strconcat(name, " ", type, NULL);
+		case TM_PARSER_PASCAL:
+		case TM_PARSER_PYTHON:
+			return g_strconcat(name, ": ", type, NULL);
 		default:
 			return g_strconcat(type, " ", name, NULL);
 	}
@@ -966,15 +967,19 @@ gchar *tm_parser_format_function(TMParserType lang, const gchar *fname, const gc
 	{
 		switch (lang)
 		{
-			case TM_PARSER_PASCAL:
 			case TM_PARSER_GO:
+			case TM_PARSER_PASCAL:
+			case TM_PARSER_PYTHON:
 			{
 				/* retval after function */
 				const gchar *sep;
 				switch (lang)
 				{
 					case TM_PARSER_PASCAL:
-						sep = " : ";
+						sep = ": ";
+						break;
+					case TM_PARSER_PYTHON:
+						sep = " -> ";
 						break;
 					default:
 						sep = " ";

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -818,6 +818,23 @@ void tm_parser_verify_type_mappings(void)
 }
 
 
+/* Get the name of constructor method. Arguments of this method will be used
+ * for calltips when creating an object using the class name
+ * (e.g. after the opening brace in 'c = MyClass()' in Python) */
+const gchar *tm_parser_get_constructor_method(TMParserType lang)
+{
+	switch (lang)
+	{
+		case TM_PARSER_D:
+			return "this";
+		case TM_PARSER_PYTHON:
+			return "__init__";
+		default:
+			return NULL;
+	}
+}
+
+
 static gchar *replace_string_if_present(gchar *haystack, gchar *needle, gchar *subst)
 {
 	if (strstr(haystack, needle))

--- a/src/tagmanager/tm_parser.h
+++ b/src/tagmanager/tm_parser.h
@@ -130,6 +130,11 @@ gboolean tm_parser_enable_role(TMParserType lang, gchar kind);
 
 gboolean tm_parser_enable_kind(TMParserType lang, gchar kind);
 
+gchar *tm_parser_format_variable(TMParserType lang, const gchar *name, const gchar *type);
+
+gchar *tm_parser_format_function(TMParserType lang, const gchar *fname, const gchar *args,
+	const gchar *retval, const gchar *scope);
+
 const gchar *tm_parser_context_separator(TMParserType lang);
 
 gboolean tm_parser_has_full_context(TMParserType lang);

--- a/src/tagmanager/tm_parser.h
+++ b/src/tagmanager/tm_parser.h
@@ -124,6 +124,8 @@ gchar tm_parser_get_tag_kind(TMTagType type, TMParserType lang);
 
 TMTagType tm_parser_get_subparser_type(TMParserType lang, TMParserType sublang, TMTagType type);
 
+const gchar *tm_parser_get_constructor_method(TMParserType lang);
+
 gchar *tm_parser_update_scope(TMParserType lang, gchar *scope);
 
 gboolean tm_parser_enable_role(TMParserType lang, gchar kind);

--- a/src/tagmanager/tm_parser.h
+++ b/src/tagmanager/tm_parser.h
@@ -124,6 +124,8 @@ gchar tm_parser_get_tag_kind(TMTagType type, TMParserType lang);
 
 TMTagType tm_parser_get_subparser_type(TMParserType lang, TMParserType sublang, TMTagType type);
 
+gint tm_parser_scope_autocomplete_suffix(TMParserType lang, const gchar *str);
+
 const gchar *tm_parser_get_constructor_method(TMParserType lang);
 
 gchar *tm_parser_update_scope(TMParserType lang, gchar *scope);

--- a/tests/ctags/cython_sample.pyx.tags
+++ b/tests/ctags/cython_sample.pyx.tags
@@ -1,5 +1,5 @@
 # format=tagmanager
-CDefClassÌ1Í(self)Ö0
+CDefClassÌ1Ö0
 StdClassÌ1Ö0
 __init__Ì128Í(self)ÎCDefClassÖ0
 c_methodÌ128Í(self,int i)ÎCDefClassÖ0

--- a/tests/ctags/py_constructor_arglist.py.tags
+++ b/tests/ctags/py_constructor_arglist.py.tags
@@ -3,7 +3,7 @@ HttpResponseÌ32768Ö0
 HttpResponseBadRequestÌ32768Ö0
 InterfaceDataValidationErrorÌ32768Ö0
 RequestContextÌ32768Ö0
-SomeClassÌ1Í(self, filename, pathsep='', treegap=64)Ö0
+SomeClassÌ1Ö0
 __init__Ì128Í(self, filename, pathsep='', treegap=64)ÎSomeClassÖ0
 btopenÌ32768Ö0
 csrf_exemptÌ32768Ö0

--- a/tests/ctags/simple.py.tags
+++ b/tests/ctags/simple.py.tags
@@ -14,7 +14,7 @@ even_moreÌ128Í()Î_test.ignored_function.more_nesting.deeply_nestedÖ0
 fooÌ16Í(Ö0
 ignored_functionÌ16Í()Î_testÖ0
 more_nestingÌ16Í()Î_test.ignored_functionÖ0
-oneÌ1Í(self, filename, pathsep='', treegap=64)Ö0
+oneÌ1Ö0
 onlyÌ128Í(arg)ÎtwoÖ0
 public_functionÌ128Í(self, key)ÎoneÖ0
 so_is_thisÌ1ÎoneÖ0


### PR DESCRIPTION
There is various language-specific code related to tag manager which is scattered across Geany codebase. First, it makes such code hard to maintain, second, it makes it hard to discover for people adding support for a new parser to Geany. This code includes:

1. Formatting of functions for calltips and popups for sidebar (also for variables). This is language-specific where e.g. function return type can be in front of function for C but behind function for go.
2. Displaying of calltips for object constructors based on certain method name (`__init__()` arguments after typing `MyClass(` for Python) - there were actually two different implementations of this feature, one for Python, one for D.
3. Code detecting whether scope autocompletion should be triggered - the characters triggering it are specific to used languages.

Since `tm_parser.c` already contains language-specific mappings from parsers, it seems to be a good home for this kind of code.

The only remaining language-specific tag manager related code is the mappings  of tags to the symbol tree in `symbols.c` which I'd like to move to `tm_parser.c` once the various parser pull requests are merged (not to introduce merge conflicts).