### PR TITLE
Make tab label length and window title length configurable

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -34,6 +34,13 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment14">
+    <property name="lower">3</property>
+    <property name="upper">100000</property>
+    <property name="value">99999</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="lower">1</property>
     <property name="upper">99</property>
@@ -2191,6 +2198,49 @@
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
                                     <property name="position">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <!-- n-columns=2 n-rows=1 -->
+                                  <object class="GtkGrid">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="column-spacing">10</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label251">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Set limit on visible characters in tab label.</property>
+                                        <property name="label" translatable="yes">Tab Label Length:</property>
+                                        <property name="mnemonic-widget">spin_tab_label_len</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spin_tab_label_len">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Characters to be visible on the tab label of the file.</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
+                                        <property name="adjustment">adjustment14</property>
+                                        <property name="climb-rate">1</property>
+                                        <property name="numeric">True</property>
+                                        <property name="update-policy">if-valid</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">5</property>
                                   </packing>
                                 </child>
                               </object>

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -2211,7 +2211,7 @@
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="tooltip-text" translatable="yes">Set limit on visible characters in tab label.</property>
-                                        <property name="label" translatable="yes">Tab Label Length:</property>
+                                        <property name="label" translatable="yes">Tab label length:</property>
                                         <property name="mnemonic-widget">spin_tab_label_len</property>
                                       </object>
                                       <packing>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2022,6 +2022,10 @@ Double-clicking hides all additional widgets
     Whether to call the View->Toggle All Additional Widgets command
     when double-clicking on a notebook tab.
 
+Tab label length
+    If filenames are long, set the number of characters that should be
+    visible on each tab's label.
+
 Tab positions
 `````````````
 

--- a/src/document.c
+++ b/src/document.c
@@ -434,7 +434,7 @@ void document_update_tab_label(GeanyDocument *doc)
 
 	g_return_if_fail(doc != NULL);
 
-	short_name = document_get_basename_for_display(doc, -1);
+	short_name = document_get_basename_for_display(doc, interface_prefs.tab_label_len);
 
 	/* we need to use the event box for the tooltip, labels don't get the necessary events */
 	parent = gtk_widget_get_parent(doc->priv->tab_label);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -537,6 +537,7 @@ static void save_dialog_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "tab_order_beside", file_prefs.tab_order_beside);
 	g_key_file_set_integer(config, PACKAGE, "tab_pos_editor", interface_prefs.tab_pos_editor);
 	g_key_file_set_integer(config, PACKAGE, "tab_pos_msgwin", interface_prefs.tab_pos_msgwin);
+	g_key_file_set_integer(config, PACKAGE, "tab_label_length", interface_prefs.tab_label_len);
 
 	/* display */
 	g_key_file_set_boolean(config, PACKAGE, "show_indent_guide", editor_prefs.show_indent_guide);

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -57,7 +57,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 245
+#define GEANY_API_VERSION 246
 
 /* hack to have a different ABI when built with different GTK major versions
  * because loading plugins linked to a different one leads to crashes.

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -965,6 +965,8 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_statusbar_visible");
 		interface_prefs.statusbar_visible = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "spin_tab_label_len");
+		interface_prefs.tab_label_len = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
 
 		/* Toolbar settings */
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_toolbar_show");
@@ -1303,6 +1305,7 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		ui_save_buttons_toggle((doc != NULL) ? doc->changed : FALSE);
 		msgwin_show_hide_tabs();
 		ui_update_statusbar(doc, -1);
+		document_update_tab_label(doc);
 
 		/* store all settings */
 		configuration_save();

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1296,6 +1296,8 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 				editor_apply_update_prefs(documents[i]->editor);
 				if (! editor_prefs.folding)
 					editor_unfold_all(documents[i]->editor);
+
+				document_update_tab_label(documents[i]);
 			}
 		}
 		ui_document_show_hide(NULL);
@@ -1305,7 +1307,7 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		ui_save_buttons_toggle((doc != NULL) ? doc->changed : FALSE);
 		msgwin_show_hide_tabs();
 		ui_update_statusbar(doc, -1);
-		document_update_tab_label(doc);
+		ui_set_window_title(doc);
 
 		/* store all settings */
 		configuration_save();

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2369,6 +2369,8 @@ void ui_init_prefs(void)
 		"msgwin_scribble_visible", TRUE);
 	stash_group_add_boolean(group, &interface_prefs.warn_on_project_close,
 		"warn_on_project_close", TRUE);
+	stash_group_add_spin_button_integer(group, &interface_prefs.tab_label_len,
+		"tab_label_length", 99999, "spin_tab_label_len");
 }
 
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -383,7 +383,7 @@ void ui_set_window_title(GeanyDocument *doc)
 			g_string_append(str, DOC_FILENAME(doc));
 		else
 		{
-			gchar *short_name = document_get_basename_for_display(doc, 30);
+			gchar *short_name = document_get_basename_for_display(doc, interface_prefs.tab_label_len);
 			gchar *dirname = g_path_get_dirname(DOC_FILENAME(doc));
 
 			g_string_append(str, short_name);

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -72,6 +72,8 @@ typedef struct GeanyInterfacePrefs
 	/** whether to show a warning when closing a project to open a new one */
 	gboolean		warn_on_project_close;
 	gint			openfiles_path_mode;
+	/** number of characters of a filename to be visible on the tab label */
+	gint			tab_label_len;
 }
 GeanyInterfacePrefs;
 


### PR DESCRIPTION
Implements #3344 
Added a GtkSpinButton in "Notebook tabs" in Interface preferences. This will take as input, number of characters that the user wants to display on the tab label.
For now, Maximum value that can be entered: 100000
**Default value**: 99999(as suggested by @elextr to be very big number)
Minimum value that can be entered: 3
The value is stored in the variable **tab_label_len** declared in GeanyInterfacePrefs struct. This value will be written in **geany.conf** when **save_dialog_prefs** of keyfile.c is executed.
The tab label will get updated dynamically on clicking the Apply/Ok button in the Preferences dialog.
![Screenshot from 2023-01-04 11-34-19](https://user-images.githubusercontent.com/96364226/210493983-dcdc886e-63a0-49b2-b0fd-1a46d3cff13e.png)
