### PR TITLE
ctags: Matlab: generate tag with only the function name, not the function name plus arguments

### DIFF
--- a/ctags/parsers/geany_matlab.c
+++ b/ctags/parsers/geany_matlab.c
@@ -62,7 +62,8 @@ static void findMatlabTags (void)
 		for (i = 0  ;  line [i] != '\0'  &&  ! isspace (line [i])  ;  ++i)
 			;
 
-		if (strncmp ((const char *) line, "function", (size_t) 8) == 0)
+		if (strncmp ((const char *) line, "function", (size_t) 8) == 0
+			&& isspace (line [8]))
 		{
 			const unsigned char *cp = line + i;
 			const unsigned char *ptr = cp;
@@ -71,9 +72,12 @@ static void findMatlabTags (void)
 			while (isspace ((int) *cp))
 				++cp;
 
-			/* search for '=' character in the line */
+			/* search for '=' character in the line (ignoring comments) */
 			while (*ptr != '\0')
 			{
+				if (*ptr == '%')
+					break;
+
 				if (*ptr == '=')
 				{
 					eq=true;
@@ -82,25 +86,24 @@ static void findMatlabTags (void)
 				ptr++;
 			}
 
-			/* '=' was found => get the right most part of the line after '=' and before '%' */
+			/* '=' was found => get the first word of the line after '=' */
 			if (eq)
 			{
 				ptr++;
 				while (isspace ((int) *ptr))
 					++ptr;
 
-				while (*ptr != '\0' && *ptr != '%')
+				while (isalnum ((int) *ptr) || *ptr == '_')
 				{
 					vStringPut (name, (int) *ptr);
 					++ptr;
 				}
 			}
 
-			/* '=' was not found => get the right most part of the line after
-			 * 'function' and before '%' */
+			/* '=' was not found => get the first word of the line after "function" */
 			else
 			{
-				while (*cp != '\0' && *cp != '%')
+				while (isalnum ((int) *cp) || *cp == '_')
 				{
 					vStringPut (name, (int) *cp);
 					++cp;

--- a/tests/ctags/matlab_backtracking.m.tags
+++ b/tests/ctags/matlab_backtracking.m.tags
@@ -1,2 +1,2 @@
-backtrack(xc,d,fc,fnc,DDfnc,c,gamma,eps)Ì16Ö0
-function:   backtrack(xc,d,fc,fnc,DDfnc,c,gamma,eps)
+backtrackÌ16Ö0
+function:   backtrack

--- a/tests/ctags/matlab_test.m
+++ b/tests/ctags/matlab_test.m
@@ -1,4 +1,7 @@
 function [x,y,z] = func1 
 function x = func2 
 function func3 
+function y = func4(a, b, c)
+function func5   % this comment should be ignored --> X = FAIL5
+functionality = FAIL6; % this is not a function and should not be parsed
 

--- a/tests/ctags/matlab_test.m.tags
+++ b/tests/ctags/matlab_test.m.tags
@@ -1,6 +1,6 @@
-func1 Ì16Ö0
-function:   func1 
-func2 Ì16Ö0
-function:   func2 
-func3 Ì16Ö0
-function:   func3 
+func1Ì16Ö0
+function:   func1
+func2Ì16Ö0
+function:   func2
+func3Ì16Ö0
+function:   func3

--- a/tests/ctags/matlab_test.m.tags
+++ b/tests/ctags/matlab_test.m.tags
@@ -4,3 +4,7 @@ func2Ì16Ö0
 function:   func2
 func3Ì16Ö0
 function:   func3
+func4Ì16Ö0
+function:   func4
+func5Ì16Ö0
+function:   func5


### PR DESCRIPTION
A line like `function y = foo(a, b, c)` should yield a tag of `foo`, not `foo(a, b, c)`.
That way, Ctrl-clicking `foo` somewhere in the code will take me there.
The function name is `foo` after all, not `foo(a, b c)`.

Also, fixed issue where a line like `function foo() % this = bug` would yield a tag of `bug` instead of `foo` because the `=` in the comment was not ignored.

Finally, added a check to ensure that the line starts with the keyword `function`, and not any word starting with `function...` which could be a variable name (e.g. `functionality`).

Here I am considering that function names contain only alphanumeric characters (and underscore) as Matlab's documentation states.  I'm not aware of the possibility of declaring functions with `.` or other special characters directly using `function`.

Example Matlab file demonstrating the issue:
```matlab
function y = foo(a, b, c) % the function name should be `foo`, not `foo(a, b, c)`
    y = a+b+c;
end
function baz() % this = bug
    disp('The function name is `baz`, not `bug`');
end
functionality = struct('a', 1, 'b', 2);
```
This used to yield tags `foo(a, b, c)` and `bug`, as well as `struct('a', 1, 'b', 2);` as a function; now it yields tags `foo` and `baz` as expected, and omits the `functionality` thing.

_(If it's any consolation, notice that GitHub also messes up the highlighting of `baz()` because of the `=` in the comment.)_

____

PS: Similarly, it might be good to figure out a way to also exclude occurrences of the substring `"struct"` that aren't the keyword `struct` itself, such as in strings, or as part of words, e.g.:
```matlab
restructure = true;
disp('You are on the way to destruction.');
```