### PR TITLE
autoit: use local/global variable tags

### DIFF
--- a/ctags/parsers/autoit.c
+++ b/ctags/parsers/autoit.c
@@ -283,7 +283,7 @@ static void findAutoItTags (void)
 					skipSpaces (&p);
 				if (*p == '$')
 				{
-					vStringPut (name, (int) *p++);
+					p++;
 					while (isIdentChar ((int) *p))
 					{
 						vStringPut (name, (int) *p);

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -1083,13 +1083,14 @@ static TMParserMapGroup group_BATCH[] = {
 static TMParserMapEntry map_AUTOIT[] = {
 	{'f', tm_tag_function_t},
 	{'r', tm_tag_other_t},
-	{'g', tm_tag_undef_t},
-	{'l', tm_tag_undef_t},
+	{'g', tm_tag_variable_t},
+	{'l', tm_tag_variable_t},
 	{'S', tm_tag_undef_t},
 };
 static TMParserMapGroup group_AUTOIT[] = {
 	{N_("Functions"), TM_ICON_METHOD, tm_tag_function_t},
 	{N_("Regions"), TM_ICON_OTHER, tm_tag_other_t},
+	{N_("Variables"), TM_ICON_VAR, tm_tag_variable_t},
 };
 
 typedef struct

--- a/tests/ctags/simple.au3.tags
+++ b/tests/ctags/simple.au3.tags
@@ -1,3 +1,9 @@
+$iDoubledÌ16384Ö0
+variable:   $iDoubled
+$iMagicÌ16384Ö0
+variable:   $iMagic
+$iNumberÌ16384Ö0
+variable:   $iNumber
 All functionsÌ524288Ö0
 other:      All functions
 MyDoubleÌ16Í($iValue)ÎAll functionsÖ0

--- a/tests/ctags/simple.au3.tags
+++ b/tests/ctags/simple.au3.tags
@@ -1,9 +1,3 @@
-$iDoubledÌ16384Ö0
-variable:   $iDoubled
-$iMagicÌ16384Ö0
-variable:   $iMagic
-$iNumberÌ16384Ö0
-variable:   $iNumber
 All functionsÌ524288Ö0
 other:      All functions
 MyDoubleÌ16Í($iValue)ÎAll functionsÖ0
@@ -12,3 +6,9 @@ MyDouble0Ì16Í($iValue)ÎAll functionsÖ0
 function:   All functions :: MyDouble0($iValue)
 MyDouble1Ì16Í($iValue)ÎAll functionsÖ0
 function:   All functions :: MyDouble1($iValue)
+iDoubledÌ16384Ö0
+variable:   iDoubled
+iMagicÌ16384Ö0
+variable:   iMagic
+iNumberÌ16384Ö0
+variable:   iNumber


### PR DESCRIPTION
Note that "local" variables seem to be local for the given file and not local within a certain function so mapping them to `tm_tag_local_var_t` isn't appropriate.

At the moment autocompletion doesn't work - this is caused by

https://github.com/universal-ctags/ctags/pull/3697

which I add to this PR if it gets merged upstream.