### PR TITLE
Hide overwrite button for readonly documents.

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -3604,7 +3604,7 @@ static void monitor_reload_file(GeanyDocument *doc)
 
 		bar = document_show_message(doc, GTK_MESSAGE_QUESTION, on_monitor_reload_file_response,
 				_("_Reload"), RESPONSE_DOCUMENT_RELOAD,
-				_("_Overwrite"), RESPONSE_DOCUMENT_SAVE,
+				doc->readonly ? NULL : _("_Overwrite"), doc->readonly ? GTK_RESPONSE_NONE :RESPONSE_DOCUMENT_SAVE,
 				GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
 				_("Do you want to reload it?"),
 				_("The file '%s' on the disk is more recent than the current buffer."),


### PR DESCRIPTION
I have noticed that even when I mark a document "readonly" in the UI (for example via the document menu), when Geany detects a file change, the requester proposes me to overwrite it anyway.

This looks wrong, I mark the file read only because I want to avoid writing to it by mistake.

I often open the same file in two windows and mark it read only in one of those, I find this better than the split window (which I also use sometimes). I happened to overwrite a file by mistake due to a stray click on the overwrite button, so I decided to create this patch.