### PR TITLE
Remove deprecated symbols from plugindata.h

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -31,7 +31,6 @@
 #ifndef GEANY_PLUGIN_DATA_H
 #define GEANY_PLUGIN_DATA_H 1
 
-#include "geany.h"  /* for GEANY_DEPRECATED */
 #include "build.h"  /* GeanyBuildGroup, GeanyBuildSource, GeanyBuildCmdEntries enums */
 #include "document.h" /* GeanyDocument */
 #include "editor.h"	/* GeanyEditor, GeanyIndentType */
@@ -385,78 +384,6 @@ struct GeanyProxyFuncs
 };
 
 gint geany_plugin_register_proxy(GeanyPlugin *plugin, const gchar **extensions);
-
-/* Deprecated aliases */
-#ifndef GEANY_DISABLE_DEPRECATED
-
-/* This remains so that older plugins that contain a `GeanyFunctions *geany_functions;`
- * variable in their plugin - as was previously required - will still compile
- * without changes.  */
-typedef struct GeanyFunctionsUndefined GeanyFunctions GEANY_DEPRECATED;
-
-/** @deprecated - use plugin_set_key_group() instead.
- * @see PLUGIN_KEY_GROUP() macro. */
-typedef struct GeanyKeyGroupInfo
-{
-	const gchar *name;		/**< Group name used in the configuration file, such as @c "html_chars" */
-	gsize count;			/**< The number of keybindings the group will hold */
-}
-GeanyKeyGroupInfo GEANY_DEPRECATED_FOR(plugin_set_key_group);
-
-/** @deprecated - use plugin_set_key_group() instead.
- * Declare and initialise a keybinding group.
- * @code GeanyKeyGroup *plugin_key_group; @endcode
- * You must then set the @c plugin_key_group::keys[] entries for the group in plugin_init(),
- * normally using keybindings_set_item().
- * The @c plugin_key_group::label field is set by Geany after @c plugin_init()
- * is called, to the name of the plugin.
- * @param group_name A unique group name (without quotes) to be used in the
- * configuration file, such as @c html_chars.
- * @param key_count	The number of keybindings the group will hold. */
-#define PLUGIN_KEY_GROUP(group_name, key_count) \
-	/* We have to declare this as a single element array.
-	 * Declaring as a pointer to a struct doesn't work with g_module_symbol(). */ \
-	GeanyKeyGroupInfo plugin_key_group_info[1] = \
-	{ \
-		{G_STRINGIFY(group_name), key_count} \
-	};\
-	GeanyKeyGroup *plugin_key_group = NULL;
-
-/** @deprecated Use @ref ui_add_document_sensitive() instead.
- * Flags to be set by plugins in PluginFields struct. */
-typedef enum
-{
-	/** Whether a plugin's menu item should be disabled when there are no open documents */
-	PLUGIN_IS_DOCUMENT_SENSITIVE	= 1 << 0
-}
-PluginFlags;
-
-/** @deprecated Use @ref ui_add_document_sensitive() instead.
- * Fields set and owned by the plugin. */
-typedef struct PluginFields
-{
-	/** Bitmask of @c PluginFlags. */
-	PluginFlags	flags;
-	/** Pointer to a plugin's menu item which will be automatically enabled/disabled when there
-	 *  are no open documents and @c PLUGIN_IS_DOCUMENT_SENSITIVE is set.
-	 *  This is required if using @c PLUGIN_IS_DOCUMENT_SENSITIVE, ignored otherwise */
-	GtkWidget	*menu_item;
-}
-PluginFields GEANY_DEPRECATED_FOR(ui_add_document_sensitive);
-
-#define document_reload_file document_reload_force
-
-/** @deprecated - copy into your plugin code if needed.
- * @c NULL-safe way to get the index of @a doc_ptr in the documents array. */
-#define DOC_IDX(doc_ptr) \
-	(doc_ptr ? doc_ptr->index : -1)
-#define DOC_IDX_VALID(doc_idx) \
-	((doc_idx) >= 0 && (guint)(doc_idx) < documents_array->len && documents[doc_idx]->is_valid)
-
-#define GEANY_WINDOW_MINIMAL_WIDTH		550
-#define GEANY_WINDOW_MINIMAL_HEIGHT		GEANY_DEFAULT_DIALOG_HEIGHT
-
-#endif	/* GEANY_DISABLE_DEPRECATED */
 
 G_END_DECLS
 

--- a/src/pluginprivate.h
+++ b/src/pluginprivate.h
@@ -55,7 +55,6 @@ typedef struct GeanyPluginPrivate
 	void		(*configure_single) (GtkWidget *parent); /* plugin configure dialog, optional and deprecated */
 
 	/* extra stuff */
-	PluginFields	fields;
 	GeanyKeyGroup	*key_group;
 	GeanyAutoSeparator	toolbar_separator;
 	GArray			*signal_ids;			/* SignalConnection's to disconnect when unloading */


### PR DESCRIPTION
This PR removes remaining deprecated symbols from `plugindata.h`.  (See #3019 for overview of currently deprecated symbols.) 

* GeanyFunctions
* GeanyKeyGroupInfo
* PluginFields
* PluginFlags
* PLUGIN_KEY_GROUP
* document_reload_file
* DOC_IDX(doc_ptr)
* DOC_IDX_VALID(doc_idx)
* GEANY_WINDOW_MINIMAL_HEIGHT
* GEANY_WINDOW_MINIMAL_WIDTH

The multiterm plugin, which currently doesn't compile because of GTK2-related dependencies, refers to the following symbols:  PluginFlags, PluginFields, document_reload_file

The other symbols removed in this PR are not used by any known plugins.