### PR TITLE
Fix intermittent, erratic right-click behavior on documents sidebar page

### DIFF
--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -1093,7 +1093,22 @@ void sidebar_add_common_menu_items(GtkMenu *menu)
 
 static void on_openfiles_show_paths_activate(GtkCheckMenuItem *item, gpointer user_data)
 {
-	interface_prefs.openfiles_path_mode = GPOINTER_TO_INT(user_data);
+	gint new_mode = GPOINTER_TO_INT(user_data);
+	/* This is also called for menu items that became inactive (in response to activating
+	 * another one in the same group).
+	 */
+	if (!gtk_check_menu_item_get_active(item))
+		return;
+
+	/* Only if the mode changes...otherwise sidebar_openfiles_update_all() recreates the
+	 * list which messes up the current selection and more.
+	 *
+	 * This can happen (for example) right after startup, when no menu item was active yet.
+	 */
+	if (interface_prefs.openfiles_path_mode == new_mode)
+		return;
+
+	interface_prefs.openfiles_path_mode = new_mode;
 	sidebar_openfiles_update_all();
 	gtk_tree_view_expand_all(GTK_TREE_VIEW(tv.tree_openfiles));
 	sidebar_select_openfiles_item(document_get_current());


### PR DESCRIPTION
Sometimes right-click to open a the popup menu in the document sidebar
wouldn't change the selection before showing the popup. Then the
popup wasn't related to the document that was clicked.

This was especially bad with middle-click to close. It closed anything
but the clicked document (or folder in case of tree view).

This was caused by some unexpected calls to the "activate" signal handler
for the "openfiles_path_mode" menu items. The handler might re-create
the document list which in turn invalidates the current selection.

Now the signal handler has some protection against unexpected calls and
the selection properly updates upon right-click before spawing the popup.