### PR TITLE
Support gtk-mac-integration by meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,9 @@ foreach dep : deps_in
 	deps_for_pc += ' ' + dep[0] + ' >= ' + dep[1]
 endforeach
 
+mac_integration = dependency('gtk-mac-integration', version: '>= 3.0.1',
+	required: get_option('mac-integration'))
+
 glib = deps[0]
 
 # detect libc
@@ -837,6 +840,7 @@ libgeany = shared_library('geany',
 	'src/utils.h',
 	gen_src,
 	win_src,
+	mac_integration.found() ? ['src/osx.c', 'src/osx.h'] : [],
 	host_machine.system() == 'windows' ? ['src/win32.c',  'src/win32.h'] : [ 'src/vte.c', 'src/vte.h' ],
 	soversion: '0',
 	c_args: geany_cflags + [ '-DG_LOG_DOMAIN="Geany"' ],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,4 @@ option('api-docs', type : 'feature', description : 'enable to generate API docum
 option('gtkdoc', type : 'boolean', description : 'enable to generate gtk-doc compatible headers for the API')
 option('python-command', type: 'string', description: 'the default Python command')
 option('socket', type: 'boolean', description: 'enable if you want to detect a running instance')
+option('mac-integration', type: 'feature', description: 'enable for improved macOS integration using the gtk-mac-integration library')


### PR DESCRIPTION
This library is used by the autotools build to provide improved system
integration on macOS such as global menus or various dock features. Add this
for the meson build too.

@kugel- Does it look OK to you?