### PR TITLE
Don't insert * after new line in multi-line comment if previous line …

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2209,7 +2209,7 @@ Automatic continuation multi-line comments
 
     on the next line with the correct indentation based on the previous line,
     as long as the multi-line is not closed by ``*/``. If the previous line
-    has no ``*`` prefix, the new line will not be changed.
+    has no ``*`` prefix, no ``*`` will be added to the new line.
 
 Autocomplete symbols
     When you start to type a symbol name, look for the full string to

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2208,7 +2208,8 @@ Automatic continuation multi-line comments
       *
 
     on the next line with the correct indentation based on the previous line,
-    as long as the multi-line is not closed by ``*/``.
+    as long as the multi-line is not closed by ``*/``. If the previous line
+    has no ``*`` prefix, the new line will not be changed.
 
 Autocomplete symbols
     When you start to type a symbol name, look for the full string to

--- a/src/editor.c
+++ b/src/editor.c
@@ -3492,8 +3492,8 @@ static void auto_multiline(GeanyEditor *editor, gint cur_line)
 	if (sci_get_style_at(sci, indent_pos) == style || indent_pos >= sci_get_length(sci))
 	{
 		gchar *previous_line = sci_get_line(sci, cur_line - 1);
-		/* the type of comment, '*' (C/C++/Java), '+' and the others (D) */
-		const gchar *continuation = "*";
+		/* the type of comment, '*' (C/C++/Java), '+' D comment that nests */
+		const gchar *continuation = (style == SCE_D_COMMENTNESTED) ? "+" : "*";
 		const gchar *whitespace = ""; /* to hold whitespace if needed */
 		gchar *result;
 		gint len = strlen(previous_line);
@@ -3526,10 +3526,13 @@ static void auto_multiline(GeanyEditor *editor, gint cur_line)
 		{ /* we are on the second line of a multi line comment, so we have to insert white space */
 			whitespace = " ";
 		}
-
-		if (style == SCE_D_COMMENTNESTED)
-			continuation = "+"; /* for nested comments in D */
-
+		else if (!(g_str_has_prefix(previous_line + i, continuation) &&
+			(i + 1 == len || isspace(previous_line[i + 1]))))
+		{
+			// previous line isn't formatted so abort
+			g_free(previous_line);
+			return;
+		}
 		result = g_strconcat(whitespace, continuation, " ", NULL);
 		sci_add_text(sci, result);
 		g_free(result);


### PR DESCRIPTION
…doesn't start with *

Fixes #3386.

Note: This was already the case when the previous line is blank, but a * was inserted when it is not blank.