### PR TITLE
Windows: Bundle xz in installer

### DIFF
--- a/scripts/gtk-bundle-from-msys2.sh
+++ b/scripts/gtk-bundle-from-msys2.sh
@@ -55,6 +55,7 @@ libxml2
 pango
 pcre
 pixman
+xz
 zlib
 "
 


### PR DESCRIPTION
Xz is needed for librsvg.

Followup of https://github.com/geany/geany/pull/3082.