### PR TITLE
[config files] Don't comment global content unless it is Conf

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2133,7 +2133,8 @@ static void on_config_file_clicked(GtkWidget *widget, gpointer user_data)
 			g_file_get_contents(global_file, &global_content, NULL, NULL);
 
 		doc = document_new_file(utf8_filename, ft, global_content);
-		if (global_content)
+		// comment conf entries so we don't override defaults unnecessarily
+		if (g_str_has_suffix(file_name, ".conf") || (ft && ft->id == GEANY_FILETYPES_CONF))
 		{
 			sci_select_all(doc->editor->sci);
 			keybindings_send_command(GEANY_KEY_GROUP_FORMAT,


### PR DESCRIPTION
When using *Tools->Config Files* to open a user file that doesn't exist.
This fixes the first line of `geany.css` being wrongly uncommented (and the rest unchanged) due to toggle comment being used and CSS not having a line comment.

Split out from #3396 as it's independent of it.