### PR TITLE
Don't use temporary file when creating tag files without running preprocessor

### DIFF
--- a/tests/ctags/process_order.c.tags
+++ b/tests/ctags/process_order.c.tags
@@ -2,11 +2,9 @@ I1_E1Ì4Îanon_enum_1Ö0
 enumerator: anon_enum_1 :: I1_E1
 I1_E2Ì4Îanon_enum_1Ö0
 enumerator: anon_enum_1 :: I1_E2
-I2_E1Ì4Îanon_enum_2Ö0
-enumerator: anon_enum_2 :: I2_E1
-I2_E2Ì4Îanon_enum_2Ö0
-enumerator: anon_enum_2 :: I2_E2
+I2_E1Ì4Îanon_enum_1Ö0
+enumerator: anon_enum_1 :: I2_E1
+I2_E2Ì4Îanon_enum_1Ö0
+enumerator: anon_enum_1 :: I2_E2
 anon_enum_1Ì2Ö1
 enum:       anon_enum_1    flags: 1
-anon_enum_2Ì2Ö1
-enum:       anon_enum_2    flags: 1


### PR DESCRIPTION
This patch avoids creating a temporary file containing concatenated source files passed on the command-line when the `-P` option is used (or when tags are generated for other languages than C/C++) by e.g.
```
geany -P -g file1.h file2.h file3.h
```
More discussion can be found in #3163.