### PR TITLE
Fix renaming tag type containing anonymous type

### DIFF
--- a/src/tagmanager/tm_ctags.c
+++ b/src/tagmanager/tm_ctags.c
@@ -380,18 +380,24 @@ static void rename_anon_tags(TMSourceFile *source_file)
 			}
 
 			/* We are out of the nesting - the next tags could be variables
-			 * of an anonymous struct such as "struct {} a, b;" */
+			 * of an anonymous struct such as "struct {} a[2], *b, c;" */
 			while (j < source_file->tags_array->len)
 			{
 				TMTag *var_tag = TM_TAG(source_file->tags_array->pdata[j]);
 				guint var_scope_len = var_tag->scope ? strlen(var_tag->scope) : 0;
+				gchar *pos;
 
 				/* Should be at the same scope level as the anon tag */
 				if (var_scope_len == scope_len &&
-					g_strcmp0(var_tag->var_type, orig_name) == 0)
+					var_tag->var_type && (pos = strstr(var_tag->var_type, orig_name)))
 				{
+					GString *str = g_string_new(var_tag->var_type);
+					gssize p = pos - var_tag->var_type;
+					g_string_erase(str, p, strlen(orig_name));
+					g_string_insert(str, p, new_name);
 					g_free(var_tag->var_type);
-					var_tag->var_type = g_strdup(new_name);
+					var_tag->var_type = str->str;
+					g_string_free(str, FALSE);
 				}
 				else
 					break;


### PR DESCRIPTION
The current code assumes that the whole `var_type` string consists of the
anonymous type name. This works for simple cases like
```
struct {} X;
```
where `X` is of the type `__anonXXXX` but not for cases like
```
struct {} X[2];
```
where `X` is of type `__anonXXXX[]`.

For these cases checking for equality of `var_tag->var_type`, `orig_name` isn't
sufficient and we have to check whether `orig_name` is a substring
of `var_tag->var_type` and replace this substring with the new anon name.

This problem can be seen for instance in the symbol tree tooltip of
the `symbols_icons` variable inside `symbols.c`.