### PR TITLE
Improve some comments in filetype conf files

### DIFF
--- a/data/filedefs/filetypes.Arduino.conf
+++ b/data/filedefs/filetypes.Arduino.conf
@@ -22,9 +22,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 # context action command (please see Geany's main documentation for details)

--- a/data/filedefs/filetypes.CUDA.conf
+++ b/data/filedefs/filetypes.CUDA.conf
@@ -20,7 +20,8 @@ tag_parser=CUDA
 # default extension used when saving files
 extension=cu
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.CUDA.conf
+++ b/data/filedefs/filetypes.CUDA.conf
@@ -31,9 +31,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.Clojure.conf
+++ b/data/filedefs/filetypes.Clojure.conf
@@ -22,9 +22,9 @@ comment_single=;
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.Clojure.conf
+++ b/data/filedefs/filetypes.Clojure.conf
@@ -11,7 +11,8 @@ extension=clj
 lexer_filetype=Lisp
 tag_parser=Clojure
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.Genie.conf
+++ b/data/filedefs/filetypes.Genie.conf
@@ -19,7 +19,8 @@ tag_parser=Python
 # default extension used when saving files
 extension=gs
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.Graphviz.conf
+++ b/data/filedefs/filetypes.Graphviz.conf
@@ -31,9 +31,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.Graphviz.conf
+++ b/data/filedefs/filetypes.Graphviz.conf
@@ -20,7 +20,8 @@ extension=gv
 # MIME type
 mime_type=text/vnd.graphviz
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.Scala.conf
+++ b/data/filedefs/filetypes.Scala.conf
@@ -21,7 +21,8 @@ extension=scala
 # MIME type
 mime_type=text/x-scala
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.Swift.conf
+++ b/data/filedefs/filetypes.Swift.conf
@@ -19,7 +19,8 @@ extension=swift
 # MIME type
 mime_type=text/x-swift
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.TypeScript.conf
+++ b/data/filedefs/filetypes.TypeScript.conf
@@ -31,9 +31,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.TypeScript.conf
+++ b/data/filedefs/filetypes.TypeScript.conf
@@ -20,7 +20,8 @@ tag_parser=TypeScript
 # MIME type
 mime_type=text/x-typescript
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.abaqus
+++ b/data/filedefs/filetypes.abaqus
@@ -30,9 +30,9 @@ comment_single=**
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=false
 

--- a/data/filedefs/filetypes.abaqus
+++ b/data/filedefs/filetypes.abaqus
@@ -19,7 +19,8 @@ arguments=elset engineering inc input line material name nset pin tie type write
 # default extension used when saving files
 extension=inp
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.actionscript
+++ b/data/filedefs/filetypes.actionscript
@@ -16,7 +16,8 @@ extension=as
 # MIME type
 mime_type=application/ecmascript
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.actionscript
+++ b/data/filedefs/filetypes.actionscript
@@ -27,9 +27,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.ada
+++ b/data/filedefs/filetypes.ada
@@ -26,7 +26,8 @@ extension=adb
 # MIME type
 mime_type=text/x-adasrc
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.ada
+++ b/data/filedefs/filetypes.ada
@@ -37,9 +37,9 @@ comment_single=--
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.asm
+++ b/data/filedefs/filetypes.asm
@@ -30,7 +30,8 @@ directives=org list nolist page equivalent word text
 # default extension used when saving files
 extension=asm
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.asm
+++ b/data/filedefs/filetypes.asm
@@ -41,9 +41,9 @@ comment_single=;
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.batch
+++ b/data/filedefs/filetypes.batch
@@ -30,9 +30,9 @@ comment_single=REM\s
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.batch
+++ b/data/filedefs/filetypes.batch
@@ -19,7 +19,8 @@ keywords_optional=
 # default extension used when saving files
 extension=bat
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.c
+++ b/data/filedefs/filetypes.c
@@ -49,7 +49,8 @@ extension=c
 # MIME type
 mime_type=text/x-csrc
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.c
+++ b/data/filedefs/filetypes.c
@@ -60,9 +60,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.caml
+++ b/data/filedefs/filetypes.caml
@@ -42,9 +42,9 @@ comment_close=*)
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.caml
+++ b/data/filedefs/filetypes.caml
@@ -31,7 +31,8 @@ extension=ml
 # MIME type
 mime_type=text/x-ocaml
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.cmake
+++ b/data/filedefs/filetypes.cmake
@@ -31,7 +31,8 @@ extension=cmake
 # MIME type
 mime_type=text/x-cmake
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.cmake
+++ b/data/filedefs/filetypes.cmake
@@ -42,9 +42,9 @@ comment_single=#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.cobol
+++ b/data/filedefs/filetypes.cobol
@@ -36,9 +36,9 @@ comment_single=*>
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=false
 

--- a/data/filedefs/filetypes.cobol
+++ b/data/filedefs/filetypes.cobol
@@ -25,7 +25,8 @@ extension=cob
 # MIME type
 mime_type=text/x-cobol
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.conf
+++ b/data/filedefs/filetypes.conf
@@ -28,9 +28,9 @@ comment_single=#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.conf
+++ b/data/filedefs/filetypes.conf
@@ -17,7 +17,8 @@ lexer.props.allow.initial.spaces=0
 # default extension used when saving files
 extension=conf
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.cpp
+++ b/data/filedefs/filetypes.cpp
@@ -19,7 +19,8 @@ extension=cpp
 # MIME type
 mime_type=text/x-c++src
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.cpp
+++ b/data/filedefs/filetypes.cpp
@@ -30,9 +30,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.cs
+++ b/data/filedefs/filetypes.cs
@@ -20,7 +20,8 @@ extension=cs
 # MIME type
 mime_type=text/x-csharp
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.cs
+++ b/data/filedefs/filetypes.cs
@@ -31,9 +31,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.css
+++ b/data/filedefs/filetypes.css
@@ -57,9 +57,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.css
+++ b/data/filedefs/filetypes.css
@@ -46,7 +46,8 @@ extension=css
 # MIME type
 mime_type=text/css
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.d
+++ b/data/filedefs/filetypes.d
@@ -38,7 +38,8 @@ extension=d
 # MIME type
 mime_type=text/x-dsrc
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.d
+++ b/data/filedefs/filetypes.d
@@ -52,9 +52,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.diff
+++ b/data/filedefs/filetypes.diff
@@ -26,7 +26,8 @@ extension=diff
 # MIME type
 mime_type=text/x-patch
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # only the text before the first --- is a comment

--- a/data/filedefs/filetypes.docbook
+++ b/data/filedefs/filetypes.docbook
@@ -48,7 +48,8 @@ extension=docbook
 # MIME type
 mime_type=application/docbook+xml
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.docbook
+++ b/data/filedefs/filetypes.docbook
@@ -59,9 +59,9 @@ comment_close=-->
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.erlang
+++ b/data/filedefs/filetypes.erlang
@@ -59,9 +59,9 @@ comment_single=%
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.erlang
+++ b/data/filedefs/filetypes.erlang
@@ -48,7 +48,8 @@ extension=erl
 # MIME type
 mime_type=text/x-erlang
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.f77
+++ b/data/filedefs/filetypes.f77
@@ -31,7 +31,8 @@ extension=f
 # MIME type
 mime_type=text/x-fortran
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.f77
+++ b/data/filedefs/filetypes.f77
@@ -42,9 +42,9 @@ comment_single=c
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=false
 

--- a/data/filedefs/filetypes.forth
+++ b/data/filedefs/filetypes.forth
@@ -41,9 +41,9 @@ comment_close= )
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.forth
+++ b/data/filedefs/filetypes.forth
@@ -27,7 +27,8 @@ preword2=! c! @ c@ 2! 2@ and or xor invert negate / /mod mod rshift lshift
 # default extension used when saving files
 extension=fs
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.fortran
+++ b/data/filedefs/filetypes.fortran
@@ -15,7 +15,8 @@ extension=f90
 # MIME type
 mime_type=text/x-fortran
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.fortran
+++ b/data/filedefs/filetypes.fortran
@@ -26,9 +26,9 @@ comment_single=!
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=false
 

--- a/data/filedefs/filetypes.freebasic
+++ b/data/filedefs/filetypes.freebasic
@@ -48,9 +48,9 @@ comment_close='/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.freebasic
+++ b/data/filedefs/filetypes.freebasic
@@ -37,7 +37,8 @@ user2=
 # default extension used when saving files
 extension=bas
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.gdscript
+++ b/data/filedefs/filetypes.gdscript
@@ -42,9 +42,9 @@ comment_single=#\s
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.glsl
+++ b/data/filedefs/filetypes.glsl
@@ -16,7 +16,8 @@ lexer_filetype=C
 # default extension used when saving files
 extension=glsl
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.glsl
+++ b/data/filedefs/filetypes.glsl
@@ -27,9 +27,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.go
+++ b/data/filedefs/filetypes.go
@@ -23,7 +23,8 @@ extension=go
 # MIME type
 mime_type=text/x-go
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.go
+++ b/data/filedefs/filetypes.go
@@ -34,9 +34,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.haskell
+++ b/data/filedefs/filetypes.haskell
@@ -47,7 +47,8 @@ extension=hs
 # MIME type
 mime_type=text/x-haskell
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.haskell
+++ b/data/filedefs/filetypes.haskell
@@ -58,9 +58,9 @@ comment_close=-}
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.haxe
+++ b/data/filedefs/filetypes.haxe
@@ -16,7 +16,8 @@ lexer.cpp.track.preprocessor=0
 # default extension used when saving files
 extension=hx
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.haxe
+++ b/data/filedefs/filetypes.haxe
@@ -27,9 +27,9 @@ comment_single=//
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.html
+++ b/data/filedefs/filetypes.html
@@ -99,7 +99,8 @@ extension=html
 # MIME type
 mime_type=text/html
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # these comments are used for PHP, the comments used in HTML are in filetypes.xml

--- a/data/filedefs/filetypes.html
+++ b/data/filedefs/filetypes.html
@@ -111,9 +111,9 @@ comment_close=-->
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.java
+++ b/data/filedefs/filetypes.java
@@ -28,9 +28,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.java
+++ b/data/filedefs/filetypes.java
@@ -17,7 +17,8 @@ extension=java
 # MIME type
 mime_type=text/x-java
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.javascript
+++ b/data/filedefs/filetypes.javascript
@@ -28,9 +28,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.javascript
+++ b/data/filedefs/filetypes.javascript
@@ -17,7 +17,8 @@ extension=js
 # MIME type
 mime_type=application/javascript
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.latex
+++ b/data/filedefs/filetypes.latex
@@ -28,7 +28,8 @@ extension=tex
 # MIME type
 mime_type=text/x-tex
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.latex
+++ b/data/filedefs/filetypes.latex
@@ -39,9 +39,9 @@ comment_single=%
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.lisp
+++ b/data/filedefs/filetypes.lisp
@@ -34,9 +34,9 @@ comment_close=|#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.lisp
+++ b/data/filedefs/filetypes.lisp
@@ -23,7 +23,8 @@ special_keywords=always and appending array-dimension-limit array-rank-limit arr
 # default extension used when saving files
 extension=lisp
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.lua
+++ b/data/filedefs/filetypes.lua
@@ -56,9 +56,9 @@ comment_close=--]]
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.lua
+++ b/data/filedefs/filetypes.lua
@@ -45,7 +45,8 @@ extension=lua
 # MIME type
 mime_type=text/x-lua
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.makefile
+++ b/data/filedefs/filetypes.makefile
@@ -16,7 +16,8 @@ extension=mak
 # MIME type
 mime_type=text/x-makefile
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.makefile
+++ b/data/filedefs/filetypes.makefile
@@ -27,9 +27,9 @@ comment_single=#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=false
 

--- a/data/filedefs/filetypes.matlab
+++ b/data/filedefs/filetypes.matlab
@@ -22,7 +22,8 @@ extension=m
 # MIME type
 mime_type=text/x-matlab
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.matlab
+++ b/data/filedefs/filetypes.matlab
@@ -33,9 +33,9 @@ comment_single=%
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.nsis
+++ b/data/filedefs/filetypes.nsis
@@ -47,9 +47,9 @@ comment_single=;
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.nsis
+++ b/data/filedefs/filetypes.nsis
@@ -36,7 +36,8 @@ nsis.ignorecase=1
 # default extension used when saving files
 extension=nsi
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.objectivec
+++ b/data/filedefs/filetypes.objectivec
@@ -18,7 +18,8 @@ extension=m
 # MIME type
 mime_type=text/x-objc
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.objectivec
+++ b/data/filedefs/filetypes.objectivec
@@ -29,9 +29,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.pascal
+++ b/data/filedefs/filetypes.pascal
@@ -44,9 +44,9 @@ comment_close=}
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.pascal
+++ b/data/filedefs/filetypes.pascal
@@ -33,7 +33,8 @@ extension=pas
 # MIME type
 mime_type=text/x-pascal
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.perl
+++ b/data/filedefs/filetypes.perl
@@ -64,7 +64,8 @@ extension=pl
 # MIME type
 mime_type=application/x-perl
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.perl
+++ b/data/filedefs/filetypes.perl
@@ -75,9 +75,9 @@ comment_single=#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.php
+++ b/data/filedefs/filetypes.php
@@ -25,9 +25,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.php
+++ b/data/filedefs/filetypes.php
@@ -13,7 +13,8 @@ extension=php
 # MIME type
 mime_type=application/x-php
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # these comments are used for PHP, the comments used in HTML are in filetypes.xml

--- a/data/filedefs/filetypes.po
+++ b/data/filedefs/filetypes.po
@@ -36,9 +36,9 @@ comment_single=#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.po
+++ b/data/filedefs/filetypes.po
@@ -25,7 +25,8 @@ extension=po
 # MIME type
 mime_type=text/x-gettext-translation
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.powershell
+++ b/data/filedefs/filetypes.powershell
@@ -32,7 +32,8 @@ user1=
 # default extension used when saving files
 extension=ps1
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.powershell
+++ b/data/filedefs/filetypes.powershell
@@ -43,9 +43,9 @@ comment_close=#>
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.python.in
+++ b/data/filedefs/filetypes.python.in
@@ -53,9 +53,9 @@ comment_single=#\s
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.python.in
+++ b/data/filedefs/filetypes.python.in
@@ -42,7 +42,8 @@ extension=py
 # MIME type
 mime_type=text/x-python
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comment char, like # in this file

--- a/data/filedefs/filetypes.r
+++ b/data/filedefs/filetypes.r
@@ -38,9 +38,9 @@ comment_single=#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-   #command_example();
+# 		#command_example();
 # setting to false would generate this
-#  command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=false
 

--- a/data/filedefs/filetypes.r
+++ b/data/filedefs/filetypes.r
@@ -27,7 +27,8 @@ package_other=
 # default extension used when saving files
 extension=R
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.restructuredtext
+++ b/data/filedefs/filetypes.restructuredtext
@@ -20,9 +20,9 @@ comment_single=..\s
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 #comment_use_indent=true
 

--- a/data/filedefs/filetypes.restructuredtext
+++ b/data/filedefs/filetypes.restructuredtext
@@ -9,7 +9,8 @@ extension=rst
 # MIME type
 mime_type=text/x-rst
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.ruby
+++ b/data/filedefs/filetypes.ruby
@@ -48,7 +48,8 @@ extension=rb
 # MIME type
 mime_type=application/x-ruby
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.ruby
+++ b/data/filedefs/filetypes.ruby
@@ -59,9 +59,9 @@ comment_single=#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.rust
+++ b/data/filedefs/filetypes.rust
@@ -48,9 +48,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.sh
+++ b/data/filedefs/filetypes.sh
@@ -27,7 +27,8 @@ extension=sh
 # MIME type
 mime_type=application/x-shellscript
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.sh
+++ b/data/filedefs/filetypes.sh
@@ -36,11 +36,11 @@ comment_single=#
 #comment_open=
 #comment_close=
 
-# set to false if a comment character/string should start a column 0 of a line, true uses any
+# set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.smalltalk
+++ b/data/filedefs/filetypes.smalltalk
@@ -41,9 +41,9 @@ comment_close="
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.smalltalk
+++ b/data/filedefs/filetypes.smalltalk
@@ -30,7 +30,8 @@ extension=st
 # MIME type
 mime_type=text/x-smalltalk
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.sql
+++ b/data/filedefs/filetypes.sql
@@ -32,7 +32,8 @@ extension=sql
 # MIME type
 mime_type=text/x-sql
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.sql
+++ b/data/filedefs/filetypes.sql
@@ -43,9 +43,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.tcl
+++ b/data/filedefs/filetypes.tcl
@@ -36,7 +36,8 @@ extension=tcl
 # MIME type
 mime_type=text/x-tcl
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.tcl
+++ b/data/filedefs/filetypes.tcl
@@ -47,9 +47,9 @@ comment_single=#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.vala
+++ b/data/filedefs/filetypes.vala
@@ -20,7 +20,8 @@ extension=vala
 # MIME type
 mime_type=text/x-vala
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.vala
+++ b/data/filedefs/filetypes.vala
@@ -31,9 +31,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 #comment_use_indent=true
 

--- a/data/filedefs/filetypes.verilog
+++ b/data/filedefs/filetypes.verilog
@@ -35,7 +35,8 @@ extension=v
 # MIME type
 mime_type=text/x-verilog
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.verilog
+++ b/data/filedefs/filetypes.verilog
@@ -46,9 +46,9 @@ comment_close=*/
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.vhdl
+++ b/data/filedefs/filetypes.vhdl
@@ -46,9 +46,9 @@ comment_single=--
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.vhdl
+++ b/data/filedefs/filetypes.vhdl
@@ -35,7 +35,8 @@ extension=vhd
 # MIME type
 mime_type=text/x-vhdl
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.xml
+++ b/data/filedefs/filetypes.xml
@@ -10,7 +10,8 @@ extension=xml
 # MIME type
 mime_type=application/xml
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.xml
+++ b/data/filedefs/filetypes.xml
@@ -21,9 +21,9 @@ comment_close=-->
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 

--- a/data/filedefs/filetypes.yaml
+++ b/data/filedefs/filetypes.yaml
@@ -24,7 +24,8 @@ extension=yaml
 # MIME type
 mime_type=application/x-yaml
 
-# the following characters are these which a "word" can contains, see documentation
+# these characters define word boundaries when making selections and searching
+# using word matching options
 #wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 
 # single comments, like # in this file

--- a/data/filedefs/filetypes.yaml
+++ b/data/filedefs/filetypes.yaml
@@ -35,9 +35,9 @@ comment_single=#
 
 # set to false if a comment character/string should start at column 0 of a line, true uses any
 # indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
-	#command_example();
+# 		#command_example();
 # setting to false would generate this
-#	command_example();
+# #		command_example();
 # This setting works only for single line comments
 comment_use_indent=true
 


### PR DESCRIPTION
These are two improvements of the comments discussed in #3413:

1. The indented `#command_example();` in
```ini
# set to false if a comment character/string should start at column 0 of a line, true uses any
# indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
	#command_example();
# setting to false would generate this
#	command_example();
# This setting works only for single line comments
comment_use_indent=true
```
isn't a valid conf file line as `#` should be placed at the beginning of the line. This makes Scintilla to render `#command_example();` as if it weren't a comment. This  patch changes this to
```ini
# set to false if a comment character/string should start at column 0 of a line, true uses any
# indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
# 		#command_example();
# setting to false would generate this
# #		command_example();
# This setting works only for single line comments
```

2. The patch replaces the not-very-English-sounding
```ini
# the following characters are these which a "word" can contains, see documentation
#wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
```
with the following description from the documentation:
```ini
# these characters define word boundaries when making selections and searching
# using word matching options
#wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
```