### PR TITLE
Scintilla 5.1.5 aftermath

### DIFF
--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -726,14 +726,12 @@ gchar *sci_get_line(ScintillaObject *sci, gint line_num)
  *
  * @param sci Scintilla widget.
  * @param len Length of @a text buffer, usually sci_get_length() + 1.
- * @param text Text buffer; must be allocated @a len + 1 bytes for null-termination. */
+ * @param text Text buffer; must be allocated @a len bytes for null-termination. */
 GEANY_API_SYMBOL
 void sci_get_text(ScintillaObject *sci, gint len, gchar *text)
 {
-	if (len > 0) {
-		SSM(sci, SCI_GETTEXT, (uptr_t) len - 1, (sptr_t) text);
-		text[len] = '\0';
-	}
+	g_return_if_fail(len > 0);
+	SSM(sci, SCI_GETTEXT, (uptr_t) len - 1, (sptr_t) text);
 }
 
 
@@ -751,15 +749,13 @@ gchar *sci_get_contents(ScintillaObject *sci, gint buffer_len)
 {
 	gchar *text;
 
-	if (buffer_len < 0)
-		return sci_get_string(sci, SCI_GETTEXT, 0);
+	g_return_if_fail(buffer_len != 0);
 
-	text = NULL;
-	if (buffer_len > 0) {
-		text = g_malloc(buffer_len);
-		sci_get_text(sci, buffer_len - 1, text);
-		text[buffer_len - 1] = '\0';
-	}
+	if (buffer_len < 0)
+		buffer_len = sci_get_length(sci) + 1;
+
+	text = g_malloc(buffer_len);
+	SSM(sci, SCI_GETTEXT, (uptr_t) buffer_len - 1, (sptr_t) text);
 	return text;
 }
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -227,7 +227,7 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 				break;
 			case 's':
 			{
-				gint len = sci_get_selected_text_length(sci) - 1;
+				gint len = sci_get_selected_text_length(sci);
 				/* check if whole lines are selected */
 				if (!len || sci_get_col_from_position(sci,
 						sci_get_selection_start(sci)) != 0 ||
@@ -241,7 +241,7 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 			}
 			case 'n' :
 				g_string_append_printf(stats_str, "%d",
-					sci_get_selected_text_length(doc->editor->sci) - 1);
+					sci_get_selected_text_length(doc->editor->sci));
 				break;
 			case 'w':
 				/* RO = read-only */


### PR DESCRIPTION
This commit fixes a few problems introduced by the last Scintilla update.
That update caused some headache around the incompatible changes to
`SCI_GETTEXT`, `SCI_GETSELTEXT`, and `SCI_GETCURLINE`.

- An explicit NUL termination was added to `sci_get_text()`. This is both
  superflous and wrong (it writes behind the allocated buffer) as SCI_GETTEXT
  already does NUL termination.

- In `sci_get_contents()`, sci_get_string() cannot be used. That would call
  SCI_GETTEXT with length == 0 which is not the desired outcome. Instead,
  basically revert to the old implementation but account for the API change.

- The callers of sci_get_selected_text_length() must be adapted, this
  was missing yet. sci_get_selected_text_length() return value does not
  include the NUL termination anymore.

Resolves #3095

Fixes: d7c985e47 ("Adapt to SCI_GETTEXT changes")