### PR TITLE
Show correct icons in autocompletion popups

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -2023,6 +2023,14 @@ gint symbols_get_current_scope(GeanyDocument *doc, const gchar **tagname)
 }
 
 
+const gchar *symbols_get_icon_name(guint icon_id)
+{
+	if (icon_id < TM_N_ICONS)
+		return symbols_icons[icon_id].icon_name;
+	return NULL;
+}
+
+
 static void on_symbol_tree_sort_clicked(GtkMenuItem *menuitem, gpointer user_data)
 {
 	gint sort_mode = GPOINTER_TO_INT(user_data);

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -63,6 +63,8 @@ gint symbols_get_current_function(GeanyDocument *doc, const gchar **tagname);
 
 gint symbols_get_current_scope(GeanyDocument *doc, const gchar **tagname);
 
+const gchar *symbols_get_icon_name(guint icon_id);
+
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS


### PR DESCRIPTION
Since we can easily query icons assigned to specific TM types now
(together with having the possibility to change the icons to whatever
we like independently of TM type), we can display the same icon that
is used in the symbol tree and goto symbol definition/declaration
popup for autocompletion too.