### PR TITLE
Add option to only show line endings if they differ from file default

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAccelGroup" id="accelgroup1"/>
@@ -3811,19 +3811,45 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkCheckButton" id="check_line_end">
-                                    <property name="label" translatable="yes">Show line endings</property>
+                                  <object class="GtkFrame">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Shows the line ending character</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="draw-indicator">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label-xalign">0</property>
+                                    <property name="shadow-type">none</property>
+                                    <child type="label">
+                                      <object class="GtkCheckButton" id="check_line_end">
+                                        <property name="label" translatable="yes">Show line endings</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Shows the line ending character</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkAlignment">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="left-padding">12</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="check_line_endings_only_when_differ">
+                                            <property name="label" translatable="yes">Show only non-default line endings</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">Shows line ending characters only when they differ from the file default line ending character</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
-                                    <property name="position">3</property>
+                                    <property name="position">4</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -3839,7 +3865,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
-                                    <property name="position">4</property>
+                                    <property name="position">5</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -3855,7 +3881,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
-                                    <property name="position">5</property>
+                                    <property name="position">6</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -3871,7 +3897,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
-                                    <property name="position">6</property>
+                                    <property name="position">7</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -3912,7 +3938,7 @@
                                   <packing>
                                     <property name="expand">True</property>
                                     <property name="fill">True</property>
-                                    <property name="position">7</property>
+                                    <property name="position">8</property>
                                   </packing>
                                 </child>
                               </object>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2301,6 +2301,10 @@ Show line endings
     Display a symbol everywhere that a carriage return or line feed
     is present.
 
+Show only non-default line endings
+    Shows line ending characters only when they differ from the
+    file default line ending character.
+
 Show line numbers
     Show or hide the Line Number margin.
 

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2705,7 +2705,7 @@ Statusbar Templates
 
 The default statusbar template is (note ``\t`` = tab):
 
-``line: %l / %L\t col: %c\t sel: %s\t %w      %t      %mmode: %M      encoding: %e      filetype: %f      scope: %S``
+``line: %l / %L\t col: %c\t sel: %s\t %w      %t      %mEOL: %M      encoding: %e      filetype: %f      scope: %S``
 
 Settings the preference to an empty string will also cause Geany to use this
 internal default.

--- a/src/editor.c
+++ b/src/editor.c
@@ -5150,6 +5150,7 @@ void editor_apply_update_prefs(GeanyEditor *editor)
 	sci_set_visible_eols(sci, editor_prefs.show_line_endings);
 	sci_set_symbol_margin(sci, editor_prefs.show_markers_margin);
 	sci_set_line_numbers(sci, editor_prefs.show_linenumber_margin);
+	sci_set_eol_representation_characters(sci, sci_get_eol_mode(sci));
 
 	sci_set_folding_margin_visible(sci, editor_prefs.folding);
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -138,6 +138,7 @@ typedef struct GeanyEditorPrefs
 	gint		autocompletion_update_freq;
 	gint		scroll_lines_around_cursor;
 	gint		ime_interaction; /* input method editor's candidate window behaviour */
+	gboolean	show_line_endings_only_when_differ;
 }
 GeanyEditorPrefs;
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -543,6 +543,7 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "show_indent_guide", editor_prefs.show_indent_guide);
 	g_key_file_set_boolean(config, PACKAGE, "show_white_space", editor_prefs.show_white_space);
 	g_key_file_set_boolean(config, PACKAGE, "show_line_endings", editor_prefs.show_line_endings);
+	g_key_file_set_boolean(config, PACKAGE, "show_line_endings_only_when_differ", editor_prefs.show_line_endings_only_when_differ);
 	g_key_file_set_boolean(config, PACKAGE, "show_markers_margin", editor_prefs.show_markers_margin);
 	g_key_file_set_boolean(config, PACKAGE, "show_linenumber_margin", editor_prefs.show_linenumber_margin);
 	g_key_file_set_boolean(config, PACKAGE, "long_line_enabled", editor_prefs.long_line_enabled);
@@ -905,6 +906,7 @@ static void load_dialog_prefs(GKeyFile *config)
 	editor_prefs.show_indent_guide = utils_get_setting_boolean(config, PACKAGE, "show_indent_guide", FALSE);
 	editor_prefs.show_white_space = utils_get_setting_boolean(config, PACKAGE, "show_white_space", FALSE);
 	editor_prefs.show_line_endings = utils_get_setting_boolean(config, PACKAGE, "show_line_endings", FALSE);
+	editor_prefs.show_line_endings_only_when_differ = utils_get_setting_boolean(config, PACKAGE, "show_line_endings_only_when_differ", FALSE);
 	editor_prefs.scroll_stop_at_last_line = utils_get_setting_boolean(config, PACKAGE, "scroll_stop_at_last_line", TRUE);
 	editor_prefs.auto_close_xml_tags = utils_get_setting_boolean(config, PACKAGE, "auto_close_xml_tags", TRUE);
 	editor_prefs.complete_snippets = utils_get_setting_boolean(config, PACKAGE, "complete_snippets", TRUE);

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -57,7 +57,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 244
+#define GEANY_API_VERSION 245
 
 /* hack to have a different ABI when built with different GTK major versions
  * because loading plugins linked to a different one leads to crashes.

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -88,6 +88,7 @@ static void on_toolbar_show_toggled(GtkToggleButton *togglebutton, gpointer user
 static void on_show_notebook_tabs_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_enable_plugins_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_use_folding_toggled(GtkToggleButton *togglebutton, gpointer user_data);
+static void on_check_line_end_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_open_encoding_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_sidebar_visible_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_prefs_print_radio_button_toggled(GtkToggleButton *togglebutton, gpointer user_data);
@@ -595,6 +596,10 @@ static void prefs_init_dialog(void)
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_end");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.show_line_endings);
 
+	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_endings_only_when_differ");
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
+		editor_prefs.show_line_endings_only_when_differ);
+
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_numbers");
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), editor_prefs.show_linenumber_margin);
 
@@ -1071,6 +1076,10 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_end");
 		editor_prefs.show_line_endings = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_endings_only_when_differ");
+		editor_prefs.show_line_endings_only_when_differ = gtk_toggle_button_get_active(
+			GTK_TOGGLE_BUTTON(widget));
+
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_numbers");
 		editor_prefs.show_linenumber_margin = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
@@ -1537,6 +1546,14 @@ static void on_use_folding_toggled(GtkToggleButton *togglebutton, gpointer user_
 }
 
 
+static void on_check_line_end_toggled(GtkToggleButton *togglebutton, gpointer user_data)
+{
+	gboolean sens = gtk_toggle_button_get_active(togglebutton);
+
+	gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_endings_only_when_differ"), sens);
+}
+
+
 static void on_enable_plugins_toggled(GtkToggleButton *togglebutton, gpointer user_data)
 {
 	gboolean sens = gtk_toggle_button_get_active(togglebutton);
@@ -1810,6 +1827,8 @@ void prefs_show_dialog(void)
 				"toggled", G_CALLBACK(on_show_notebook_tabs_toggled), NULL);
 		g_signal_connect(ui_lookup_widget(ui_widgets.prefs_dialog, "check_folding"),
 				"toggled", G_CALLBACK(on_use_folding_toggled), NULL);
+		g_signal_connect(ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_end"),
+				"toggled", G_CALLBACK(on_check_line_end_toggled), NULL);
 		g_signal_connect(ui_lookup_widget(ui_widgets.prefs_dialog, "check_open_encoding"),
 				"toggled", G_CALLBACK(on_open_encoding_toggled), NULL);
 		g_signal_connect(ui_lookup_widget(ui_widgets.prefs_dialog, "check_sidebar_visible"),

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -37,6 +37,7 @@
 #include "sciwrappers.h"
 #include <Lexilla.h> /* ILexer5 */
 
+#include "editor.h"
 #include "utils.h"
 
 #include <string.h>
@@ -269,6 +270,30 @@ gint sci_get_eol_mode(ScintillaObject *sci)
 void sci_set_eol_mode(ScintillaObject *sci, gint eolmode)
 {
 	SSM(sci, SCI_SETEOLMODE, (uptr_t) eolmode, 0);
+	sci_set_eol_representation_characters(sci, eolmode);
+}
+
+
+/* Show only EOL characters if they differ from the file default EOL character */
+void sci_set_eol_representation_characters(ScintillaObject *sci, gint new_eolmode)
+{
+	const gchar *eolchar = NULL;
+	const gchar *new_eolchar = NULL;
+	gboolean visible = FALSE;
+	gint *eolmode;
+	gint appearance;
+	gint eol_modes[3] = {SC_EOL_CRLF, SC_EOL_CR, SC_EOL_LF};
+
+	foreach_c_array(eolmode, eol_modes, 3)
+	{
+		visible = (*eolmode != new_eolmode) || ! editor_prefs.show_line_endings_only_when_differ;
+		new_eolchar = (visible) ? utils_get_eol_short_name(*eolmode) : "";
+		appearance = (visible) ? SC_REPRESENTATION_BLOB : SC_REPRESENTATION_PLAIN;
+		eolchar = utils_get_eol_char(*eolmode);
+
+		SSM(sci, SCI_SETREPRESENTATION, (sptr_t) eolchar, (sptr_t) new_eolchar);
+		SSM(sci, SCI_SETREPRESENTATIONAPPEARANCE, (sptr_t) eolchar, appearance);
+	}
 }
 
 

--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -130,6 +130,7 @@ void				sci_set_visible_white_spaces(ScintillaObject *sci, gboolean set);
 void 				sci_convert_eols			(ScintillaObject *sci, gint eolmode);
 gint				sci_get_eol_mode			(ScintillaObject *sci);
 void 				sci_set_eol_mode			(ScintillaObject *sci, gint eolmode);
+void				sci_set_eol_representation_characters(ScintillaObject *sci, gint new_eolmode);
 void 				sci_zoom_in					(ScintillaObject *sci);
 void 				sci_zoom_out				(ScintillaObject *sci);
 void 				sci_zoom_off				(ScintillaObject *sci);

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -63,7 +63,7 @@
 	"col: %c\t "         \
 	"sel: %s\t "         \
 	"%w      %t      %m" \
-	"mode: %M      "     \
+	"EOL: %M      "      \
 	"encoding: %e      " \
 	"filetype: %f      " \
 	"scope: %S")


### PR DESCRIPTION
This adds a new option in the preferences dialog to show line ending characters only when they differ from what the majority of the line endings in the file use.

So it should be easier to spot accidentally misused line endings.

The idea is from @cousteaulecommandant and shamelessly implemented by me :D.

I guess we can improve the wording of the visible option name and its tooltip.

Screenshot:
![geany_show_eol_only_when_differ](https://user-images.githubusercontent.com/617017/189527774-a9072f31-0a82-4f70-868b-9dbd8a715aa0.png)

Testfile: [show_differing_eols.zip](https://github.com/geany/geany/files/9542533/show_differing_eols.zip)
