### PR TITLE
Update doc->priv->tag_tree_dirty only if doc is set

### DIFF
--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -191,7 +191,7 @@ void sidebar_update_tag_list(GeanyDocument *doc, gboolean update)
 
 	g_return_if_fail(doc == NULL || doc->is_valid);
 
-	if (update)
+	if (update && doc != NULL)
 		doc->priv->tag_tree_dirty = TRUE;
 
 	if (gtk_notebook_get_current_page(GTK_NOTEBOOK(main_widgets.sidebar_notebook)) != TREEVIEW_SYMBOL)


### PR DESCRIPTION
This prevents a potential crash if `sidebar_update_tag_list()` is called with update=true and document=NULL.

Found this by accident while testing the tag tree filter PR.
Currently, this is no problem as `sidebar_update_tag_list()` is not called with update=true and document=NULL but just in case it might happen.