### PR TITLE
Unconditionally set up VTE stash group (fixes #3151)

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -861,9 +861,9 @@ static gchar *prepare_run_cmd(GeanyDocument *doc, gchar **working_dir, guint cmd
 	cmd_string = utils_get_locale_from_utf8(cmd_string_utf8);
 
 #ifdef HAVE_VTE
-	if (vte_info.have_vte && vc->run_in_vte)
+	if (vte_info.have_vte && vte_config.run_in_vte)
 	{
-		if (vc->skip_run_script)
+		if (vte_config.skip_run_script)
 		{
 			utils_free_pointers(2, cmd_string_utf8, working_dir_utf8, NULL);
 			return cmd_string;
@@ -914,7 +914,7 @@ static void build_run_cmd(GeanyDocument *doc, guint cmdindex)
 	run_info[cmdindex].file_type_id = doc->file_type->id;
 
 #ifdef HAVE_VTE
-	if (vte_info.have_vte && vc->run_in_vte)
+	if (vte_info.have_vte && vte_config.run_in_vte)
 	{
 		gchar *vte_cmd;
 
@@ -922,7 +922,7 @@ static void build_run_cmd(GeanyDocument *doc, guint cmdindex)
 		SETPTR(run_cmd, utils_get_utf8_from_locale(run_cmd));
 		SETPTR(working_dir, utils_get_utf8_from_locale(working_dir));
 
-		if (vc->skip_run_script)
+		if (vte_config.skip_run_script)
 			vte_cmd = g_strconcat(run_cmd, "\n", NULL);
 		else
 			vte_cmd = g_strconcat("\n/bin/sh ", run_cmd, "\n", NULL);
@@ -933,13 +933,13 @@ static void build_run_cmd(GeanyDocument *doc, guint cmdindex)
 			const gchar *msg = _("File not executed because the terminal may contain some input (press Ctrl+C or Enter to clear it).");
 			ui_set_statusbar(FALSE, "%s", msg);
 			geany_debug("%s", msg);
-			if (!vc->skip_run_script)
+			if (!vte_config.skip_run_script)
 				g_unlink(run_cmd);
 		}
 
 		/* show the VTE */
 		gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_VTE);
-		gtk_widget_grab_focus(vc->vte);
+		gtk_widget_grab_focus(vte_config.vte);
 		msgwin_show_hide(TRUE);
 
 		run_info[cmdindex].pid = 1;
@@ -2823,4 +2823,3 @@ gboolean build_keybinding(guint key_id)
 		gtk_menu_item_activate(GTK_MENU_ITEM(item));
 	return TRUE;
 }
-

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1259,7 +1259,7 @@ void on_menu_select_all1_activate(GtkMenuItem *menuitem, gpointer user_data)
 	}
 	/* special case for Select All in the VTE widget */
 #ifdef HAVE_VTE
-	else if (vte_info.have_vte && focusw == vc->vte)
+	else if (vte_info.have_vte && focusw == vte_config.vte)
 	{
 		vte_select_all();
 	}

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1204,7 +1204,7 @@ static gboolean check_menu_key(GeanyDocument *doc, guint keyval, guint state, gu
 		 || focusw == msgwindow.tree_msg
 		 || focusw == msgwindow.scribble
 #ifdef HAVE_VTE
-		 || (vte_info.have_vte && focusw == vc->vte)
+		 || (vte_info.have_vte && focusw == vte_config.vte)
 #endif
 		)
 		{
@@ -1231,12 +1231,12 @@ static gboolean check_vte(GdkModifierType state, guint keyval)
 	GeanyKeyGroup *group;
 	GtkWidget *widget;
 
-	if (gtk_window_get_focus(GTK_WINDOW(main_widgets.window)) != vc->vte)
+	if (gtk_window_get_focus(GTK_WINDOW(main_widgets.window)) != vte_config.vte)
 		return FALSE;
 	/* let VTE copy/paste override any user keybinding */
 	if (state == (GEANY_PRIMARY_MOD_MASK | GDK_SHIFT_MASK) && (keyval == GDK_KEY_c || keyval == GDK_KEY_v))
 		return TRUE;
-	if (! vc->enable_bash_keys)
+	if (! vte_config.enable_bash_keys)
 		return FALSE;
 	/* prevent menubar flickering: */
 	if (state == GDK_SHIFT_MASK && (keyval >= GDK_KEY_a && keyval <= GDK_KEY_z))

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -299,6 +299,17 @@ static void init_pref_groups(void)
 		"socket_remote_cmd_port", SOCKET_WINDOWS_REMOTE_CMD_PORT);
 #endif
 
+#ifdef HAVE_VTE
+	/* various VTE prefs. */
+	group = stash_group_new("VTE");
+	configuration_add_various_pref_group(group, "terminal");
+
+	stash_group_add_string(group, &vte_config.send_cmd_prefix,
+		"send_cmd_prefix", "");
+	stash_group_add_boolean(group, &vte_config.send_selection_unsafe,
+		"send_selection_unsafe", FALSE);
+#endif
+
 	/* Note: Interface-related various prefs are in ui_init_prefs() */
 
 	/* various build-menu prefs */
@@ -911,7 +922,6 @@ static void load_dialog_prefs(GKeyFile *config)
 	if (vte_info.load_vte && vte_info.load_vte_cmdline /* not disabled on the cmdline */)
 	{
 		VteConfig *vc = &vte_config;
-		StashGroup *group;
 		struct passwd *pw = getpwuid(getuid());
 		const gchar *shell = (pw != NULL) ? pw->pw_shell : "/bin/sh";
 
@@ -943,15 +953,6 @@ static void load_dialog_prefs(GKeyFile *config)
 		vc->scrollback_lines = utils_get_setting_integer(config, "VTE", "scrollback_lines", 500);
 		get_setting_color(config, "VTE", "colour_fore", &vc->colour_fore, "#ffffff");
 		get_setting_color(config, "VTE", "colour_back", &vc->colour_back, "#000000");
-
-		/* various VTE prefs.
-		 * this can't be done in init_pref_groups() because we need to know the value of
-		 * vte_info.load_vte, and `vc` to be initialized */
-		group = stash_group_new("VTE");
-		configuration_add_various_pref_group(group, "terminal");
-
-		stash_group_add_string(group, &vc->send_cmd_prefix, "send_cmd_prefix", "");
-		stash_group_add_boolean(group, &vc->send_selection_unsafe, "send_selection_unsafe", FALSE);
 	}
 #endif
 	/* templates */

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -563,6 +563,7 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, "VTE", "load_vte", vte_info.load_vte);
 	if (vte_info.have_vte)
 	{
+		VteConfig *vc = &vte_config;
 		gchar *tmp_string;
 
 		g_key_file_set_string(config, "VTE", "font", vc->font);
@@ -909,6 +910,7 @@ static void load_dialog_prefs(GKeyFile *config)
 	vte_info.load_vte = utils_get_setting_boolean(config, "VTE", "load_vte", TRUE);
 	if (vte_info.load_vte && vte_info.load_vte_cmdline /* not disabled on the cmdline */)
 	{
+		VteConfig *vc = &vte_config;
 		StashGroup *group;
 		struct passwd *pw = getpwuid(getuid());
 		const gchar *shell = (pw != NULL) ? pw->pw_shell : "/bin/sh";
@@ -920,7 +922,6 @@ static void load_dialog_prefs(GKeyFile *config)
 			shell = "/bin/bash -l";
 #endif
 
-		vc = g_new0(VteConfig, 1);
 		vte_info.dir = utils_get_setting_string(config, "VTE", "last_dir", NULL);
 		if ((vte_info.dir == NULL || utils_str_equal(vte_info.dir, "")) && pw != NULL)
 			/* last dir is not set, fallback to user's home directory */

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -1281,7 +1281,7 @@ void msgwin_switch_tab(gint tabnum, gboolean show)
 		case MSG_STATUS: widget = msgwindow.tree_status; break;
 		case MSG_MESSAGE: widget = msgwindow.tree_msg; break;
 #ifdef HAVE_VTE
-		case MSG_VTE: widget = (vte_info.have_vte) ? vc->vte : NULL; break;
+		case MSG_VTE: widget = (vte_info.have_vte) ? vte_config.vte : NULL; break;
 #endif
 		default: break;
 	}

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -759,6 +759,8 @@ static void prefs_init_dialog(void)
 	/* VTE settings */
 	if (vte_info.have_vte)
 	{
+		VteConfig *vc = &vte_config;
+
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "font_term");
 		gtk_font_button_set_font_name(GTK_FONT_BUTTON(widget), vc->font);
 
@@ -1232,6 +1234,8 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		/* VTE settings */
 		if (vte_info.have_vte)
 		{
+			VteConfig *vc = &vte_config;
+
 			widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_scrollback");
 			gtk_spin_button_update(GTK_SPIN_BUTTON(widget));
 			vc->scrollback_lines = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));

--- a/src/vte.h
+++ b/src/vte.h
@@ -61,8 +61,8 @@ typedef struct
 	GdkColor colour_fore;
 	GdkColor colour_back;
 } VteConfig;
-extern VteConfig *vc;
 
+extern VteConfig vte_config;
 
 void vte_init(void);
 


### PR DESCRIPTION
The crash was caused by incorrectly reading the send_cmd_prefix pref from the configuration file, because that now happens after setting up the VTE stash group.

Fixes #3151 

