### PR TITLE
Sort autocompletion tags also based on their presence in included files

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1133,7 +1133,7 @@ gboolean symbols_recreate_tag_list(GeanyDocument *doc, gint sort_mode)
 
 	g_return_val_if_fail(DOC_VALID(doc), FALSE);
 
-	tags = get_tag_list(doc, ~tm_tag_local_var_t);
+	tags = get_tag_list(doc, ~(tm_tag_local_var_t | tm_tag_include_t));
 	if (tags == NULL)
 		return FALSE;
 

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -69,7 +69,7 @@ static GHashTable *subparser_map = NULL;
 	{'u', tm_tag_union_t},       /* union */      \
 	{'v', tm_tag_variable_t},    /* variable */   \
 	{'x', tm_tag_externvar_t},   /* externvar */  \
-	{'h', tm_tag_undef_t},       /* header */     \
+	{'h', tm_tag_include_t},     /* header */     \
 	{'l', tm_tag_local_var_t},   /* local */      \
 	{'z', tm_tag_local_var_t},   /* parameter */  \
 	{'L', tm_tag_undef_t},       /* label */      \
@@ -81,7 +81,7 @@ static TMParserMapEntry map_C[] = {
 /* Used also by other languages than C - keep all the tm_tag_* here even though
  * they aren't used by C as they might be used by some other language */
 static TMParserMapGroup group_C[] = {
-	{_("Namespaces"), TM_ICON_NAMESPACE, tm_tag_namespace_t | tm_tag_package_t},
+	{_("Namespaces"), TM_ICON_NAMESPACE, tm_tag_namespace_t | tm_tag_package_t | tm_tag_include_t},
 	{_("Classes"), TM_ICON_CLASS, tm_tag_class_t},
 	{_("Interfaces"), TM_ICON_STRUCT, tm_tag_interface_t},
 	{_("Functions"), TM_ICON_METHOD, tm_tag_prototype_t | tm_tag_method_t | tm_tag_function_t},

--- a/src/tagmanager/tm_parser.h
+++ b/src/tagmanager/tm_parser.h
@@ -42,7 +42,8 @@ typedef enum
 	tm_tag_macro_with_arg_t = 131072, /**< Parameterized macro */
 	tm_tag_local_var_t = 262144, /**< Local variable (inside function) */
 	tm_tag_other_t = 524288, /**< Other (non C/C++/Java tag) */
-	tm_tag_max_t = 1048575 /**< Maximum value of TMTagType */
+	tm_tag_include_t = 1048576, /**< C/C++ included header file name */
+	tm_tag_max_t = 2097151 /**< Maximum value of TMTagType */
 } TMTagType;
 
 

--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -540,7 +540,7 @@ static gboolean create_global_tags_preprocessed(const char *pre_process_cmd,
 	}
 
 	tm_tags_sort(source_file->tags_array, global_tags_sort_attrs, TRUE, FALSE);
-	filtered_tags = tm_tags_extract(source_file->tags_array, ~tm_tag_local_var_t);
+	filtered_tags = tm_tags_extract(source_file->tags_array, ~(tm_tag_local_var_t | tm_tag_include_t));
 	ret = tm_source_file_write_tags_file(tags_file, filtered_tags);
 	g_ptr_array_free(filtered_tags, TRUE);
 	tm_source_file_free(source_file);
@@ -573,7 +573,7 @@ static gboolean create_global_tags_direct(GList *source_files, const char *tags_
 		}
 	}
 
-	filtered_tags = tm_tags_extract(tags, ~tm_tag_local_var_t);
+	filtered_tags = tm_tags_extract(tags, ~(tm_tag_local_var_t | tm_tag_include_t));
 	tm_tags_sort(filtered_tags, global_tags_sort_attrs, TRUE, FALSE);
 
 	if (filtered_tags->len > 0)
@@ -676,7 +676,8 @@ gboolean tm_workspace_is_autocomplete_tag(TMTag *tag,
 	gboolean valid_local = !tag->local || current_file == tag->file;
 
 	return valid && valid_local &&
-		!tm_tag_is_anon(tag) && tm_parser_langs_compatible(lang, tag->lang);
+		!tm_tag_is_anon(tag) && tm_parser_langs_compatible(lang, tag->lang) &&
+		!(tag->type & tm_tag_include_t);
 }
 
 

--- a/src/tagmanager/tm_workspace.h
+++ b/src/tagmanager/tm_workspace.h
@@ -32,6 +32,7 @@ typedef struct TMWorkspace
 		(just pointers to source file tags, the tag objects are owned by the source files). @elementtype{TMTag} */
 	GPtrArray *typename_array; /* Typename tags for syntax highlighting (pointers owned by source files) */
 	GPtrArray *global_typename_array; /* Like above for global tags */
+	GHashTable *source_file_map; /* File name -> GPtrArray<TMSourceFile> map to speed up lookups based on file name */
 } TMWorkspace;
 
 


### PR DESCRIPTION
This is a reworked and extended implementation of sorting based on tag presence in header files discussed (and dropped) from #3185. This implementation uses the header tags from ctags so we know precisely which files are included so we can use not only the tags from the source's header file but also tags from other included files. After this change the ordering sequence looks this way:

- sort local vars first (with highest line number first),
- followed by tags from current file,
- NEW: followed by tags from header,
- NEW: followed by tags from other included files,
- followed by workspace tags,
- followed by global tags

To me, the result seems to improve autocompletion results (it's a bit hard to tell for sure, one can always prepare artificial examples to test where it works better, with the real world it's harder to spot a difference between different orderings unless something is visibly broken).

For reference, I also tried the option to use the includes from the included headers recursively to some depth but the results didn't seem visibly better and were actually slightly worse (by including `<gtk.h>` one got all the GTK symbols which were then fighting with symbols from explicitly included headers that started to appear lower in the list which was often worse).