### PR TITLE
Enable local variable and function parameter tag reporting for C/C++

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -698,6 +698,7 @@ static gboolean autocomplete_scope(GeanyEditor *editor, const gchar *root, gsize
 {
 	ScintillaObject *sci = editor->sci;
 	gint pos = sci_get_current_position(editor->sci);
+	gint line = sci_get_current_line(editor->sci) + 1;
 	gchar typed = sci_get_char_at(sci, pos - 1);
 	gchar brace_char;
 	gchar *name;
@@ -764,7 +765,7 @@ static gboolean autocomplete_scope(GeanyEditor *editor, const gchar *root, gsize
 	if (symbols_get_current_scope(editor->document, &current_scope) == -1)
 		current_scope = "";
 	tags = tm_workspace_find_scope_members(editor->document->tm_file, name, function,
-				member, current_scope, scope_sep_typed);
+				member, current_scope, line, scope_sep_typed);
 	if (tags)
 	{
 		GPtrArray *filtered = g_ptr_array_new();

--- a/src/editor.c
+++ b/src/editor.c
@@ -2019,12 +2019,19 @@ gboolean editor_show_calltip(GeanyEditor *editor, gint pos)
 static gboolean
 autocomplete_tags(GeanyEditor *editor, GeanyFiletype *ft, const gchar *root, gsize rootlen)
 {
+	GeanyDocument *doc = editor->document;
+	const gchar *current_scope = NULL;
+	guint current_line;
 	GPtrArray *tags;
 	gboolean found;
 
-	g_return_val_if_fail(editor, FALSE);
+	g_return_val_if_fail(editor && doc, FALSE);
 
-	tags = tm_workspace_find_prefix(root, ft->lang, editor_prefs.autocompletion_max_entries);
+	symbols_get_current_function(doc, &current_scope);
+	current_line = sci_get_current_line(editor->sci) + 1;
+
+	tags = tm_workspace_find_prefix(root, doc->tm_file, current_line, current_scope,
+		ft->lang, editor_prefs.autocompletion_max_entries);
 	found = tags->len > 0;
 	if (found)
 		show_tags_list(editor, tags, rootlen);

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -70,8 +70,8 @@ static GHashTable *subparser_map = NULL;
 	{'v', tm_tag_variable_t},    /* variable */   \
 	{'x', tm_tag_externvar_t},   /* externvar */  \
 	{'h', tm_tag_undef_t},       /* header */     \
-	{'l', tm_tag_undef_t},       /* local */      \
-	{'z', tm_tag_undef_t},       /* parameter */  \
+	{'l', tm_tag_local_var_t},   /* local */      \
+	{'z', tm_tag_local_var_t},   /* parameter */  \
 	{'L', tm_tag_undef_t},       /* label */      \
 	{'D', tm_tag_undef_t},       /* macroparam */
 
@@ -1194,7 +1194,11 @@ void tm_parser_verify_type_mappings(void)
 					kinds[i], tm_ctags_get_lang_name(lang));
 
 			presence_map[(unsigned char) map->entries[i].kind]++;
-			lang_types |= map->entries[i].type;
+
+			/* we don't display local variables in the symbol tree so don't
+			 * check whether they are mapped to some group */
+			if (map->entries[i].type != tm_tag_local_var_t)
+				lang_types |= map->entries[i].type;
 		}
 
 		for (i = 0; i < sizeof(presence_map); i++)

--- a/src/tagmanager/tm_parser.h
+++ b/src/tagmanager/tm_parser.h
@@ -40,7 +40,7 @@ typedef enum
 	tm_tag_externvar_t = 32768, /**< Extern or forward declaration */
 	tm_tag_macro_t = 65536, /**<  Macro (without arguments) */
 	tm_tag_macro_with_arg_t = 131072, /**< Parameterized macro */
-	tm_tag_file_t = 262144, /**< File (Pseudo tag) - obsolete */
+	tm_tag_local_var_t = 262144, /**< Local variable (inside function) */
 	tm_tag_other_t = 524288, /**< Other (non C/C++/Java tag) */
 	tm_tag_max_t = 1048575 /**< Maximum value of TMTagType */
 } TMTagType;

--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -684,8 +684,25 @@ GPtrArray *tm_workspace_find(const char *name, const char *scope, TMTagType type
 }
 
 
+static gboolean is_valid_tag(TMTag *tag,
+	TMSourceFile *current_file,
+	guint current_line,
+	const gchar *current_scope)
+{
+	/* ignore local variables from other files/functions or after current line */
+	return !(tag->type & tm_tag_local_var_t) ||
+		(current_file == tag->file &&
+		 current_line >= tag->line &&
+		 g_strcmp0(current_scope, tag->scope) == 0);
+}
+
+
 static void fill_find_tags_array_prefix(GPtrArray *dst, const GPtrArray *src,
-	const char *name, TMParserType lang, guint max_num)
+	const char *name,
+	TMSourceFile *current_file,
+	guint current_line,
+	const gchar *current_scope,
+	TMParserType lang, guint max_num)
 {
 	TMTag **tag, *last = NULL;
 	guint i, count, num;
@@ -697,20 +714,24 @@ static void fill_find_tags_array_prefix(GPtrArray *dst, const GPtrArray *src,
 	tag = tm_tags_find(src, name, TRUE, &count);
 	for (i = 0; i < count && num < max_num; ++i)
 	{
-		if (tm_parser_langs_compatible(lang, (*tag)->lang) &&
-			!tm_tag_is_anon(*tag) &&
-			(!last || g_strcmp0(last->name, (*tag)->name) != 0))
+		if (is_valid_tag(*tag, current_file, current_line, current_scope))
 		{
-			g_ptr_array_add(dst, *tag);
-			last = *tag;
-			num++;
+			if (tm_parser_langs_compatible(lang, (*tag)->lang) &&
+				!tm_tag_is_anon(*tag) &&
+				(!last || g_strcmp0(last->name, (*tag)->name) != 0))
+			{
+				g_ptr_array_add(dst, *tag);
+				last = *tag;
+				num++;
+			}
 		}
 		tag++;
 	}
 }
 
 
-/* Returns tags with the specified prefix sorted by name. If there are several
+/* Returns tags with the specified prefix sorted by name, ignoring local
+ variables from other files/functions or after current line. If there are several
  tags with the same name, only one of them appears in the resulting array.
  @param prefix The prefix of the tag to find.
  @param lang Specifies the language(see the table in tm_parsers.h) of the tags to be found,
@@ -718,13 +739,19 @@ static void fill_find_tags_array_prefix(GPtrArray *dst, const GPtrArray *src,
  @param max_num The maximum number of tags to return.
  @return Array of matching tags sorted by their name.
 */
-GPtrArray *tm_workspace_find_prefix(const char *prefix, TMParserType lang, guint max_num)
+GPtrArray *tm_workspace_find_prefix(const char *prefix,
+	TMSourceFile *current_file,
+	guint current_line,
+	const gchar *current_scope,
+	TMParserType lang, guint max_num)
 {
 	TMTagAttrType attrs[] = { tm_tag_attr_name_t, 0 };
 	GPtrArray *tags = g_ptr_array_new();
 
-	fill_find_tags_array_prefix(tags, theWorkspace->tags_array, prefix, lang, max_num);
-	fill_find_tags_array_prefix(tags, theWorkspace->global_tags, prefix, lang, max_num);
+	fill_find_tags_array_prefix(tags, theWorkspace->tags_array, prefix,
+		current_file, current_line, current_scope, lang, max_num);
+	fill_find_tags_array_prefix(tags, theWorkspace->global_tags, prefix,
+		current_file, current_line, current_scope, lang, max_num);
 
 	tm_tags_sort(tags, attrs, TRUE, FALSE);
 	if (tags->len > max_num)

--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -580,6 +580,7 @@ gboolean tm_workspace_create_global_tags(const char *pre_process, const char **i
 	TMSourceFile *source_file;
 	GList *includes_files;
 	gchar *temp_file = create_temp_file("tmp_XXXXXX.cpp");
+	GPtrArray *filtered_tags;
 
 	if (!temp_file)
 		return FALSE;
@@ -624,7 +625,9 @@ gboolean tm_workspace_create_global_tags(const char *pre_process, const char **i
 	}
 
 	tm_tags_sort(source_file->tags_array, global_tags_sort_attrs, TRUE, FALSE);
-	ret = tm_source_file_write_tags_file(tags_file, source_file->tags_array);
+	filtered_tags = tm_tags_extract(source_file->tags_array, ~tm_tag_local_var_t);
+	ret = tm_source_file_write_tags_file(tags_file, filtered_tags);
+	g_ptr_array_free(filtered_tags, TRUE);
 	tm_source_file_free(source_file);
 
 cleanup:

--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -761,55 +761,6 @@ GPtrArray *tm_workspace_find_prefix(const char *prefix,
 }
 
 
-/* Gets all members of type_tag; search them inside the all array.
- * The namespace parameter determines whether we are performing the "namespace"
- * search (user has typed something like "A::" where A is a type) or "scope" search
- * (user has typed "a." where a is a global struct-like variable). With the
- * namespace search we return all direct descendants of any type while with the
- * scope search we return only those which can be invoked on a variable (member,
- * method, etc.). */
-static GPtrArray *
-find_scope_members_tags (const GPtrArray *all, TMTag *type_tag, gboolean namespace)
-{
-	TMTagType member_types = tm_tag_max_t & ~(TM_TYPE_WITH_MEMBERS | tm_tag_typedef_t);
-	GPtrArray *tags = g_ptr_array_new();
-	gchar *scope;
-	guint i;
-
-	if (namespace)
-		member_types = tm_tag_max_t;
-
-	if (type_tag->scope && *(type_tag->scope))
-		scope = g_strconcat(type_tag->scope, tm_parser_scope_separator(type_tag->lang), type_tag->name, NULL);
-	else
-		scope = g_strdup(type_tag->name);
-
-	for (i = 0; i < all->len; ++i)
-	{
-		TMTag *tag = TM_TAG (all->pdata[i]);
-
-		if (tag && (tag->type & member_types) &&
-			tag->scope && tag->scope[0] != '\0' &&
-			tm_parser_langs_compatible(tag->lang, type_tag->lang) &&
-			strcmp(scope, tag->scope) == 0 &&
-			(!namespace || !tm_tag_is_anon(tag)))
-		{
-			g_ptr_array_add (tags, tag);
-		}
-	}
-
-	g_free(scope);
-
-	if (tags->len == 0)
-	{
-		g_ptr_array_free(tags, TRUE);
-		return NULL;
-	}
-
-	return tags;
-}
-
-
 static gboolean replace_with_char(gchar *haystack, const gchar *needle, char replacement)
 {
 	gchar *pos = strstr(haystack, needle);
@@ -880,6 +831,73 @@ static gchar *strip_type(const gchar *scoped_name, TMParserType lang)
 		return name;
 	}
 	return NULL;
+}
+
+
+/* Gets all members of type_tag; search them inside the all array.
+ * The namespace parameter determines whether we are performing the "namespace"
+ * search (user has typed something like "A::" where A is a type) or "scope" search
+ * (user has typed "a." where a is a global struct-like variable). With the
+ * namespace search we return all direct descendants of any type while with the
+ * scope search we return only those which can be invoked on a variable (member,
+ * method, etc.). */
+static GPtrArray *
+find_scope_members_tags (const GPtrArray *all, TMTag *type_tag, gboolean namespace)
+{
+	TMTagType member_types = tm_tag_max_t & ~(TM_TYPE_WITH_MEMBERS | tm_tag_typedef_t);
+	GPtrArray *tags = g_ptr_array_new();
+	gchar *scope;
+	guint i;
+
+	if (namespace)
+		member_types = tm_tag_max_t;
+
+	if (type_tag->scope && *(type_tag->scope))
+		scope = g_strconcat(type_tag->scope, tm_parser_scope_separator(type_tag->lang), type_tag->name, NULL);
+	else
+		scope = g_strdup(type_tag->name);
+
+	for (i = 0; i < all->len; ++i)
+	{
+		TMTag *tag = TM_TAG (all->pdata[i]);
+
+		if (tag && (tag->type & member_types) &&
+			tag->scope && tag->scope[0] != '\0' &&
+			tm_parser_langs_compatible(tag->lang, type_tag->lang) &&
+			strcmp(scope, tag->scope) == 0 &&
+			(!namespace || !tm_tag_is_anon(tag)))
+		{
+			g_ptr_array_add (tags, tag);
+		}
+	}
+
+	g_free(scope);
+
+	if (tags->len == 0)
+	{
+		g_ptr_array_free(tags, TRUE);
+		return NULL;
+	}
+
+	return tags;
+}
+
+
+		for (i = 0; parent = split_strv[i]; i++)
+		{
+			GPtrArray *parent_tags;
+		}
+
+	}
+
+
+	if (tags->len == 0)
+
+	if (depth == 0)
+	{
+		TMTagAttrType sort_attrs[] = {tm_tag_attr_name_t, 0};
+	}
+
 }
 
 

--- a/src/tagmanager/tm_workspace.h
+++ b/src/tagmanager/tm_workspace.h
@@ -56,7 +56,9 @@ gboolean tm_workspace_create_global_tags(const char *pre_process, const char **i
 GPtrArray *tm_workspace_find(const char *name, const char *scope, TMTagType type,
 	TMTagAttrType *attrs, TMParserType lang);
 
-GPtrArray *tm_workspace_find_prefix(const char *prefix, TMParserType lang, guint max_num);
+GPtrArray *tm_workspace_find_prefix(const char *prefix,
+	TMSourceFile *current_file, guint current_line, const gchar *current_scope,
+	TMParserType lang, guint max_num);
 
 GPtrArray *tm_workspace_find_scope_members (TMSourceFile *source_file, const char *name,
 	gboolean function, gboolean member, const gchar *current_scope, gboolean search_namespace);

--- a/src/tagmanager/tm_workspace.h
+++ b/src/tagmanager/tm_workspace.h
@@ -61,7 +61,7 @@ GPtrArray *tm_workspace_find_prefix(const char *prefix,
 	TMParserType lang, guint max_num);
 
 GPtrArray *tm_workspace_find_scope_members (TMSourceFile *source_file, const char *name,
-	gboolean function, gboolean member, const gchar *current_scope, gboolean search_namespace);
+	gboolean function, gboolean member, const gchar *current_scope, guint current_line, gboolean search_namespace);
 
 
 void tm_workspace_add_source_file_noupdate(TMSourceFile *source_file);


### PR DESCRIPTION
This PR enables local variable (and function parameter) tags and fixes related problems:

1. Disables local variables for the symbol tree (it becomes too crowded when these are shown IMO).
2. Disables local variables for generated tag files - these aren't interesting for what we use global tags for. This however also means that unit tests don't cover local variables because they are generated in the same way as global tag files.
3. Update goto tag definition/declaration to ignore local tags from other functions than the current one and also ignoring local variables defined on a line which is behind the current line.
4. Update non-scope autocompletion ignoring local variables like in (3).
5. Update scope autocompletion ignoring local variables like in (3). In addition, when searching for applicable types for the variable for which we perform scope autocompletion, sort the candidate types so local variables from current function above the current line are preferred to global variables from the current file which are preferred to other variables.

This PR also improves the scope autocompletion a bit by
1. Removing some keywords like "const", "struct" from the type, also removing `&` and contents of `<>` braces and `[]` braces so we only get the "pure" type without additional garbage.
2. Supporting (multiple) inheritance and including members of parent classes in the result.

More details are in the individual commit messages.

@elextr Your turn, bring your evil C++ code :-)