### PR TITLE
Add recent filename on saving when real_path is not set

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1860,9 +1860,6 @@ gboolean document_save_file_as(GeanyDocument *doc, const gchar *utf8_fname)
 	 * to ignore any earlier events */
 	monitor_file_setup(doc);
 	doc->priv->file_disk_status = FILE_IGNORE;
-
-	if (ret)
-		ui_add_recent_document(doc);
 	return ret;
 }
 
@@ -2038,6 +2035,7 @@ static gchar *save_doc(GeanyDocument *doc, const gchar *locale_filename,
 		doc->real_path = utils_get_real_path(locale_filename);
 		doc->priv->is_remote = utils_is_remote_path(locale_filename);
 		monitor_file_setup(doc);
+		ui_add_recent_document(doc);
 	}
 	return NULL;
 }

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -852,8 +852,6 @@ gboolean main_handle_filename(const gchar *locale_filename)
 			document_show_tab(doc);
 		else
 			doc = document_new_file(utf8_filename, NULL, NULL);
-		if (doc != NULL)
-			ui_add_recent_document(doc);
 		g_free(utf8_filename);
 		g_free(filename);
 		return TRUE;


### PR DESCRIPTION
Note: `real_path` gets set for any documents on disk.

Don't add new document opened from CLI to recent files, because it doesn't exist yet. It may be closed unsaved.
No need now to add a recent file in `document_save_file_as`, because `real_path` is nulled before calling `document_save_file`, so that function will add the recent file.