### PR TITLE
Update sci_get_selected_text_length() after change to Scintilla 5.1.5 

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 242
+#define GEANY_API_VERSION 243
 
 /* hack to have a different ABI when built with different GTK major versions
  * because loading plugins linked to a different one leads to crashes.

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -792,12 +792,24 @@ gchar *sci_get_selection_contents(ScintillaObject *sci)
 
 
 /** Gets selected text length including the terminating NUL character.
+ * @deprecated sci_get_selected_text_length is deprecated and should not be used in newly-written code.
+ * Use sci_get_selected_text_length2() instead.
  * @param sci Scintilla widget.
  * @return Length. */
 GEANY_API_SYMBOL
 gint sci_get_selected_text_length(ScintillaObject *sci)
 {
 	return (gint) SSM(sci, SCI_GETSELTEXT, 0, 0) + 1;
+}
+
+
+/** Gets selected text length without the terminating NUL character.
+ * @param sci Scintilla widget.
+ * @return Length. */
+GEANY_API_SYMBOL
+gint sci_get_selected_text_length2(ScintillaObject *sci)
+{
+	return (gint) SSM(sci, SCI_GETSELTEXT, 0, 0);
 }
 
 

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -749,7 +749,7 @@ gchar *sci_get_contents(ScintillaObject *sci, gint buffer_len)
 {
 	gchar *text;
 
-	g_return_if_fail(buffer_len != 0);
+	g_return_val_if_fail(buffer_len != 0, NULL);
 
 	if (buffer_len < 0)
 		buffer_len = sci_get_length(sci) + 1;

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -791,13 +791,13 @@ gchar *sci_get_selection_contents(ScintillaObject *sci)
 }
 
 
-/** Gets selected text length.
+/** Gets selected text length including the terminating NUL character.
  * @param sci Scintilla widget.
  * @return Length. */
 GEANY_API_SYMBOL
 gint sci_get_selected_text_length(ScintillaObject *sci)
 {
-	return (gint) SSM(sci, SCI_GETSELTEXT, 0, 0);
+	return (gint) SSM(sci, SCI_GETSELTEXT, 0, 0) + 1;
 }
 
 

--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -64,7 +64,7 @@ void				sci_set_selection_end		(ScintillaObject *sci, gint position);
 
 gint				sci_get_length				(ScintillaObject *sci);
 gchar*				sci_get_contents			(ScintillaObject *sci, gint buffer_len);
-gint				sci_get_selected_text_length(ScintillaObject *sci);
+gint				sci_get_selected_text_length2(ScintillaObject *sci);
 gchar*				sci_get_selection_contents	(ScintillaObject *sci);
 gchar*				sci_get_line				(ScintillaObject *sci, gint line_num);
 gint 				sci_get_line_length			(ScintillaObject *sci, gint line);
@@ -106,6 +106,7 @@ gint				sci_find_matching_brace		(ScintillaObject *sci, gint pos);
 void				sci_get_text				(ScintillaObject *sci, gint len, gchar *text) GEANY_DEPRECATED_FOR(sci_get_contents);
 void				sci_get_selected_text		(ScintillaObject *sci, gchar *text) GEANY_DEPRECATED_FOR(sci_get_selection_contents);
 void				sci_get_text_range			(ScintillaObject *sci, gint start, gint end, gchar *text) GEANY_DEPRECATED_FOR(sci_get_contents_range);
+gint				sci_get_selected_text_length(ScintillaObject *sci) GEANY_DEPRECATED_FOR(sci_get_selected_text_length2);
 #endif	/* GEANY_DISABLE_DEPRECATED */
 
 #ifdef GEANY_PRIVATE

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -227,7 +227,7 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 				break;
 			case 's':
 			{
-				gint len = sci_get_selected_text_length(sci) - 1;
+				gint len = sci_get_selected_text_length2(sci);
 				/* check if whole lines are selected */
 				if (!len || sci_get_col_from_position(sci,
 						sci_get_selection_start(sci)) != 0 ||
@@ -241,7 +241,7 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 			}
 			case 'n' :
 				g_string_append_printf(stats_str, "%d",
-					sci_get_selected_text_length(doc->editor->sci) - 1);
+					sci_get_selected_text_length2(doc->editor->sci));
 				break;
 			case 'w':
 				/* RO = read-only */

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -227,7 +227,7 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 				break;
 			case 's':
 			{
-				gint len = sci_get_selected_text_length(sci);
+				gint len = sci_get_selected_text_length(sci) - 1;
 				/* check if whole lines are selected */
 				if (!len || sci_get_col_from_position(sci,
 						sci_get_selection_start(sci)) != 0 ||
@@ -241,7 +241,7 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 			}
 			case 'n' :
 				g_string_append_printf(stats_str, "%d",
-					sci_get_selected_text_length(doc->editor->sci));
+					sci_get_selected_text_length(doc->editor->sci) - 1);
 				break;
 			case 'w':
 				/* RO = read-only */


### PR DESCRIPTION
Update sci_get_selected_text_length() so it returns the same value like
Scintilla 5.1.4 and earlier versions.