### PR TITLE
Fix goto popup location

### DIFF
--- a/plugins/filebrowser.c
+++ b/plugins/filebrowser.c
@@ -743,7 +743,7 @@ static gboolean on_button_press(GtkWidget *widget, GdkEventButton *event, gpoint
 
 		gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(popup_items.show_hidden_files),
 			show_hidden_files);
-		gtk_menu_popup(GTK_MENU(popup_menu), NULL, NULL, NULL, NULL, event->button, event->time);
+		gtk_menu_popup_at_pointer(GTK_MENU(popup_menu), (GdkEvent *) event);
 		/* don't return TRUE here, unless the selection won't be changed */
 	}
 	return FALSE;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -634,7 +634,7 @@ gboolean toolbar_popup_menu(GtkWidget *widget, GdkEventButton *event, gpointer u
 {
 	if (event->button == 3)
 	{
-		ui_menu_popup(GTK_MENU(ui_widgets.toolbar_menu), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(ui_widgets.toolbar_menu), NULL);
 		return TRUE;
 	}
 	return FALSE;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -634,7 +634,7 @@ gboolean toolbar_popup_menu(GtkWidget *widget, GdkEventButton *event, gpointer u
 {
 	if (event->button == 3)
 	{
-		ui_menu_popup(GTK_MENU(ui_widgets.toolbar_menu), NULL, NULL, event->button, event->time);
+		ui_menu_popup(GTK_MENU(ui_widgets.toolbar_menu), NULL, event->button, event->time);
 		return TRUE;
 	}
 	return FALSE;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -634,7 +634,7 @@ gboolean toolbar_popup_menu(GtkWidget *widget, GdkEventButton *event, gpointer u
 {
 	if (event->button == 3)
 	{
-		ui_menu_popup(GTK_MENU(ui_widgets.toolbar_menu), NULL, event->button, event->time);
+		ui_menu_popup(GTK_MENU(ui_widgets.toolbar_menu), NULL);
 		return TRUE;
 	}
 	return FALSE;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -634,7 +634,7 @@ gboolean toolbar_popup_menu(GtkWidget *widget, GdkEventButton *event, gpointer u
 {
 	if (event->button == 3)
 	{
-		gtk_menu_popup_at_pointer(GTK_MENU(ui_widgets.toolbar_menu), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(ui_widgets.toolbar_menu), (GdkEvent *) event);
 		return TRUE;
 	}
 	return FALSE;

--- a/src/editor.c
+++ b/src/editor.c
@@ -346,7 +346,7 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 		g_signal_emit_by_name(geany_object, "update-editor-menu",
 			current_word, editor_info.click_pos, doc);
 
-		ui_menu_popup(GTK_MENU(main_widgets.editor_menu), NULL, event->button, event->time);
+		ui_menu_popup(GTK_MENU(main_widgets.editor_menu), NULL);
 		return TRUE;
 	}
 	return FALSE;

--- a/src/editor.c
+++ b/src/editor.c
@@ -346,7 +346,7 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 		g_signal_emit_by_name(geany_object, "update-editor-menu",
 			current_word, editor_info.click_pos, doc);
 
-		ui_menu_popup(GTK_MENU(main_widgets.editor_menu), NULL, NULL, event->button, event->time);
+		ui_menu_popup(GTK_MENU(main_widgets.editor_menu), NULL, event->button, event->time);
 		return TRUE;
 	}
 	return FALSE;

--- a/src/editor.c
+++ b/src/editor.c
@@ -346,7 +346,7 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 		g_signal_emit_by_name(geany_object, "update-editor-menu",
 			current_word, editor_info.click_pos, doc);
 
-		gtk_menu_popup_at_pointer(GTK_MENU(main_widgets.editor_menu), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(main_widgets.editor_menu), (GdkEvent *) event);
 		return TRUE;
 	}
 	return FALSE;

--- a/src/editor.c
+++ b/src/editor.c
@@ -346,7 +346,7 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 		g_signal_emit_by_name(geany_object, "update-editor-menu",
 			current_word, editor_info.click_pos, doc);
 
-		ui_menu_popup(GTK_MENU(main_widgets.editor_menu), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(main_widgets.editor_menu), NULL);
 		return TRUE;
 	}
 	return FALSE;

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -1236,19 +1236,19 @@ static gboolean on_msgwin_button_press_event(GtkWidget *widget, GdkEventButton *
 		{
 			case MSG_STATUS:
 			{
-				ui_menu_popup(GTK_MENU(msgwindow.popup_status_menu), NULL, NULL,
+				ui_menu_popup(GTK_MENU(msgwindow.popup_status_menu), NULL,
 							  event->button, event->time);
 				break;
 			}
 			case MSG_MESSAGE:
 			{
-				ui_menu_popup(GTK_MENU(msgwindow.popup_msg_menu), NULL, NULL,
+				ui_menu_popup(GTK_MENU(msgwindow.popup_msg_menu), NULL,
 							  event->button, event->time);
 				break;
 			}
 			case MSG_COMPILER:
 			{
-				ui_menu_popup(GTK_MENU(msgwindow.popup_compiler_menu), NULL, NULL,
+				ui_menu_popup(GTK_MENU(msgwindow.popup_compiler_menu), NULL,
 							  event->button, event->time);
 				break;
 			}

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -1236,17 +1236,17 @@ static gboolean on_msgwin_button_press_event(GtkWidget *widget, GdkEventButton *
 		{
 			case MSG_STATUS:
 			{
-				ui_menu_popup(GTK_MENU(msgwindow.popup_status_menu), NULL);
+				gtk_menu_popup_at_pointer(GTK_MENU(msgwindow.popup_status_menu), NULL);
 				break;
 			}
 			case MSG_MESSAGE:
 			{
-				ui_menu_popup(GTK_MENU(msgwindow.popup_msg_menu), NULL);
+				gtk_menu_popup_at_pointer(GTK_MENU(msgwindow.popup_msg_menu), NULL);
 				break;
 			}
 			case MSG_COMPILER:
 			{
-				ui_menu_popup(GTK_MENU(msgwindow.popup_compiler_menu), NULL);
+				gtk_menu_popup_at_pointer(GTK_MENU(msgwindow.popup_compiler_menu), NULL);
 				break;
 			}
 		}

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -1236,17 +1236,17 @@ static gboolean on_msgwin_button_press_event(GtkWidget *widget, GdkEventButton *
 		{
 			case MSG_STATUS:
 			{
-				gtk_menu_popup_at_pointer(GTK_MENU(msgwindow.popup_status_menu), NULL);
+				gtk_menu_popup_at_pointer(GTK_MENU(msgwindow.popup_status_menu), (GdkEvent *) event);
 				break;
 			}
 			case MSG_MESSAGE:
 			{
-				gtk_menu_popup_at_pointer(GTK_MENU(msgwindow.popup_msg_menu), NULL);
+				gtk_menu_popup_at_pointer(GTK_MENU(msgwindow.popup_msg_menu), (GdkEvent *) event);
 				break;
 			}
 			case MSG_COMPILER:
 			{
-				gtk_menu_popup_at_pointer(GTK_MENU(msgwindow.popup_compiler_menu), NULL);
+				gtk_menu_popup_at_pointer(GTK_MENU(msgwindow.popup_compiler_menu), (GdkEvent *) event);
 				break;
 			}
 		}

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -1236,20 +1236,17 @@ static gboolean on_msgwin_button_press_event(GtkWidget *widget, GdkEventButton *
 		{
 			case MSG_STATUS:
 			{
-				ui_menu_popup(GTK_MENU(msgwindow.popup_status_menu), NULL,
-							  event->button, event->time);
+				ui_menu_popup(GTK_MENU(msgwindow.popup_status_menu), NULL);
 				break;
 			}
 			case MSG_MESSAGE:
 			{
-				ui_menu_popup(GTK_MENU(msgwindow.popup_msg_menu), NULL,
-							  event->button, event->time);
+				ui_menu_popup(GTK_MENU(msgwindow.popup_msg_menu), NULL);
 				break;
 			}
 			case MSG_COMPILER:
 			{
-				ui_menu_popup(GTK_MENU(msgwindow.popup_compiler_menu), NULL,
-							  event->button, event->time);
+				ui_menu_popup(GTK_MENU(msgwindow.popup_compiler_menu), NULL);
 				break;
 			}
 		}

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -512,7 +512,7 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_all1_activate), NULL);
 
-	ui_menu_popup(GTK_MENU(menu), NULL, NULL, event->button, event->time);
+	ui_menu_popup(GTK_MENU(menu), NULL, event->button, event->time);
 }
 
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -512,7 +512,7 @@ static void show_tab_bar_popup_menu(GeanyDocument *doc)
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_all1_activate), NULL);
 
-	ui_menu_popup(GTK_MENU(menu), NULL);
+	gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
 }
 
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -458,7 +458,7 @@ static void on_close_documents_right_activate(GtkMenuItem *menuitem, GeanyDocume
 }
 
 
-static void show_tab_bar_popup_menu(GeanyDocument *doc)
+static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 {
 	GtkWidget *menu_item;
 	static GtkWidget *menu = NULL;
@@ -512,7 +512,7 @@ static void show_tab_bar_popup_menu(GeanyDocument *doc)
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_all1_activate), NULL);
 
-	gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
+	gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *) event);
 }
 
 
@@ -541,7 +541,7 @@ static gboolean notebook_tab_bar_click_cb(GtkWidget *widget, GdkEventButton *eve
 	 * on a tab directly */
 	else if (event->button == 3)
 	{
-		show_tab_bar_popup_menu(NULL);
+		show_tab_bar_popup_menu(event, NULL);
 		return TRUE;
 	}
 	return FALSE;
@@ -676,7 +676,7 @@ static gboolean notebook_tab_click(GtkWidget *widget, GdkEventButton *event, gpo
 	/* right-click is first handled here if it happened on a notebook tab */
 	if (event->button == 3)
 	{
-		show_tab_bar_popup_menu(doc);
+		show_tab_bar_popup_menu(event, doc);
 		return TRUE;
 	}
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -458,7 +458,7 @@ static void on_close_documents_right_activate(GtkMenuItem *menuitem, GeanyDocume
 }
 
 
-static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
+static void show_tab_bar_popup_menu(GeanyDocument *doc)
 {
 	GtkWidget *menu_item;
 	static GtkWidget *menu = NULL;
@@ -512,7 +512,7 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 	gtk_container_add(GTK_CONTAINER(menu), menu_item);
 	g_signal_connect(menu_item, "activate", G_CALLBACK(on_close_all1_activate), NULL);
 
-	ui_menu_popup(GTK_MENU(menu), NULL, event->button, event->time);
+	ui_menu_popup(GTK_MENU(menu), NULL);
 }
 
 
@@ -541,7 +541,7 @@ static gboolean notebook_tab_bar_click_cb(GtkWidget *widget, GdkEventButton *eve
 	 * on a tab directly */
 	else if (event->button == 3)
 	{
-		show_tab_bar_popup_menu(event, NULL);
+		show_tab_bar_popup_menu(NULL);
 		return TRUE;
 	}
 	return FALSE;
@@ -676,7 +676,7 @@ static gboolean notebook_tab_click(GtkWidget *widget, GdkEventButton *event, gpo
 	/* right-click is first handled here if it happened on a notebook tab */
 	if (event->button == 3)
 	{
-		show_tab_bar_popup_menu(event, doc);
+		show_tab_bar_popup_menu(doc);
 		return TRUE;
 	}
 

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1642,7 +1642,7 @@ static gboolean pm_treeview_button_press_cb(GtkWidget *widget, GdkEventButton *e
 {
 	if (event->button == 3)
 	{
-		ui_menu_popup(GTK_MENU(pm_widgets.popup_menu), NULL, NULL,
+		ui_menu_popup(GTK_MENU(pm_widgets.popup_menu), NULL,
 					  event->button, event->time);
 	}
 	return FALSE;

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1642,7 +1642,7 @@ static gboolean pm_treeview_button_press_cb(GtkWidget *widget, GdkEventButton *e
 {
 	if (event->button == 3)
 	{
-		ui_menu_popup(GTK_MENU(pm_widgets.popup_menu), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(pm_widgets.popup_menu), NULL);
 	}
 	return FALSE;
 }

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1642,7 +1642,7 @@ static gboolean pm_treeview_button_press_cb(GtkWidget *widget, GdkEventButton *e
 {
 	if (event->button == 3)
 	{
-		gtk_menu_popup_at_pointer(GTK_MENU(pm_widgets.popup_menu), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(pm_widgets.popup_menu), (GdkEvent *) event);
 	}
 	return FALSE;
 }

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1642,8 +1642,7 @@ static gboolean pm_treeview_button_press_cb(GtkWidget *widget, GdkEventButton *e
 {
 	if (event->button == 3)
 	{
-		ui_menu_popup(GTK_MENU(pm_widgets.popup_menu), NULL,
-					  event->button, event->time);
+		ui_menu_popup(GTK_MENU(pm_widgets.popup_menu), NULL);
 	}
 	return FALSE;
 }

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -211,11 +211,9 @@ static void kb_tree_view_change_button_clicked_cb(GtkWidget *button, KbData *kbd
 }
 
 
-static void kb_show_popup_menu(KbData *kbdata, GtkWidget *widget, GdkEventButton *event)
+static void kb_show_popup_menu(KbData *kbdata, GtkWidget *widget)
 {
 	static GtkWidget *menu = NULL;
-	guint button;
-	guint32 event_time;
 
 	if (menu == NULL)
 	{
@@ -236,24 +234,13 @@ static void kb_show_popup_menu(KbData *kbdata, GtkWidget *widget, GdkEventButton
 		gtk_menu_attach_to_widget(GTK_MENU(menu), widget, NULL);
 	}
 
-	if (event != NULL)
-	{
-		button = event->button;
-		event_time = event->time;
-	}
-	else
-	{
-		button = 0;
-		event_time = gtk_get_current_event_time();
-	}
-
-	ui_menu_popup(GTK_MENU(menu), NULL, button, event_time);
+	ui_menu_popup(GTK_MENU(menu), NULL);
 }
 
 
 static gboolean kb_popup_menu_cb(GtkWidget *widget, KbData *kbdata)
 {
-	kb_show_popup_menu(kbdata, widget, NULL);
+	kb_show_popup_menu(kbdata, widget);
 	return TRUE;
 }
 
@@ -263,7 +250,7 @@ static gboolean kb_tree_view_button_press_event_cb(GtkWidget *widget, GdkEventBu
 {
 	if (event->button == 3 && event->type == GDK_BUTTON_PRESS)
 	{
-		kb_show_popup_menu(kbdata, widget, event);
+		kb_show_popup_menu(kbdata, widget);
 		return TRUE;
 	}
 	else if (event->type == GDK_2BUTTON_PRESS)

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -211,7 +211,7 @@ static void kb_tree_view_change_button_clicked_cb(GtkWidget *button, KbData *kbd
 }
 
 
-static void kb_show_popup_menu(KbData *kbdata, GtkWidget *widget)
+static void kb_show_popup_menu(KbData *kbdata, GtkWidget *widget, GdkEventButton *event)
 {
 	static GtkWidget *menu = NULL;
 
@@ -234,13 +234,13 @@ static void kb_show_popup_menu(KbData *kbdata, GtkWidget *widget)
 		gtk_menu_attach_to_widget(GTK_MENU(menu), widget, NULL);
 	}
 
-	gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
+	gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent *) event);
 }
 
 
 static gboolean kb_popup_menu_cb(GtkWidget *widget, KbData *kbdata)
 {
-	kb_show_popup_menu(kbdata, widget);
+	kb_show_popup_menu(kbdata, widget, NULL);
 	return TRUE;
 }
 
@@ -250,7 +250,7 @@ static gboolean kb_tree_view_button_press_event_cb(GtkWidget *widget, GdkEventBu
 {
 	if (event->button == 3 && event->type == GDK_BUTTON_PRESS)
 	{
-		kb_show_popup_menu(kbdata, widget);
+		kb_show_popup_menu(kbdata, widget, event);
 		return TRUE;
 	}
 	else if (event->type == GDK_2BUTTON_PRESS)

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -247,7 +247,7 @@ static void kb_show_popup_menu(KbData *kbdata, GtkWidget *widget, GdkEventButton
 		event_time = gtk_get_current_event_time();
 	}
 
-	ui_menu_popup(GTK_MENU(menu), NULL, NULL, button, event_time);
+	ui_menu_popup(GTK_MENU(menu), NULL, button, event_time);
 }
 
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -234,7 +234,7 @@ static void kb_show_popup_menu(KbData *kbdata, GtkWidget *widget)
 		gtk_menu_attach_to_widget(GTK_MENU(menu), widget, NULL);
 	}
 
-	ui_menu_popup(GTK_MENU(menu), NULL);
+	gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
 }
 
 

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -145,7 +145,7 @@ on_default_tag_tree_button_press_event(GtkWidget *widget, GdkEventButton *event,
 {
 	if (event->button == 3)
 	{
-		ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL, NULL, event->button, event->time);
+		ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL, event->button, event->time);
 		return TRUE;
 	}
 	return FALSE;
@@ -1513,12 +1513,12 @@ static gboolean sidebar_button_press_cb(GtkWidget *widget, GdkEventButton *event
 
 			/* update menu item sensitivity */
 			documents_menu_update(selection);
-			ui_menu_popup(GTK_MENU(openfiles_popup_menu), NULL, NULL,
+			ui_menu_popup(GTK_MENU(openfiles_popup_menu), NULL,
 						  event->button, event->time);
 		}
 		else
 		{
-			ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL, NULL,
+			ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL,
 						  event->button, event->time);
 		}
 		handled = TRUE;

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -145,7 +145,7 @@ on_default_tag_tree_button_press_event(GtkWidget *widget, GdkEventButton *event,
 {
 	if (event->button == 3)
 	{
-		ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL, event->button, event->time);
+		ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL);
 		return TRUE;
 	}
 	return FALSE;
@@ -1513,13 +1513,11 @@ static gboolean sidebar_button_press_cb(GtkWidget *widget, GdkEventButton *event
 
 			/* update menu item sensitivity */
 			documents_menu_update(selection);
-			ui_menu_popup(GTK_MENU(openfiles_popup_menu), NULL,
-						  event->button, event->time);
+			ui_menu_popup(GTK_MENU(openfiles_popup_menu), NULL);
 		}
 		else
 		{
-			ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL,
-						  event->button, event->time);
+			ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL);
 		}
 		handled = TRUE;
 	}

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -145,7 +145,7 @@ on_default_tag_tree_button_press_event(GtkWidget *widget, GdkEventButton *event,
 {
 	if (event->button == 3)
 	{
-		gtk_menu_popup_at_pointer(GTK_MENU(tv.popup_taglist), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(tv.popup_taglist), (GdkEvent *) event);
 		return TRUE;
 	}
 	return FALSE;
@@ -1513,11 +1513,11 @@ static gboolean sidebar_button_press_cb(GtkWidget *widget, GdkEventButton *event
 
 			/* update menu item sensitivity */
 			documents_menu_update(selection);
-			gtk_menu_popup_at_pointer(GTK_MENU(openfiles_popup_menu), NULL);
+			gtk_menu_popup_at_pointer(GTK_MENU(openfiles_popup_menu), (GdkEvent *) event);
 		}
 		else
 		{
-			gtk_menu_popup_at_pointer(GTK_MENU(tv.popup_taglist), NULL);
+			gtk_menu_popup_at_pointer(GTK_MENU(tv.popup_taglist), (GdkEvent *) event);
 		}
 		handled = TRUE;
 	}

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -145,7 +145,7 @@ on_default_tag_tree_button_press_event(GtkWidget *widget, GdkEventButton *event,
 {
 	if (event->button == 3)
 	{
-		ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(tv.popup_taglist), NULL);
 		return TRUE;
 	}
 	return FALSE;
@@ -1513,11 +1513,11 @@ static gboolean sidebar_button_press_cb(GtkWidget *widget, GdkEventButton *event
 
 			/* update menu item sensitivity */
 			documents_menu_update(selection);
-			ui_menu_popup(GTK_MENU(openfiles_popup_menu), NULL);
+			gtk_menu_popup_at_pointer(GTK_MENU(openfiles_popup_menu), NULL);
 		}
 		else
 		{
-			ui_menu_popup(GTK_MENU(tv.popup_taglist), NULL);
+			gtk_menu_popup_at_pointer(GTK_MENU(tv.popup_taglist), NULL);
 		}
 		handled = TRUE;
 	}

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1413,8 +1413,6 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 	GtkWidget *first = NULL;
 	GtkWidget *menu;
 	GtkSizeGroup *group = gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL);
-	GdkEvent *event;
-	GdkEventButton *button_event = NULL;
 	TMTag *tmtag;
 	guint i;
 	gchar **short_names, **file_names;
@@ -1480,16 +1478,7 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 	if (first) /* always select the first item for better keyboard navigation */
 		g_signal_connect(menu, "realize", G_CALLBACK(gtk_menu_shell_select_item), first);
 
-	event = gtk_get_current_event();
-	if (event && event->type == GDK_BUTTON_PRESS)
-		button_event = (GdkEventButton *) event;
-	else
-		gdk_event_free(event);
-
-	g_object_set_data_full(G_OBJECT(menu), "geany-button-event", button_event,
-	                       button_event ? (GDestroyNotify) gdk_event_free : NULL);
-	ui_menu_popup(GTK_MENU(menu), doc->editor->sci,
-				  button_event ? button_event->button : 0, gtk_get_current_event_time ());
+	ui_menu_popup(GTK_MENU(menu), doc->editor->sci);
 
 	g_object_unref(group);
 }

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1432,6 +1432,7 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 	GtkWidget *first = NULL;
 	GtkWidget *menu;
 	GtkSizeGroup *group = gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL);
+	GdkEvent *event;
 	TMTag *tmtag;
 	guint i;
 	gchar **short_names, **file_names;
@@ -1497,7 +1498,13 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 	if (first) /* always select the first item for better keyboard navigation */
 		g_signal_connect(menu, "realize", G_CALLBACK(gtk_menu_shell_select_item), first);
 
-	show_menu_at_caret(GTK_MENU(menu), doc->editor->sci);
+	event = gtk_get_current_event();
+	if (event && event->type == GDK_BUTTON_PRESS)
+		gtk_menu_popup_at_pointer(GTK_MENU(menu), event);
+	else
+		show_menu_at_caret(GTK_MENU(menu), doc->editor->sci);
+	if (event)
+		gdk_event_free(event);
 
 	g_object_unref(group);
 }

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1408,84 +1408,6 @@ static guint get_tag_class(const TMTag *tag)
 }
 
 
-/* positions a popup at the caret from the ScintillaObject in @p data */
-static void goto_popup_position_func(GtkMenu *menu, gint *x, gint *y, gboolean *push_in, gpointer data)
-{
-	gint line_height;
-	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(menu));
-	gint monitor_num;
-	GdkRectangle monitor;
-	GtkRequisition req;
-	GdkEventButton *event_button = g_object_get_data(G_OBJECT(menu), "geany-button-event");
-
-	if (event_button)
-	{
-		/* if we got a mouse click, popup at that position */
-		*x = (gint) event_button->x_root;
-		*y = (gint) event_button->y_root;
-		line_height = 0; /* we don't want to offset below the line or anything */
-	}
-	else /* keyboard positioning */
-	{
-		ScintillaObject *sci = data;
-		GdkWindow *window = gtk_widget_get_window(GTK_WIDGET(sci));
-		gint pos = sci_get_current_position(sci);
-		gint line = sci_get_line_from_position(sci, pos);
-		gint pos_x = SSM(sci, SCI_POINTXFROMPOSITION, 0, pos);
-		gint pos_y = SSM(sci, SCI_POINTYFROMPOSITION, 0, pos);
-
-		line_height = SSM(sci, SCI_TEXTHEIGHT, line, 0);
-
-		gdk_window_get_origin(window, x, y);
-		*x += pos_x;
-		*y += pos_y;
-	}
-
-	monitor_num = gdk_screen_get_monitor_at_point(screen, *x, *y);
-
-	gtk_widget_get_preferred_size(GTK_WIDGET(menu), NULL, &req);
-
-#if GTK_CHECK_VERSION(3, 4, 0)
-	gdk_screen_get_monitor_workarea(screen, monitor_num, &monitor);
-#else
-	gdk_screen_get_monitor_geometry(screen, monitor_num, &monitor);
-#endif
-
-	/* put on one size of the X position, but within the monitor */
-	if (gtk_widget_get_direction(GTK_WIDGET(menu)) == GTK_TEXT_DIR_RTL)
-	{
-		if (*x - req.width - 1 >= monitor.x)
-			*x -= req.width + 1;
-		else if (*x + req.width > monitor.x + monitor.width)
-			*x = monitor.x;
-		else
-			*x += 1;
-	}
-	else
-	{
-		if (*x + req.width + 1 <= monitor.x + monitor.width)
-			*x = MAX(monitor.x, *x + 1);
-		else if (*x - req.width - 1 >= monitor.x)
-			*x -= req.width + 1;
-		else
-			*x = monitor.x + MAX(0, monitor.width - req.width);
-	}
-
-	/* try to put, in order:
-	 * 1. below the Y position, under the line
-	 * 2. above the Y position
-	 * 3. within the monitor */
-	if (*y + line_height + req.height <= monitor.y + monitor.height)
-		*y = MAX(monitor.y, *y + line_height);
-	else if (*y - req.height >= monitor.y)
-		*y = *y - req.height;
-	else
-		*y = monitor.y + MAX(0, monitor.height - req.height);
-
-	*push_in = FALSE;
-}
-
-
 static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_best)
 {
 	GtkWidget *first = NULL;
@@ -1566,7 +1488,7 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 
 	g_object_set_data_full(G_OBJECT(menu), "geany-button-event", button_event,
 	                       button_event ? (GDestroyNotify) gdk_event_free : NULL);
-	ui_menu_popup(GTK_MENU(menu), goto_popup_position_func, doc->editor->sci,
+	ui_menu_popup(GTK_MENU(menu), doc->editor->sci,
 				  button_event ? button_event->button : 0, gtk_get_current_event_time ());
 
 	g_object_unref(group);

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1407,6 +1407,20 @@ static guint get_tag_class(const TMTag *tag)
 	return TM_ICON_STRUCT;
 }
 
+/* opens menu at caret position */
+static void show_menu_at_caret(GtkMenu* menu, ScintillaObject *sci)
+{
+	GdkWindow *window = gtk_widget_get_window(GTK_WIDGET(sci));
+	gint pos = sci_get_current_position(sci);
+	gint line = sci_get_line_from_position(sci, pos);
+	gint line_height = SSM(sci, SCI_TEXTHEIGHT, line, 0);
+	gint x = SSM(sci, SCI_POINTXFROMPOSITION, 0, pos);
+	gint y = SSM(sci, SCI_POINTYFROMPOSITION, 0, pos) + line_height;
+	GdkRectangle rect = {x, y, 0, 0};
+	GdkGravity rect_anchor = gtk_widget_get_direction(GTK_WIDGET(menu)) == GTK_TEXT_DIR_RTL ? GDK_GRAVITY_NORTH_EAST : GDK_GRAVITY_NORTH_WEST;
+	gtk_menu_popup_at_rect(GTK_MENU(menu), window, &rect, rect_anchor, GDK_GRAVITY_NORTH_WEST, NULL);
+}
+
 
 static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_best)
 {
@@ -1478,7 +1492,7 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 	if (first) /* always select the first item for better keyboard navigation */
 		g_signal_connect(menu, "realize", G_CALLBACK(gtk_menu_shell_select_item), first);
 
-	ui_menu_popup(GTK_MENU(menu), doc->editor->sci);
+	show_menu_at_caret(GTK_MENU(menu), doc->editor->sci);
 
 	g_object_unref(group);
 }

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1407,6 +1407,7 @@ static guint get_tag_class(const TMTag *tag)
 	return TM_ICON_STRUCT;
 }
 
+
 /* opens menu at caret position */
 static void show_menu_at_caret(GtkMenu* menu, ScintillaObject *sci)
 {
@@ -1415,10 +1416,13 @@ static void show_menu_at_caret(GtkMenu* menu, ScintillaObject *sci)
 	gint line = sci_get_line_from_position(sci, pos);
 	gint line_height = SSM(sci, SCI_TEXTHEIGHT, line, 0);
 	gint x = SSM(sci, SCI_POINTXFROMPOSITION, 0, pos);
-	gint y = SSM(sci, SCI_POINTYFROMPOSITION, 0, pos) + line_height;
-	GdkRectangle rect = {x, y, 0, 0};
-	GdkGravity rect_anchor = gtk_widget_get_direction(GTK_WIDGET(menu)) == GTK_TEXT_DIR_RTL ? GDK_GRAVITY_NORTH_EAST : GDK_GRAVITY_NORTH_WEST;
-	gtk_menu_popup_at_rect(GTK_MENU(menu), window, &rect, rect_anchor, GDK_GRAVITY_NORTH_WEST, NULL);
+	gint y = SSM(sci, SCI_POINTYFROMPOSITION, 0, pos);
+	gint pos_next = sci_get_position_after(sci, pos);
+	gint char_width = 0;
+	if (sci_get_line_from_position(sci, pos_next) == line)
+		char_width = SSM(sci, SCI_POINTXFROMPOSITION, 0, pos_next) - x;
+	GdkRectangle rect = {x, y, char_width, line_height};
+	gtk_menu_popup_at_rect(GTK_MENU(menu), window, &rect, GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, NULL);
 }
 
 

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1419,7 +1419,8 @@ static void show_menu_at_caret(GtkMenu* menu, ScintillaObject *sci)
 	gint y = SSM(sci, SCI_POINTYFROMPOSITION, 0, pos);
 	gint pos_next = sci_get_position_after(sci, pos);
 	gint char_width = 0;
-	if (sci_get_line_from_position(sci, pos_next) == line)
+	/* if next pos is on the same Y (same line and not after wrapping), diff the X */
+	if (pos_next > pos && SSM(sci, SCI_POINTYFROMPOSITION, 0, pos_next) == y)
 		char_width = SSM(sci, SCI_POINTXFROMPOSITION, 0, pos_next) - x;
 	GdkRectangle rect = {x, y, char_width, line_height};
 	gtk_menu_popup_at_rect(GTK_MENU(menu), window, &rect, GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, NULL);

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -3258,14 +3258,109 @@ gboolean ui_encodings_combo_box_set_active_encoding(GtkComboBox *combo, gint enc
 	return FALSE;
 }
 
-void ui_menu_popup(GtkMenu* menu, GtkMenuPositionFunc func, gpointer data, guint button, guint32 activate_time)
+
+#if GTK_CHECK_VERSION(3,22,0)
+/* positions a popup at the caret from the ScintillaObject in @p data */
+static void position_at_caret(GtkMenu *menu, gint *x, gint *y, gboolean *push_in, gpointer data)
+{
+	gint line_height;
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(menu));
+	gint monitor_num;
+	GdkRectangle monitor;
+	GtkRequisition req;
+	GdkEventButton *event_button = g_object_get_data(G_OBJECT(menu), "geany-button-event");
+
+	if (event_button)
+	{
+		/* if we got a mouse click, popup at that position */
+		*x = (gint) event_button->x_root;
+		*y = (gint) event_button->y_root;
+		line_height = 0; /* we don't want to offset below the line or anything */
+	}
+	else /* keyboard positioning */
+	{
+		ScintillaObject *sci = data;
+		GdkWindow *window = gtk_widget_get_window(GTK_WIDGET(sci));
+		gint pos = sci_get_current_position(sci);
+		gint line = sci_get_line_from_position(sci, pos);
+		gint pos_x = SSM(sci, SCI_POINTXFROMPOSITION, 0, pos);
+		gint pos_y = SSM(sci, SCI_POINTYFROMPOSITION, 0, pos);
+
+		line_height = SSM(sci, SCI_TEXTHEIGHT, line, 0);
+
+		gdk_window_get_origin(window, x, y);
+		*x += pos_x;
+		*y += pos_y;
+	}
+
+	monitor_num = gdk_screen_get_monitor_at_point(screen, *x, *y);
+
+	gtk_widget_get_preferred_size(GTK_WIDGET(menu), NULL, &req);
+
+#if GTK_CHECK_VERSION(3, 4, 0)
+	gdk_screen_get_monitor_workarea(screen, monitor_num, &monitor);
+#else
+	gdk_screen_get_monitor_geometry(screen, monitor_num, &monitor);
+#endif
+
+	/* put on one size of the X position, but within the monitor */
+	if (gtk_widget_get_direction(GTK_WIDGET(menu)) == GTK_TEXT_DIR_RTL)
+	{
+		if (*x - req.width - 1 >= monitor.x)
+			*x -= req.width + 1;
+		else if (*x + req.width > monitor.x + monitor.width)
+			*x = monitor.x;
+		else
+			*x += 1;
+	}
+	else
+	{
+		if (*x + req.width + 1 <= monitor.x + monitor.width)
+			*x = MAX(monitor.x, *x + 1);
+		else if (*x - req.width - 1 >= monitor.x)
+			*x -= req.width + 1;
+		else
+			*x = monitor.x + MAX(0, monitor.width - req.width);
+	}
+
+	/* try to put, in order:
+	 * 1. below the Y position, under the line
+	 * 2. above the Y position
+	 * 3. within the monitor */
+	if (*y + line_height + req.height <= monitor.y + monitor.height)
+		*y = MAX(monitor.y, *y + line_height);
+	else if (*y - req.height >= monitor.y)
+		*y = *y - req.height;
+	else
+		*y = monitor.y + MAX(0, monitor.height - req.height);
+
+	*push_in = FALSE;
+}
+#endif
+
+
+/* opens menu at caret position (if ScintillaObject is passed) or at current pointer position */
+void ui_menu_popup(GtkMenu* menu, ScintillaObject *sci, guint button, guint32 activate_time)
 {
 	/* Use appropriate function for menu popup:
 		- gtk_menu_popup_at_pointer is not available on GTK older than 3.22
 		- gtk_menu_popup is deprecated and causes issues on multimonitor wayland setups */
 #if GTK_CHECK_VERSION(3,22,0)
-	gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
+	if (!sci)
+		gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
+	else
+	{
+		GdkWindow *window = gtk_widget_get_window(GTK_WIDGET(sci));
+		gint pos = sci_get_current_position(sci);
+		gint line = sci_get_line_from_position(sci, pos);
+		gint line_height = SSM(sci, SCI_TEXTHEIGHT, line, 0);
+		gint x = SSM(sci, SCI_POINTXFROMPOSITION, 0, pos);
+		gint y = SSM(sci, SCI_POINTYFROMPOSITION, 0, pos) + line_height;
+		GdkRectangle rect = {x, y, 0, 0};
+		GdkGravity rect_anchor = gtk_widget_get_direction(GTK_WIDGET(menu)) == GTK_TEXT_DIR_RTL ? GDK_GRAVITY_NORTH_EAST : GDK_GRAVITY_NORTH_WEST;
+		gtk_menu_popup_at_rect(GTK_MENU(menu), window, &rect, rect_anchor, GDK_GRAVITY_NORTH_WEST, NULL);
+	}
 #else
-	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, func, data, button, activate_time);
+	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, sci ? position_at_caret : NULL, sci, button, activate_time);
 #endif
 }

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -3257,23 +3257,3 @@ gboolean ui_encodings_combo_box_set_active_encoding(GtkComboBox *combo, gint enc
 	}
 	return FALSE;
 }
-
-
-/* opens menu at caret position (if ScintillaObject is passed) or at current pointer position */
-void ui_menu_popup(GtkMenu* menu, ScintillaObject *sci)
-{
-	if (!sci)
-		gtk_menu_popup_at_pointer(GTK_MENU(menu), NULL);
-	else
-	{
-		GdkWindow *window = gtk_widget_get_window(GTK_WIDGET(sci));
-		gint pos = sci_get_current_position(sci);
-		gint line = sci_get_line_from_position(sci, pos);
-		gint line_height = SSM(sci, SCI_TEXTHEIGHT, line, 0);
-		gint x = SSM(sci, SCI_POINTXFROMPOSITION, 0, pos);
-		gint y = SSM(sci, SCI_POINTYFROMPOSITION, 0, pos) + line_height;
-		GdkRectangle rect = {x, y, 0, 0};
-		GdkGravity rect_anchor = gtk_widget_get_direction(GTK_WIDGET(menu)) == GTK_TEXT_DIR_RTL ? GDK_GRAVITY_NORTH_EAST : GDK_GRAVITY_NORTH_WEST;
-		gtk_menu_popup_at_rect(GTK_MENU(menu), window, &rect, rect_anchor, GDK_GRAVITY_NORTH_WEST, NULL);
-	}
-}

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -373,8 +373,6 @@ gchar *ui_get_project_directory(const gchar *path);
 
 void ui_menu_sort_by_label(GtkMenu *menu);
 
-void ui_menu_popup(GtkMenu* menu, ScintillaObject *sci);
-
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -373,7 +373,7 @@ gchar *ui_get_project_directory(const gchar *path);
 
 void ui_menu_sort_by_label(GtkMenu *menu);
 
-void ui_menu_popup(GtkMenu* menu, ScintillaObject *sci, guint button, guint32 activate_time);
+void ui_menu_popup(GtkMenu* menu, ScintillaObject *sci);
 
 #endif /* GEANY_PRIVATE */
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -373,7 +373,7 @@ gchar *ui_get_project_directory(const gchar *path);
 
 void ui_menu_sort_by_label(GtkMenu *menu);
 
-void ui_menu_popup(GtkMenu* menu, GtkMenuPositionFunc func, gpointer data, guint button, guint32 activate_time);
+void ui_menu_popup(GtkMenu* menu, ScintillaObject *sci, guint button, guint32 activate_time);
 
 #endif /* GEANY_PRIVATE */
 

--- a/src/vte.c
+++ b/src/vte.c
@@ -526,7 +526,7 @@ static gboolean vte_button_pressed(GtkWidget *widget, GdkEventButton *event, gpo
 	if (event->button == 3)
 	{
 		gtk_widget_grab_focus(vte_config.vte);
-		gtk_menu_popup_at_pointer(GTK_MENU(vte_config.menu), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(vte_config.menu), (GdkEvent *) event);
 		return TRUE;
 	}
 	else if (event->button == 2)

--- a/src/vte.c
+++ b/src/vte.c
@@ -526,7 +526,7 @@ static gboolean vte_button_pressed(GtkWidget *widget, GdkEventButton *event, gpo
 	if (event->button == 3)
 	{
 		gtk_widget_grab_focus(vte_config.vte);
-		ui_menu_popup(GTK_MENU(vte_config.menu), NULL, event->button, event->time);
+		ui_menu_popup(GTK_MENU(vte_config.menu), NULL);
 		return TRUE;
 	}
 	else if (event->button == 2)

--- a/src/vte.c
+++ b/src/vte.c
@@ -526,7 +526,7 @@ static gboolean vte_button_pressed(GtkWidget *widget, GdkEventButton *event, gpo
 	if (event->button == 3)
 	{
 		gtk_widget_grab_focus(vte_config.vte);
-		ui_menu_popup(GTK_MENU(vte_config.menu), NULL, NULL, event->button, event->time);
+		ui_menu_popup(GTK_MENU(vte_config.menu), NULL, event->button, event->time);
 		return TRUE;
 	}
 	else if (event->button == 2)

--- a/src/vte.c
+++ b/src/vte.c
@@ -526,7 +526,7 @@ static gboolean vte_button_pressed(GtkWidget *widget, GdkEventButton *event, gpo
 	if (event->button == 3)
 	{
 		gtk_widget_grab_focus(vte_config.vte);
-		ui_menu_popup(GTK_MENU(vte_config.menu), NULL);
+		gtk_menu_popup_at_pointer(GTK_MENU(vte_config.menu), NULL);
 		return TRUE;
 	}
 	else if (event->button == 2)


### PR DESCRIPTION
There was a mistake in my fix for wayland popups, as @b4n correctly noticed in https://github.com/geany/geany/pull/3011#issuecomment-1279825987. The problem was that the "Go to symbol definition" did not open the popup in correct location.

This PR contains two commits:
 - First fixes the problem
 - Second removes support for prehistoric versions of GTK
 
The first commit might be used separately, but I have to openly admit that the #ifdefed code is not tested, because I couldn't find any system in my reach with old enough GTK. The second commit should not be merged until GTK 3.24 is officially required for Geany. But I guess that it should not be a problem, this PR can probably wait untill then, since no one noticed the bug for a month.