### PR TITLE
GTK3 toolbar icons size is too big

### DIFF
--- a/data/geany.css
+++ b/data/geany.css
@@ -59,3 +59,8 @@ statusbar {
 	margin: -6px 0;
 }
 */
+
+button {
+	margin: 0;
+	padding: 0;
+}


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/282214/164252394-b1ba04bf-1c93-4353-9a1a-5be7954e1dd4.png)

After

![image](https://user-images.githubusercontent.com/282214/164252437-9c33052b-6c9b-478a-8907-137eb151684f.png)
