### PR TITLE
Enable local variable and parameter tag reporting for various languages

### DIFF
--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -166,7 +166,7 @@ static TMParserMapEntry map_PHP[] = {
 	{'d', tm_tag_macro_t},      // define
 	{'f', tm_tag_function_t},   // function
 	{'i', tm_tag_interface_t},  // interface
-	{'l', tm_tag_undef_t},      // local
+	{'l', tm_tag_local_var_t},  // local
 	{'n', tm_tag_namespace_t},  // namespace
 	{'t', tm_tag_struct_t},     // trait
 	{'v', tm_tag_variable_t},   // variable
@@ -178,7 +178,7 @@ static TMParserMapGroup group_PHP[] = {
 	{_("Classes"), TM_ICON_CLASS, tm_tag_class_t},
 	{_("Functions"), TM_ICON_METHOD, tm_tag_function_t},
 	{_("Constants"), TM_ICON_MACRO, tm_tag_macro_t},
-	{_("Variables"), TM_ICON_VAR, tm_tag_variable_t},
+	{_("Variables"), TM_ICON_VAR, tm_tag_variable_t | tm_tag_local_var_t},
 	{_("Traits"), TM_ICON_STRUCT, tm_tag_struct_t},
 };
 
@@ -192,14 +192,14 @@ static TMParserMapEntry map_PYTHON[] = {
     /* defined as externvar to get those excluded as forward type in symbols.c:goto_tag()
      * so we can jump to the real implementation (if known) instead of to the import statement */
 	{'x', tm_tag_externvar_t},  // unknown
-	{'z', tm_tag_undef_t},      // parameter
-	{'l', tm_tag_undef_t},      // local
+	{'z', tm_tag_local_var_t},  // parameter
+	{'l', tm_tag_local_var_t},  // local
 };
 static TMParserMapGroup group_PYTHON[] = {
 	{_("Classes"), TM_ICON_CLASS, tm_tag_class_t},
 	{_("Methods"), TM_ICON_MACRO, tm_tag_method_t},
 	{_("Functions"), TM_ICON_METHOD, tm_tag_function_t},
-	{_("Variables"), TM_ICON_VAR, tm_tag_variable_t},
+	{_("Variables"), TM_ICON_VAR, tm_tag_variable_t | tm_tag_local_var_t},
 	{_("Imports"), TM_ICON_NAMESPACE, tm_tag_externvar_t},
 };
 
@@ -969,16 +969,15 @@ static TMParserMapEntry map_GDSCRIPT[] = {
 	{'C', tm_tag_variable_t},  // const
 	{'g', tm_tag_enum_t},      // enum
 	{'e', tm_tag_variable_t},  // enumerator
-	{'z', tm_tag_other_t},     // parameter
-	{'l', tm_tag_other_t},     // local
+	{'z', tm_tag_local_var_t}, // parameter
+	{'l', tm_tag_local_var_t}, // local
 	{'s', tm_tag_variable_t},  // signal
 };
 static TMParserMapGroup group_GDSCRIPT[] = {
 	{_("Classes"), TM_ICON_CLASS, tm_tag_class_t},
 	{_("Methods"), TM_ICON_MACRO, tm_tag_method_t},
-	{_("Variables"), TM_ICON_VAR, tm_tag_variable_t},
+	{_("Variables"), TM_ICON_VAR, tm_tag_variable_t | tm_tag_local_var_t},
 	{_("Enums"), TM_ICON_STRUCT, tm_tag_enum_t},
-	{_("Other"), TM_ICON_OTHER, tm_tag_other_t},
 };
 
 static TMParserMapEntry map_CLOJURE[] = {
@@ -1012,10 +1011,10 @@ static TMParserMapEntry map_TYPESCRIPT[] = {
 	{'e', tm_tag_enumerator_t},  // enumerator
 	{'m', tm_tag_method_t},      // method
 	{'n', tm_tag_namespace_t},   // namespace
-	{'z', tm_tag_undef_t},       // parameter
+	{'z', tm_tag_local_var_t},   // parameter
 	{'p', tm_tag_member_t},      // property
 	{'v', tm_tag_variable_t},    // variable
-	{'l', tm_tag_undef_t},       // local
+	{'l', tm_tag_local_var_t},   // local
 	{'C', tm_tag_macro_t},       // constant
 	{'G', tm_tag_undef_t},       // generator
 	{'a', tm_tag_undef_t},       // alias
@@ -1026,7 +1025,7 @@ static TMParserMapGroup group_TYPESCRIPT[] = {
 	{_("Interfaces"), TM_ICON_STRUCT, tm_tag_interface_t},
 	{_("Functions"), TM_ICON_METHOD, tm_tag_function_t | tm_tag_method_t},
 	{_("Enums"), TM_ICON_STRUCT, tm_tag_enum_t},
-	{_("Variables"), TM_ICON_VAR, tm_tag_variable_t},
+	{_("Variables"), TM_ICON_VAR, tm_tag_variable_t | tm_tag_local_var_t},
 	{_("Constants"), TM_ICON_MACRO, tm_tag_macro_t},
 	{_("Other"), TM_ICON_MEMBER, tm_tag_member_t | tm_tag_enumerator_t},
 };

--- a/tests/ctags/cython_sample.pyx.tags
+++ b/tests/ctags/cython_sample.pyx.tags
@@ -4,8 +4,8 @@ StdClassÌ1Ö0
 class:      StdClass
 __init__Ì128Í(self)ÎCDefClassÖ0
 method:     CDefClass :: __init__(self)
-c_methodÌ128Í(self,int i)ÎCDefClassÖ0
-method:     CDefClass :: c_method(self,int i)
+c_methodÌ128Í(self, int i)ÎCDefClassÖ0
+method:     CDefClass :: c_method(self, int i)
 identityÌ16Í(x)Ö0
 function:   identity(x)
 int2stringÌ16Í(int i)Ö0

--- a/tests/ctags/gdscript-inner-class.gd.tags
+++ b/tests/ctags/gdscript-inner-class.gd.tags
@@ -22,14 +22,10 @@ _initÌ128Í(peer_id)ÎPeerÖ0
 method:     Peer :: _init(peer_id)
 centerÌ16384ÎCircle2DÖ0
 variable:   Circle2D :: center
-closeÌ524288ÎLobby.leaveÖ0
-other:      Lobby.leave :: close
 colorÌ16384ÎCircle2DÖ0
 variable:   Circle2D :: color
 hostÌ16384ÎLobbyÖ0Ïint
 variable:   int Lobby :: host
-host_idÌ524288ÎLobby._initÖ0Ïint
-other:      int Lobby._init :: host_id
 idÌ16384ÎPeerÖ0
 variable:   Peer :: id
 joinÌ128Í(peer_id, server)ÎLobbyÖ0Ïbool
@@ -40,16 +36,6 @@ lobbiesÌ16384Ö0ÏDictionary
 variable:   Dictionary lobbies
 lobbyÌ16384ÎPeerÖ0
 variable:   Peer :: lobby
-new_peerÌ524288ÎLobby.joinÖ0ÏWebSocketPeer
-other:      WebSocketPeer Lobby.join :: new_peer
-peer_idÌ524288ÎLobby.joinÖ0
-other:      Lobby.join :: peer_id
-peer_idÌ524288ÎLobby.leaveÖ0
-other:      Lobby.leave :: peer_id
-peer_idÌ524288ÎLobby.sealÖ0
-other:      Lobby.seal :: peer_id
-peer_idÌ524288ÎPeer._initÖ0
-other:      Peer._init :: peer_id
 peersÌ16384Ö0ÏDictionary
 variable:   Dictionary peers
 peersÌ16384ÎLobbyÖ0ÏArray
@@ -64,12 +50,6 @@ sealedÌ16384ÎLobbyÖ0Ïbool
 variable:   bool Lobby :: sealed
 serverÌ16384Ö0ÏWebSocketServer
 variable:   WebSocketServer server
-serverÌ524288ÎLobby.joinÖ0
-other:      Lobby.join :: server
-serverÌ524288ÎLobby.leaveÖ0
-other:      Lobby.leave :: server
-serverÌ524288ÎLobby.sealÖ0
-other:      Lobby.seal :: server
 timeÌ16384ÎLobbyÖ0
 variable:   Lobby :: time
 timeÌ16384ÎPeerÖ0

--- a/tests/ctags/gdscript-modifiers.gd.tags
+++ b/tests/ctags/gdscript-modifiers.gd.tags
@@ -1,26 +1,10 @@
 _create_block_colliderÌ128Í(block_sub_position)Ö0
 method:     _create_block_collider(block_sub_position)
-aÌ524288ÎidÖ0
-other:      id :: a
-bÌ524288ÎrÖ0
-other:      r :: b
-block_idÌ524288Îcalculate_block_uvsÖ0
-other:      calculate_block_uvs :: block_id
-block_sub_positionÌ524288Î_create_block_colliderÖ0
-other:      _create_block_collider :: block_sub_position
-cÌ524288ÎxÖ0
-other:      x :: c
 calculate_block_uvsÌ128Í(block_id)Ö0
 method:     calculate_block_uvs(block_id)
-colÌ524288Îcalculate_block_uvsÖ0
-other:      calculate_block_uvs :: col
-colliderÌ524288Î_create_block_colliderÖ0
-other:      _create_block_collider :: collider
 idÌ128Í(a)Ö0
 method:     id(a)
 rÌ128Í(b)Ö0
 method:     r(b)
-rowÌ524288Îcalculate_block_uvsÖ0
-other:      calculate_block_uvs :: row
 xÌ128Í(c)Ö0
 method:     x(c)

--- a/tests/ctags/gdscript-no-implicit-class.gd.tags
+++ b/tests/ctags/gdscript-no-implicit-class.gd.tags
@@ -38,20 +38,6 @@ fooooooooÃ128Õ()ŒSomething÷0œString
 method:     String Something :: foooooooo()
 inferred_typeÃ16384÷0
 variable:   inferred_type
-local_varÃ524288Œsome_function÷0
-other:      some_function :: local_var
-local_var2Ã524288Œsome_function÷0
-other:      some_function :: local_var2
-lvÃ524288Œ_init÷0
-other:      _init :: lv
-p1Ã524288Œsomething÷0
-other:      something :: p1
-p2Ã524288Œsomething÷0
-other:      something :: p2
-param1Ã524288Œsome_function÷0œVector3
-other:      Vector3 some_function :: param1
-param2Ã524288Œsome_function÷0œint
-other:      int some_function :: param2
 sÃ16384÷0
 variable:   s
 sigÃ16384÷0

--- a/tests/ctags/simple.py.tags
+++ b/tests/ctags/simple.py.tags
@@ -26,8 +26,8 @@ deeply_nestedÌ1Î_test.ignored_function.more_nestingÖ0
 class:      _test.ignored_function.more_nesting :: deeply_nested
 even_moreÌ128Í()Î_test.ignored_function.more_nesting.deeply_nestedÖ0
 method:     _test.ignored_function.more_nesting.deeply_nested :: even_more()
-fooÌ16Í( x , y, z)Ö0
-function:   foo( x , y, z)
+fooÌ16Í( x, y, z)Ö0
+function:   foo( x, y, z)
 ignored_functionÌ16Í()Î_testÖ0
 function:   _test :: ignored_function()
 more_nestingÌ16Í()Î_test.ignored_functionÖ0


### PR DESCRIPTION
This patch enables local variable and function parameter reporting for
Python, GDScript, PHP, and Typescript.

Because these are dynamic languages and Geany scope autocompletion
relies on static type information, scope completion doesn't work for
these languages. However, at least we get non-scope autocompletion
for local variables and function parameters.

Local variables in GDScript were previously mapped to tm_tag_other_t
and were displayed in the sidebar. We don't display these tags for
C/C++ in the sidebar and they should also be mapped to
tm_tag_local_var_t which is why there is a diff in unit tests removing
these variables from the output.

The python parser generates a slightly different output when function
parameter parsing is enabled (whitespace only change) which causes
the change of the output of some python unit tests.