### PR TITLE
CI: Define JOBS environment variable and use it for make

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ env:
   CCACHE_COMPRESS: true
   CCACHE_MAXSIZE: 1G
   PYTHON: python3
+  JOBS: 2
   DEBUG: 0
 
 jobs:
@@ -87,17 +88,17 @@ jobs:
       - name: Build
         run: |
           cd _build
-          make
+          make -j ${{ env.JOBS }}
 
       - name: Run Tests
         run: |
           cd _build
-          make -j2 check
+          make -j ${{ env.JOBS }} check
 
       - name: Run distcheck
         run: |
           cd _build
-          make -j2 distcheck DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_FLAGS";
+          make -j ${{ env.JOBS }} distcheck DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_FLAGS";
 
       - name: ccache statistics
         run: ccache --show-stats


### PR DESCRIPTION
I just noticed in the CI workflow for the "traditional" Autotools based jobs, we did not specify "-j" for parallel job execution for the main "make" call to build all the sources.
We did however for "make check" and "make distcheck".

If there is no reason for not using "-j 2", this PR adds it and potentially speeds up the CI jobs a bit.

For Meson, as far as I understood "ninja" uses parallel execution by default with the number of CPU cores available.

For Mingw64, I just enabled "-j $JOBS" if it is set (957da21ddfc6e9e00f1a7b208d55e7ed3f7ebe20).