### PR TITLE
Make New command focus editor

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -91,7 +91,7 @@ static gboolean on_window_delete_event(GtkWidget *widget, GdkEvent *event, gpoin
 
 void on_new1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	document_new_file(NULL, NULL, NULL);
+	keybindings_send_command(GEANY_KEY_GROUP_FILE, GEANY_KEYS_FILE_NEW);
 }
 
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1447,6 +1447,7 @@ static gboolean cb_func_file_action(guint key_id)
 	{
 		case GEANY_KEYS_FILE_NEW:
 			document_new_file(NULL, NULL, NULL);
+			cb_func_switch_action(GEANY_KEYS_FOCUS_EDITOR);
 			break;
 		case GEANY_KEYS_FILE_OPEN:
 			on_open1_activate(NULL, NULL);


### PR DESCRIPTION
I often need to quickly open a new document and paste text. It's annoying to have to manually focus the editor widget. This does that automatically.