### PR TITLE
Don't use ctags isFileScope tag information

### DIFF
--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -672,10 +672,7 @@ gboolean tm_workspace_is_autocomplete_tag(TMTag *tag,
 		 current_line >= tag->line &&
 		 g_strcmp0(current_scope, tag->scope) == 0);
 
-	/* tag->local indicates per-file-only visibility such as static C functions */
-	gboolean valid_local = !tag->local || current_file == tag->file;
-
-	return valid && valid_local &&
+	return valid &&
 		!tm_tag_is_anon(tag) && tm_parser_langs_compatible(lang, tag->lang) &&
 		!(tag->type & tm_tag_include_t);
 }


### PR DESCRIPTION
While it would be nice to get rid of some extra tags, this field is generated in ctags using file name and also some questionable heuristics which doesn't lead to completely reliable results so better to avoid this field.

Reverts #3268.

Fixes #3454.