### PR TITLE
session.conf split follow-up: plugins

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -153,10 +153,20 @@ void configuration_add_various_pref_group(struct StashGroup *group,
 }
 
 
-/* The group will be free'd on quitting. */
-void configuration_add_session_group(struct StashGroup *group)
+/* The group will be free'd on quitting.
+ *
+ * @a for_prefs_dialog is typically @c FALSE as session configuration is not
+ * well suited for the Preferences dialog. Probably only existing prefs that
+ * migrated to session data should set this to @c TRUE.
+ *
+ * @param for_prefs_dialog is whether the group also has Prefs dialog items.
+ */
+void configuration_add_session_group(struct StashGroup *group, gboolean for_prefs_dialog)
 {
 	g_ptr_array_add(keyfile_groups[SESSION], group);
+
+	if (for_prefs_dialog)
+		g_ptr_array_add(pref_groups, group);
 }
 
 

--- a/src/keyfile.h
+++ b/src/keyfile.h
@@ -40,7 +40,7 @@ void configuration_add_pref_group(struct StashGroup *group, gboolean for_prefs_d
 void configuration_add_various_pref_group(struct StashGroup *group,
 	const gchar *prefix);
 
-void configuration_add_session_group(struct StashGroup *group);
+void configuration_add_session_group(struct StashGroup *group, gboolean for_prefs_dialog);
 
 void configuration_save(void);
 

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1332,7 +1332,7 @@ void plugins_init(void)
 	g_free(path);
 
 	group = stash_group_new("plugins");
-	configuration_add_pref_group(group, TRUE);
+	configuration_add_session_group(group, TRUE);
 
 	stash_group_add_toggle_button(group, &prefs.load_plugins,
 		"load_plugins", TRUE, "check_plugins");

--- a/src/search.c
+++ b/src/search.c
@@ -201,7 +201,7 @@ static void init_prefs(void)
 
 	/* dialog layout & positions */
 	group = stash_group_new("search");
-	configuration_add_session_group(group);
+	configuration_add_session_group(group, FALSE);
 	stash_group_add_boolean(group, &find_dlg.all_expanded, "find_all_expanded", FALSE);
 	stash_group_add_boolean(group, &replace_dlg.all_expanded, "replace_all_expanded", FALSE);
 	stash_group_add_integer(group, &find_dlg.position[0], "position_find_x", -1);

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -1089,7 +1089,7 @@ void sidebar_init(void)
 	group = stash_group_new(PACKAGE);
 	stash_group_add_widget_property(group, &ui_prefs.sidebar_page, "sidebar_page", GINT_TO_POINTER(0),
 		main_widgets.sidebar_notebook, "page", 0);
-	configuration_add_session_group(group);
+	configuration_add_session_group(group, FALSE);
 	stash_group = group;
 
 	/* delay building documents treeview until sidebar font has been read */


### PR DESCRIPTION
Move plugin layout to session.conf

The plugin related settings can be considered session data. They
encode local paths that wouldn't work on other machines. Also I would
say it's not unusual to have a different set of plugins enabled on a
different machine.

The "load_pluings" key is moved as well to keep things simple. No
idea what's the use case to set this off. Typically you just have no
plugins enabled and the debugging aid `geany -p` bypasses any of this
anyway.