### PR TITLE
Fix docbook parser memory leak

### DIFF
--- a/ctags/parsers/geany_docbook.c
+++ b/ctags/parsers/geany_docbook.c
@@ -78,6 +78,8 @@ static void createTag(docbookKind kind, const char *buf)
 		++buf;
 	} while ((*buf != '\0') && (*buf != '"'));
 	makeSimpleTag(name, kind);
+
+	vStringDelete(name);
 }
 
 


### PR DESCRIPTION
I tested Geany with valgrind to make sure #3185 didn't introduce any memory leaks (it seems it didn't) and noticed this leak in the docbook parser (which we maintain by ourselves so no upstream patch needed). I'll merge this in a few days unless there are objections.

There are also leaks in Fortran (fixed upstream) and VHDL (different parser upstream) parsers which will get fixed once we merge the upstream versions.

For (my) future reference, I used valgrind with these parameters:
```
G_SLICE=always-malloc G_DEBUG=gc-friendly:resident-modules ./libtool --mode=execute valgrind --tool=memcheck --leak-check=full --leak-resolution=high --log-file=vgdump --suppressions=/usr/share/glib-2.0/valgrind/glib.supp src/geany
```