### PR TITLE
Ignore local tags for autocompletion in other files

### DIFF
--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -637,7 +637,12 @@ gboolean tm_workspace_is_autocomplete_tag(TMTag *tag,
 		(current_file == tag->file &&
 		 current_line >= tag->line &&
 		 g_strcmp0(current_scope, tag->scope) == 0);
-	return valid && !tm_tag_is_anon(tag) && tm_parser_langs_compatible(lang, tag->lang);
+
+	/* tag->local indicates per-file-only visibility such as static C functions */
+	gboolean valid_local = !tag->local || current_file == tag->file;
+
+	return valid && valid_local &&
+		!tm_tag_is_anon(tag) && tm_parser_langs_compatible(lang, tag->lang);
 }
 
 


### PR DESCRIPTION
ctags sets the tag's "local" flag to true for tags whose visibility is
limited to the current file only. These are for instance "static" functions
in C.

We can ignore these tags for autocompletion in other files than the
tag's file which reduces the number of irrelevant tags in the
autocompletion popup.