### PR TITLE
[trivial] [filetype config] Remove outdated build command substitution comment

### DIFF
--- a/data/filedefs/filetypes.CUDA.conf
+++ b/data/filedefs/filetypes.CUDA.conf
@@ -48,7 +48,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=nvcc -c "%f"
 linker=nvcc -o "%e" "%f"
 run_cmd="./%e"

--- a/data/filedefs/filetypes.Clojure.conf
+++ b/data/filedefs/filetypes.Clojure.conf
@@ -39,6 +39,5 @@ type=0
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=
 run_cmd=clj "%f"

--- a/data/filedefs/filetypes.Scala.conf
+++ b/data/filedefs/filetypes.Scala.conf
@@ -35,7 +35,6 @@ comment_use_indent=true
 #[build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 #compiler=g++ -Wall -c "%f"
 #linker=g++ -Wall -o "%e" "%f"
 #run_cmd="./%e"

--- a/data/filedefs/filetypes.TypeScript.conf
+++ b/data/filedefs/filetypes.TypeScript.conf
@@ -48,7 +48,6 @@ context_action_cmd=
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 #FT_02_LB=_Lint
 #FT_02_CM=jshint "%f"
 #FT_02_WD=

--- a/data/filedefs/filetypes.abaqus
+++ b/data/filedefs/filetypes.abaqus
@@ -48,7 +48,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=
 run_cmd=abaqus job="%f" interactive datacheck
 

--- a/data/filedefs/filetypes.actionscript
+++ b/data/filedefs/filetypes.actionscript
@@ -44,7 +44,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=
 run_cmd=
 

--- a/data/filedefs/filetypes.ada
+++ b/data/filedefs/filetypes.ada
@@ -55,7 +55,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=gcc -Wall -c "%f"
 linker=gnatmake "%e"
 run_cmd="./%e"

--- a/data/filedefs/filetypes.asm
+++ b/data/filedefs/filetypes.asm
@@ -58,6 +58,5 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=nasm "%f"
 

--- a/data/filedefs/filetypes.c
+++ b/data/filedefs/filetypes.c
@@ -77,7 +77,6 @@ context_action_cmd=
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 FT_00_LB=_Compile
 FT_00_CM=gcc -Wall -c "%f"
 FT_00_WD=

--- a/data/filedefs/filetypes.caml
+++ b/data/filedefs/filetypes.caml
@@ -59,7 +59,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=ocamlc -c "%f"
 linker=ocamlc -o "%e" "%f"
 run_cmd="./%e"

--- a/data/filedefs/filetypes.cpp
+++ b/data/filedefs/filetypes.cpp
@@ -47,7 +47,6 @@ context_action_cmd=
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 FT_00_LB=_Compile
 FT_00_CM=g++ -Wall -c "%f"
 FT_00_WD=

--- a/data/filedefs/filetypes.cs
+++ b/data/filedefs/filetypes.cs
@@ -48,7 +48,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 # be careful following settings are untested
 compiler=mcs /t:winexe "%f" /r:System,System.Drawing
 run_cmd=mono "%e.exe"

--- a/data/filedefs/filetypes.d
+++ b/data/filedefs/filetypes.d
@@ -69,7 +69,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=dmd -w -c "%f"
 linker=dmd -w -of"%e" "%f"
 # you can also use the gdc compiler, please use the "gdmd" wrapper script(included with gdc)

--- a/data/filedefs/filetypes.erlang
+++ b/data/filedefs/filetypes.erlang
@@ -76,6 +76,5 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=erlc "%f"
 run_cmd=erl "%f"

--- a/data/filedefs/filetypes.f77
+++ b/data/filedefs/filetypes.f77
@@ -59,7 +59,6 @@ type=0
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=gfortran -Wall -c "%f"
 linker=gfortran -Wall -o "%e" "%f"
 run_cmd="./%e"

--- a/data/filedefs/filetypes.fortran
+++ b/data/filedefs/filetypes.fortran
@@ -43,7 +43,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=gfortran -Wall -c "%f"
 linker=gfortran -Wall -o "%e" "%f"
 run_cmd="./%e"

--- a/data/filedefs/filetypes.freebasic
+++ b/data/filedefs/filetypes.freebasic
@@ -65,7 +65,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=fbc -w all "%f"
 run_cmd="./%e"
 

--- a/data/filedefs/filetypes.gdscript
+++ b/data/filedefs/filetypes.gdscript
@@ -56,7 +56,6 @@ type=1
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 FT_00_LB=_Compile
 FT_00_CM=
 FT_00_WD=

--- a/data/filedefs/filetypes.glsl
+++ b/data/filedefs/filetypes.glsl
@@ -44,7 +44,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 #compiler=
 #linker=
 #run_cmd=

--- a/data/filedefs/filetypes.haskell
+++ b/data/filedefs/filetypes.haskell
@@ -75,7 +75,6 @@ context_action_cmd=
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 FT_00_LB=_Compile
 FT_00_CM=ghc --make "%f"
 FT_00_WD=

--- a/data/filedefs/filetypes.haxe
+++ b/data/filedefs/filetypes.haxe
@@ -44,7 +44,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=haxe -neko "%e.n" -cp . "%f"
 run_cmd=neko "%e"
 

--- a/data/filedefs/filetypes.html
+++ b/data/filedefs/filetypes.html
@@ -132,7 +132,6 @@ xml_indent_tags=true
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 # use a syntax checker and ignore the formatted output
 compiler=tidy %f >/dev/null
 

--- a/data/filedefs/filetypes.java
+++ b/data/filedefs/filetypes.java
@@ -45,6 +45,5 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=javac "%f"
 run_cmd=java "%e"

--- a/data/filedefs/filetypes.javascript
+++ b/data/filedefs/filetypes.javascript
@@ -45,7 +45,6 @@ context_action_cmd=
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 FT_02_LB=_Lint
 FT_02_CM=jshint "%f"
 FT_02_WD=

--- a/data/filedefs/filetypes.julia
+++ b/data/filedefs/filetypes.julia
@@ -76,6 +76,5 @@ type=0
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=
 run_cmd=julia "%f"

--- a/data/filedefs/filetypes.latex
+++ b/data/filedefs/filetypes.latex
@@ -56,7 +56,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=latex --file-line-error-style "%f"
 # it is called linker, but here it is an alternative compiler command
 linker=pdflatex --file-line-error-style "%f"

--- a/data/filedefs/filetypes.lisp
+++ b/data/filedefs/filetypes.lisp
@@ -51,6 +51,5 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=
 run_cmd=clisp "%f"

--- a/data/filedefs/filetypes.lua
+++ b/data/filedefs/filetypes.lua
@@ -73,7 +73,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=
 run_cmd=lua "%f"
 

--- a/data/filedefs/filetypes.matlab
+++ b/data/filedefs/filetypes.matlab
@@ -50,6 +50,5 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=
 run_cmd=octave -q "%f"

--- a/data/filedefs/filetypes.nsis
+++ b/data/filedefs/filetypes.nsis
@@ -64,6 +64,5 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=makensis "%f"
 run_cmd="./%e"

--- a/data/filedefs/filetypes.objectivec
+++ b/data/filedefs/filetypes.objectivec
@@ -46,7 +46,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=gcc -Wall -c "%f"
 linker=gcc -Wall -o "%e" "%f" -lobjc
 run_cmd="./%e"

--- a/data/filedefs/filetypes.pascal
+++ b/data/filedefs/filetypes.pascal
@@ -61,6 +61,5 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=fpc "%f"
 run_cmd="./%e"

--- a/data/filedefs/filetypes.perl
+++ b/data/filedefs/filetypes.perl
@@ -92,7 +92,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 
 compiler=perl -cw "%f"
 

--- a/data/filedefs/filetypes.php
+++ b/data/filedefs/filetypes.php
@@ -46,7 +46,6 @@ xml_indent_tags=true
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=php -l "%f"
 run_cmd=php "%f"
 

--- a/data/filedefs/filetypes.po
+++ b/data/filedefs/filetypes.po
@@ -53,6 +53,5 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=msgfmt --check --check-accelerators=_ "%f"
 

--- a/data/filedefs/filetypes.powershell
+++ b/data/filedefs/filetypes.powershell
@@ -55,5 +55,4 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 run_cmd=powershell -file "%f"

--- a/data/filedefs/filetypes.python.in
+++ b/data/filedefs/filetypes.python.in
@@ -70,7 +70,6 @@ context_action_cmd=
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 FT_00_LB=_Compile
 FT_00_CM=@PYTHON_COMMAND@ -m py_compile "%f"
 FT_00_WD=

--- a/data/filedefs/filetypes.ruby
+++ b/data/filedefs/filetypes.ruby
@@ -76,7 +76,6 @@ context_action_cmd=
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 FT_00_LB=_Compile
 FT_00_CM=ruby -wc "%f"
 FT_00_WD=

--- a/data/filedefs/filetypes.sh
+++ b/data/filedefs/filetypes.sh
@@ -55,7 +55,6 @@ context_action_cmd=
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 FT_02_LB=_Lint
 FT_02_CM=shellcheck --format=gcc "%f"
 FT_02_WD=

--- a/data/filedefs/filetypes.tcl
+++ b/data/filedefs/filetypes.tcl
@@ -64,7 +64,6 @@ context_action_cmd=
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=tclsh "%f"
 run_cmd=tclsh "%f"
 

--- a/data/filedefs/filetypes.vala
+++ b/data/filedefs/filetypes.vala
@@ -48,7 +48,6 @@ comment_close=*/
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=valac -c "%f"
 linker=valac "%f"
 run_cmd=./"%e"

--- a/data/filedefs/filetypes.xml
+++ b/data/filedefs/filetypes.xml
@@ -42,7 +42,6 @@ xml_indent_tags=true
 [build-menu]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 FT_02_LB=_Lint
 FT_02_CM=xmllint --noout "%f"
 FT_02_WD=

--- a/data/filedefs/filetypes.zephir
+++ b/data/filedefs/filetypes.zephir
@@ -20,5 +20,4 @@ extension=zep
 [build_settings]
 # %f will be replaced by the complete filename
 # %e will be replaced by the filename without extension
-# (use only one of it at one time)
 compiler=zephir build


### PR DESCRIPTION
E.g. `%e` can be used twice in the same command.