### PR TITLE
Remove built in globbing support when generating tag files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ fi
 # autoscan start
 
 # Checks for header files.
-AC_CHECK_HEADERS([fcntl.h glob.h stdlib.h sys/time.h errno.h limits.h])
+AC_CHECK_HEADERS([fcntl.h stdlib.h sys/time.h errno.h limits.h])
 
 # Checks for dependencies needed by ctags
 AC_CHECK_HEADERS([dirent.h fnmatch.h direct.h io.h sys/dir.h])

--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,6 @@ check_headers = [
 	'errno.h',
 	'fcntl.h',
 	'fnmatch.h',
-	'glob.h',
 	'inttypes.h',
 	'io.h',
 	'langinfo.h',


### PR DESCRIPTION
We can rely on shell to expand wildcards for us and the current detection
of whether globbing should be enabled based on \" presence is questionable,
undocumented and probably unused.

See #3204.

Fixes #3205.