### PR TITLE
Add keybinding groups for custom build commands 

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3250,7 +3250,7 @@ fields is substituted by the items specified below:
 Build menu keyboard shortcuts
 `````````````````````````````
 
-Keyboard shortcuts can be defined for:
+By default, keyboard shortcuts are defined for:
 
 * the first two filetype build menu items
 * the first three independent build menu items
@@ -3260,7 +3260,9 @@ Keyboard shortcuts can be defined for:
 In the keybindings configuration dialog (see `Keybinding preferences`_)
 these items are identified by the default labels shown in the `Build Menu`_ section above.
 
-It is currently not possible to bind keyboard shortcuts to more than these menu items.
+Shortcuts can also be set for the other custom menu items -
+see `Build keybindings`_ for details.
+
 You can also use underlines in the labels to set mnemonic characters.
 
 Old settings
@@ -3904,6 +3906,13 @@ Run                             F5                        Executes the current f
 
 Set Build Commands                                        Opens the build commands dialog.
 =============================== ========================= ==================================================
+
+Shortcuts can also be set for the other custom menu items which are
+listed in separate groups under the main build keybindings.
+
+.. tip::
+    The number of custom commands in each group can be increased
+    using the extra build settings in `Various preferences`_.
 
 
 Tools keybindings

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -312,6 +312,8 @@ static void add_build_kbs(guint group_id, guint build_group,
 	// TODO: rename to dynamic_keys?
 	group->plugin_keys = g_new0(GeanyKeyBinding, max);
 	group->plugin_key_count = max;
+	// strings are dup'd when plugin_keys is set
+	g_ptr_array_set_free_func(group->key_items, free_key_binding);
 
 	for (guint i = fixed_count; i < max; i++)
 	{

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -311,8 +311,9 @@ void keybindings_free(void);
 
 GeanyKeyGroup *keybindings_get_core_group(guint id);
 
-GeanyKeyGroup *keybindings_set_group(GeanyKeyGroup *group, const gchar *section_name,
-		const gchar *label, gsize count, GeanyKeyGroupCallback callback) G_GNUC_WARN_UNUSED_RESULT;
+GeanyKeyGroup *keybindings_set_group(GeanyKeyGroup *group, gboolean plugin,
+	const gchar *section_name, const gchar *label,
+	gsize count, GeanyKeyGroupCallback callback);
 
 void keybindings_free_group(GeanyKeyGroup *group);
 

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -116,6 +116,9 @@ enum GeanyKeyGroupID
 	GEANY_KEY_GROUP_BUILD,			/**< Group. */
 	GEANY_KEY_GROUP_TOOLS,			/**< Group. */
 	GEANY_KEY_GROUP_HELP,			/**< Group. */
+	GEANY_KEY_GROUP_BUILD_FT,
+	GEANY_KEY_GROUP_BUILD_IND,
+	GEANY_KEY_GROUP_BUILD_EXEC,
 	GEANY_KEY_GROUP_COUNT	/* must not be used by plugins */
 };
 
@@ -311,7 +314,7 @@ void keybindings_free(void);
 
 GeanyKeyGroup *keybindings_get_core_group(guint id);
 
-GeanyKeyGroup *keybindings_set_group(GeanyKeyGroup *group, gboolean plugin,
+GeanyKeyGroup *keybindings_set_group(GeanyKeyGroup *group,
 	const gchar *section_name, const gchar *label,
 	gsize count, GeanyKeyGroupCallback callback);
 

--- a/src/keybindingsprivate.h
+++ b/src/keybindingsprivate.h
@@ -32,10 +32,14 @@ struct GeanyKeyGroup
 	const gchar *name;		/* Group name used in the configuration file, such as @c "html_chars" */
 	const gchar *label;		/* Group label used in the preferences dialog keybindings tab */
 	GeanyKeyGroupCallback callback;	/* use this or individual keybinding callbacks */
-	gboolean plugin;		/* used by plugin or runtime length bindings */
-	GPtrArray *key_items;	/* pointers to GeanyKeyBinding structs */
-	gsize plugin_key_count;			/* number of keybindings the group holds */
-	GeanyKeyBinding *plugin_keys;	/* array of GeanyKeyBinding structs */
+	gboolean plugin;		/* used by plugin */
+	/* pointers to GeanyKeyBinding structs.
+	 * always valid, fixed size or dynamic */
+	GPtrArray *key_items;
+	/* number of keybindings in plugin_keys */
+	gsize plugin_key_count;
+	/* array of GeanyKeyBinding structs, used for a dynamically sized group only. */
+	GeanyKeyBinding *plugin_keys;
 	GeanyKeyGroupFunc cb_func;	/* use this or individual keybinding callbacks (new style) */
 	gpointer cb_data;
 	GDestroyNotify cb_data_destroy; /* used to destroy handler_data */

--- a/src/keybindingsprivate.h
+++ b/src/keybindingsprivate.h
@@ -32,7 +32,7 @@ struct GeanyKeyGroup
 	const gchar *name;		/* Group name used in the configuration file, such as @c "html_chars" */
 	const gchar *label;		/* Group label used in the preferences dialog keybindings tab */
 	GeanyKeyGroupCallback callback;	/* use this or individual keybinding callbacks */
-	gboolean plugin;		/* used by plugin */
+	gboolean plugin;		/* used by plugin or runtime length bindings */
 	GPtrArray *key_items;	/* pointers to GeanyKeyBinding structs */
 	gsize plugin_key_count;			/* number of keybindings the group holds */
 	GeanyKeyBinding *plugin_keys;	/* array of GeanyKeyBinding structs */

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -333,7 +333,7 @@ GeanyKeyGroup *plugin_set_key_group(GeanyPlugin *plugin,
 {
 	Plugin *priv = plugin->priv;
 
-	priv->key_group = keybindings_set_group(priv->key_group, TRUE, section_name,
+	priv->key_group = keybindings_set_group(priv->key_group, section_name,
 		priv->info.name, count, callback);
 	return priv->key_group;
 }

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -333,7 +333,7 @@ GeanyKeyGroup *plugin_set_key_group(GeanyPlugin *plugin,
 {
 	Plugin *priv = plugin->priv;
 
-	priv->key_group = keybindings_set_group(priv->key_group, section_name,
+	priv->key_group = keybindings_set_group(priv->key_group, TRUE, section_name,
 		priv->info.name, count, callback);
 	return priv->key_group;
 }


### PR DESCRIPTION
Includes filetype, non-FT and execute groups.

Fixes https://github.com/geany/geany/issues/3385.
Fixes #705.
![custom build cmds](https://user-images.githubusercontent.com/1107820/218158486-be039546-169c-40f2-ae4c-769a9f55cfea.png)

## Further work
This does not set menu accelerators, that can be done later.
Also it would be good to move the fixed commands into the relevant groups - like compile, build into the filetype commands group - again this should be done separately.