### PR TITLE
Use asm parser from uctags

### DIFF
--- a/ctags/Makefile.am
+++ b/ctags/Makefile.am
@@ -46,7 +46,7 @@ parsers = \
 	parsers/abaqus.c \
 	parsers/abc.c \
 	parsers/asciidoc.c \
-	parsers/geany_asm.c \
+	parsers/asm.c \
 	parsers/basic.c \
 	parsers/bibtex.c \
 	parsers/geany_c.c \

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -174,6 +174,7 @@ static TMParserMapEntry map_ASM[] = {
 	{'l', tm_tag_namespace_t},
 	{'m', tm_tag_function_t},
 	{'t', tm_tag_struct_t},
+	{'s', tm_tag_undef_t},
 };
 
 /* not in universal-ctags */


### PR DESCRIPTION
This parser depends on the new `cpreprocessor` which is now merged with the new cxx parser so the asm parser can be copied now.