### PR TITLE
session.conf split follow-up: sidebar_page

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -46,6 +46,7 @@
 #include "printing.h"
 #include "project.h"
 #include "sciwrappers.h"
+#include "sidebar.h"
 #include "socket.h"
 #include "stash.h"
 #include "support.h"
@@ -152,8 +153,7 @@ void configuration_add_various_pref_group(struct StashGroup *group,
 }
 
 
-/* The group will be free'd on quitting.
- * @param for_prefs_dialog is whether the group also has Prefs dialog items. */
+/* The group will be free'd on quitting. */
 void configuration_add_session_group(struct StashGroup *group)
 {
 	g_ptr_array_add(keyfile_groups[SESSION], group);
@@ -177,6 +177,7 @@ static void init_pref_groups(void)
 	stash_group_add_toggle_button(group, &file_prefs.tab_close_switch_to_mru,
 		"tab_close_switch_to_mru", FALSE, "check_tab_close_switch_to_mru");
 	stash_group_add_integer(group, &interface_prefs.tab_pos_sidebar, "tab_pos_sidebar", GTK_POS_TOP);
+	stash_group_add_integer(group, &interface_prefs.documents_show_paths, "documents_show_paths", SHOW_PATHS_LIST);
 	stash_group_add_radio_buttons(group, &interface_prefs.sidebar_pos,
 		"sidebar_pos", GTK_POS_LEFT,
 		"radio_sidebar_left", GTK_POS_LEFT,

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -88,7 +88,6 @@ enum
 
 static GtkTreeStore	*store_openfiles;
 static GtkWidget *openfiles_popup_menu;
-static gboolean documents_show_paths;
 static GtkWidget *tag_window;	/* scrolled window that holds the symbol list GtkTreeView */
 
 /* callback prototypes */
@@ -425,7 +424,7 @@ static GtkTreeIter *get_doc_parent(GeanyDocument *doc)
 	GtkTreeModel *model = GTK_TREE_MODEL(store_openfiles);
 	static GIcon *dir_icon = NULL;
 
-	if (!documents_show_paths)
+	if (!interface_prefs.documents_show_paths)
 		return NULL;
 
 	path = g_path_get_dirname(DOC_FILENAME(doc));
@@ -620,10 +619,9 @@ void sidebar_add_common_menu_items(GtkMenu *menu)
 	g_signal_connect(item, "activate", G_CALLBACK(on_hide_sidebar), NULL);
 }
 
-
 static void on_openfiles_show_paths_activate(GtkCheckMenuItem *item, gpointer user_data)
 {
-	documents_show_paths = gtk_check_menu_item_get_active(item);
+	interface_prefs.documents_show_paths = gtk_check_menu_item_get_active(item);
 	sidebar_openfiles_update_all();
 }
 
@@ -728,7 +726,7 @@ static void create_openfiles_popup_menu(void)
 	gtk_container_add(GTK_CONTAINER(openfiles_popup_menu), item);
 
 	doc_items.show_paths = gtk_check_menu_item_new_with_mnemonic(_("Show _Paths"));
-	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(doc_items.show_paths), documents_show_paths);
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(doc_items.show_paths), interface_prefs.documents_show_paths);
 	gtk_widget_show(doc_items.show_paths);
 	gtk_container_add(GTK_CONTAINER(openfiles_popup_menu), doc_items.show_paths);
 	g_signal_connect(doc_items.show_paths, "activate",
@@ -1050,9 +1048,9 @@ static void documents_menu_update(GtkTreeSelection *selection)
 	gtk_widget_set_sensitive(doc_items.find_in_files, sel);
 	g_free(shortname);
 
-	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(doc_items.show_paths), documents_show_paths);
-	gtk_widget_set_sensitive(doc_items.expand_all, documents_show_paths);
-	gtk_widget_set_sensitive(doc_items.collapse_all, documents_show_paths);
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(doc_items.show_paths), interface_prefs.documents_show_paths);
+	gtk_widget_set_sensitive(doc_items.expand_all, interface_prefs.documents_show_paths);
+	gtk_widget_set_sensitive(doc_items.collapse_all, interface_prefs.documents_show_paths);
 }
 
 
@@ -1089,10 +1087,9 @@ void sidebar_init(void)
 	StashGroup *group;
 
 	group = stash_group_new(PACKAGE);
-	stash_group_add_boolean(group, &documents_show_paths, "documents_show_paths", TRUE);
 	stash_group_add_widget_property(group, &ui_prefs.sidebar_page, "sidebar_page", GINT_TO_POINTER(0),
 		main_widgets.sidebar_notebook, "page", 0);
-	configuration_add_pref_group(group, FALSE);
+	configuration_add_session_group(group);
 	stash_group = group;
 
 	/* delay building documents treeview until sidebar font has been read */

--- a/src/sidebar.h
+++ b/src/sidebar.h
@@ -48,6 +48,12 @@ enum
 	SYMBOLS_N_COLUMNS
 };
 
+enum
+{
+	SHOW_PATHS_NONE,
+	SHOW_PATHS_LIST
+};
+
 void sidebar_init(void);
 
 void sidebar_finalize(void);

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -71,6 +71,7 @@ typedef struct GeanyInterfacePrefs
 	gint 			symbols_sort_mode;			/**< symbol list sorting mode */
 	/** whether to show a warning when closing a project to open a new one */
 	gboolean		warn_on_project_close;
+	gint			documents_show_paths;
 }
 GeanyInterfacePrefs;
 


### PR DESCRIPTION
Move sidebar_page layout to session.conf

The current tab of the sidebar notebook is now considered "session-related",
and thus moved from geany.conf to session.conf.

To allow of "sidebar_page" to be loaded from session.conf, the
"documents_show_paths" key is moved to keyfile.c, otherwise it would
also become session-related (due to the StashGroup in sidebar.c being tied
to session.conf).

Suggested by #3007