### PR TITLE
Add preliminary support for Dartlang syntax highlighting

### DIFF
--- a/data/filedefs/filetypes.Dart.conf
+++ b/data/filedefs/filetypes.Dart.conf
@@ -1,0 +1,54 @@
+# For complete documentation of this file, please see Geany's main documentation
+[styling=C]
+
+[keywords]
+primary=abstract assert async await break case catch class const continue default do else enum export extends false final finally for function future generic get goto if implements import in Infinity inner instanceof interface late let NaN native new null num outer package private protected public rest return set static strictfp super switch synchronized this throw throws transient true try typeof undefined var void volatile while with yeild prototype
+secondary=boolean byte char double dynamic float int long short Array Boolean Date Function Future FutureOr Math Number Object String RegExp EvalError Error RangeError ReferenceError SyntaxError TypeError URIError decodeURI decodeURIComponent encodeURI encodeURIComponent eval isFinite isNaN parseFloat parseInt @override
+# documentation keywords for javadoc
+doccomment=author deprecated exception param return see serial serialData serialField since throws todo version
+typedefs=
+
+[settings]
+# default extension used when saving files
+extension=dart
+
+# MIME type
+mime_type=application/dart
+
+# Set Lexer
+lexer_filetype=Java
+tag_parser=Java
+
+# the following characters are these which a "word" can contains, see documentation
+#wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
+
+# single comments, like # in this file
+comment_single=//
+# multiline comments
+comment_open=/*
+comment_close=*/
+
+# set to false if a comment character/string should start at column 0 of a line, true uses any
+# indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
+  #command_example();
+# setting to false would generate this
+# command_example();
+# This setting works only for single line comments
+comment_use_indent=true
+
+# context action command (please see Geany's main documentation for details)
+context_action_cmd=
+
+[indentation]
+width=2
+# 0 is spaces, 1 is tabs, 2 is tab & spaces
+type=0
+
+[build-menu]
+FT_00_LB=Dart _Analyze File
+FT_00_CM=dart analyze "%f"
+FT_00_WD=
+
+EX_00_LB=Flutter Run
+EX_00_CM=flutter run
+EX_00_WD=%p

--- a/data/filetype_extensions.conf
+++ b/data/filetype_extensions.conf
@@ -24,6 +24,7 @@ Conf=*.conf;*.ini;config;*rc;*.cfg;*.desktop;*.properties;
 CSS=*.css;
 Cython=*.pyx;*.pxd;*.pxi;
 D=*.d;*.di;
+Dart=*.dart;
 Diff=*.diff;*.patch;*.rej;
 Docbook=*.docbook;
 Erlang=*.erl;*.hrl;
@@ -83,7 +84,7 @@ None=*;
 
 # Note: restarting is required after editing groups
 [Groups]
-Programming=Arduino;Clojure;CUDA;Cython;Genie;Groovy;Kotlin;Nim;Scala;Swift;
+Programming=Arduino;Clojure;CUDA;Cython;Dart;Genie;Groovy;Kotlin;Nim;Scala;Swift;
 Script=Graphviz;TypeScript;Meson;
 Markup=
 Misc=JSON;


### PR DESCRIPTION
Preliminary support for [Dart](https://dartlang.org/) has been added to address Issue #371. 

This adds keyword highlighting and indentation. Proper typing and variable support is not included and will require https://github.com/ScintillaOrg/lexilla/issues/58.