### PR TITLE
Allow Dispatching CI Build Workflow Manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 # cancel already running builds of the same branch or pull request
 concurrency:


### PR DESCRIPTION
Simply adds `workflow_dispatch` trigger to CI Build workflow to allow dispatching manually.