### PR TITLE
Prevent possible crash when using tm_workspace API by plugins

### DIFF
--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -79,7 +79,7 @@ static gboolean tm_create_workspace(void)
 	theWorkspace->source_files = g_ptr_array_new();
 	theWorkspace->typename_array = g_ptr_array_new();
 	theWorkspace->global_typename_array = g_ptr_array_new();
-	theWorkspace->source_file_map = g_hash_table_new_full(g_str_hash, g_str_equal, NULL,
+	theWorkspace->source_file_map = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
 		free_ptr_array);
 
 	tm_ctags_init();
@@ -192,7 +192,7 @@ void tm_workspace_add_source_file_noupdate(TMSourceFile *source_file)
 	if (!file_arr)
 	{
 		file_arr = g_ptr_array_new();
-		g_hash_table_insert(theWorkspace->source_file_map, source_file->short_name, file_arr);
+		g_hash_table_insert(theWorkspace->source_file_map, g_strdup(source_file->short_name), file_arr);
 	}
 	g_ptr_array_add(file_arr, source_file);
 }


### PR DESCRIPTION
The current code uses an unreffed `TMSourceFile->short_name` as the key into `source_file_map`. With Geany itself this is no problem as the `TMSourceFiles` are always destroyed after their removal from the hash table.

However, if a plugin adds 2 different files to the TM using
```
tm_workspace_add_source_file(file1);
tm_workspace_add_source_file(file2);
```
that have a different path but the same file name, such as
```
/A/B/myfile.c
/C/D/myfile.c
```
and at a later point removes them using something like
```
tm_workspace_remove_source_file(file1);
tm_source_file_free(file1);
tm_workspace_remove_source_file(file2);
tm_source_file_free(file2);
```
the
```
tm_source_file_free(file1);
```
call deallocates the key in the hash table which is now an invalid pointer and the subsequent
```
tm_workspace_remove_source_file(file2);
```
crashes the plugin.

While it would be possible to solve this crash at the plugin level by reordering the operations such as
```
tm_workspace_remove_source_file(file1);
tm_workspace_remove_source_file(file2);
tm_source_file_free(file1);
tm_source_file_free(file2);
```
this is not obvious from the plugin's perspective which doesn't know Geany's internals so better to solve it at Geany's level by using a g_strdupped value as the key.

This problem currently happens with the ProjectOrganizer plugin.