### PR TITLE
Allow mapping ctags "roles" to arbitrary tag manager type

### DIFF
--- a/src/tagmanager/tm_ctags.c
+++ b/src/tagmanager/tm_ctags.c
@@ -87,6 +87,27 @@ static void enable_kinds_and_roles()
 }
 
 
+static TMTagType get_type_from_roles(const tagEntryInfo *tag_entry, guchar kind_letter, TMParserType lang)
+{
+	kindDefinition *kind_definition = getLanguageKind(tag_entry->langType, tag_entry->kindIndex);
+	if (tag_entry->extensionFields.roleBits > 0 && kind_definition->nRoles > 0)
+	{
+		gint i;
+		for (i = 0; i < kind_definition->nRoles; i++)
+		{
+			if (kind_definition->roles[i].enabled &&
+				((tag_entry->extensionFields.roleBits >> i) & (roleBitsType)1))
+			{
+				TMTagType type = tm_parser_get_tag_type_from_role(kind_letter, kind_definition->roles[i].name, lang);
+				if (type != tm_tag_undef_t)
+					return type;
+			}
+		}
+	}
+	return tm_tag_undef_t;
+}
+
+
 /*
  Initializes a TMTag structure with information from a ctagsTag struct
  used by the ctags parsers. Note that the TMTag structure must be malloc()ed
@@ -107,7 +128,9 @@ static gboolean init_tag(TMTag *tag, TMSourceFile *file, const tagEntryInfo *tag
 
 	lang = tag_entry->langType;
 	kind_letter = getLanguageKind(tag_entry->langType, tag_entry->kindIndex)->letter;
-	type = tm_parser_get_tag_type(kind_letter, lang);
+	type = get_type_from_roles(tag_entry, kind_letter, lang);
+	if (type == tm_tag_undef_t)
+		type = tm_parser_get_tag_type(kind_letter, lang);
 	if (file->lang != lang)  /* this is a tag from a subparser */
 	{
 		/* check for possible re-definition of subparser type */

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -695,6 +695,24 @@ TMTagType tm_parser_get_tag_type(gchar kind, TMParserType lang)
 }
 
 
+TMTagType tm_parser_get_tag_type_from_role(gchar kind, const gchar *role, TMParserType lang)
+{
+	switch (lang)
+	{
+/*
+		case TM_PARSER_GO:
+		{
+			if (kind == 'p' && g_strcmp0(role, "imported") == 0)
+				return tm_tag_externvar_t;
+		}
+*/
+		default:
+			break;
+	}
+	return tm_tag_undef_t;
+}
+
+
 gchar tm_parser_get_tag_kind(TMTagType type, TMParserType lang)
 {
 	TMParserMap *map = &parser_map[lang];

--- a/src/tagmanager/tm_parser.h
+++ b/src/tagmanager/tm_parser.h
@@ -121,6 +121,8 @@ void tm_parser_verify_type_mappings(void);
 
 TMTagType tm_parser_get_tag_type(gchar kind, TMParserType lang);
 
+TMTagType tm_parser_get_tag_type_from_role(gchar kind, const gchar *role, TMParserType lang);
+
 gchar tm_parser_get_tag_kind(TMTagType type, TMParserType lang);
 
 TMTagType tm_parser_get_subparser_type(TMParserType lang, TMParserType sublang, TMTagType type);


### PR DESCRIPTION
This patch allows us to map roles reported by ctags to different tag
manager types. For instance, for the Go parser both packages and
imports are reported by the kind letter 'p' and are distinguished only
by the "imported" role.

(Code doing this for Go is commented-out for now because we need some
more improvements of the symbol tree because all root categories are
occupied and there's no place where to put the imports now.)