### PR TITLE
Use gtk_show_uri_on_window() in utils_open_browser() by default

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -4842,6 +4842,7 @@
                                     <property name="tooltip-text" translatable="yes">Path (and possibly additional arguments) to your favorite browser</property>
                                     <property name="primary-icon-activatable">False</property>
                                     <property name="secondary-icon-activatable">False</property>
+                                    <property name="placeholder-text" translatable="yes">System default</property>
                                   </object>
                                   <packing>
                                     <property name="left-attach">1</property>

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -91,7 +91,8 @@
 #define GEANY_DEFAULT_FONT_MSG_WINDOW	"Menlo Medium 12"
 #define GEANY_DEFAULT_FONT_EDITOR		"Menlo Medium 12"
 #else
-#define GEANY_DEFAULT_TOOLS_BROWSER		"firefox"
+/* Browser chosen by GTK */
+#define GEANY_DEFAULT_TOOLS_BROWSER		""
 #define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Sans 9"
 #define GEANY_DEFAULT_FONT_MSG_WINDOW	"Monospace 9"
 #define GEANY_DEFAULT_FONT_EDITOR		"Monospace 10"


### PR DESCRIPTION
Instead of requiring the user to specify a browser just try to
use the system default browser through gtk_show_uri_on_window().
This is done when tool_prefs.browser_cmd is empty which is
also the new default.

This aligns with windows where we do this already. Though we're
bypassing tool_prefs.browser_cmd there entirely, while on non-Windows
we still honor tool_prefs.browser_cmd when it's set.

This is primarily useful for flatpak support where we cannot just
execute arbitrary commands on the host (unless using flatpak-spawn).

Also, firefox is arguably a bad default these days, given the
declined marked share.