### PR TITLE
Add po/*.po~ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ Makefile.in
 /po/Makevars.template
 /po/*.mo
 /po/*.pot
+/po/*.po~
 /po/POTFILES
 /po/POTFILES.ignore
 /po/POTFILES.in.missing


### PR DESCRIPTION
After recent progress update messages in other pull requests I checked out the shiny latest to make sure all is still well and ready to pave the way for the one pr I have that depends on it, and after building I found a bunch of junk in the git status. Added a line to gitignore to hide the compile time generated junk.