### PR TITLE
Better parsing for rust errors in compiler window

### DIFF
--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -1008,6 +1008,19 @@ static void parse_compiler_error_line(const gchar *string,
 			}
 			break;
 		}
+		case GEANY_FILETYPES_RUST:
+		{
+			data.pattern = ":";
+			data.min_fields = 3;
+			data.line_idx = 1;
+			data.file_idx = 0;	
+
+			/*--> main.rs:40:8 */
+			if (strncmp(string, "--> ", 4) == 0)
+				data.string += 4;
+
+			break;
+		}
 		case GEANY_FILETYPES_HTML:
 		{
 			/* line 78 column 7 - Warning: <table> missing '>' for end of tag */


### PR DESCRIPTION
Howdy, been a big fan of geany for a while, starting writing rust for work, and found the rust interop in the compiler window to be flaky at best.

This should both open local files with errors correctly, as well as the definition if users have the source downloaded.

I'm not sure about the portability/safety of L1020, incrementing the pointer, but the php case's reassignment with strstr is pretty similar, so maybe it's ok.