### PR TITLE
Use G_DIR_SEPARATOR instead of / when getting short name

### DIFF
--- a/src/tagmanager/tm_source_file.c
+++ b/src/tagmanager/tm_source_file.c
@@ -595,7 +595,7 @@ static gboolean tm_source_file_init(TMSourceFile *source_file, const char *file_
 			return FALSE;
 		}
 		source_file->file_name = tm_get_real_path(file_name);
-		source_file->short_name = strrchr(source_file->file_name, '/');
+		source_file->short_name = strrchr(source_file->file_name, G_DIR_SEPARATOR);
 		if (source_file->short_name)
 			++ source_file->short_name;
 		else


### PR DESCRIPTION
@eht16 I'm not sure how `realpath()` behaves on Windows but if it returns a Windows-style path with backwards slashes, we should use `G_DIR_SEPARATOR` here.