### PR TITLE
Enable mouse wheel tab switching for sidebar and message window

### DIFF
--- a/src/notebook.c
+++ b/src/notebook.c
@@ -548,33 +548,6 @@ static gboolean notebook_tab_bar_click_cb(GtkWidget *widget, GdkEventButton *eve
 }
 
 
-static gboolean notebook_tab_bar_scroll_cb(GtkWidget *widget, GdkEventScroll *event)
-{
-	GtkNotebook *notebook = GTK_NOTEBOOK(widget);
-	GtkWidget *child;
-
-	child = gtk_notebook_get_nth_page(notebook, gtk_notebook_get_current_page(notebook));
-	if (child == NULL)
-		return FALSE;
-
-	switch (event->direction)
-	{
-		case GDK_SCROLL_RIGHT:
-		case GDK_SCROLL_DOWN:
-			gtk_notebook_next_page(notebook);
-			break;
-		case GDK_SCROLL_LEFT:
-		case GDK_SCROLL_UP:
-			gtk_notebook_prev_page(notebook);
-			break;
-		default:
-			break;
-	}
-
-	return TRUE;
-}
-
-
 void notebook_init(void)
 {
 	g_signal_connect_after(main_widgets.notebook, "button-press-event",
@@ -589,8 +562,7 @@ void notebook_init(void)
 	g_signal_connect(geany_object, "document-close",
 		G_CALLBACK(on_document_close), NULL);
 
-	gtk_widget_add_events(main_widgets.notebook, GDK_SCROLL_MASK);
-	g_signal_connect(main_widgets.notebook, "scroll-event", G_CALLBACK(notebook_tab_bar_scroll_cb), NULL);
+	ui_notebook_setup(GTK_NOTEBOOK(main_widgets.notebook));
 
 	/* in case the switch dialog misses an event while drawing the dialog */
 	g_signal_connect(main_widgets.window, "key-release-event", G_CALLBACK(on_key_release_event), NULL);
@@ -726,10 +698,6 @@ gint notebook_new_tab(GeanyDocument *this)
 	/* focus the current document after clicking on a tab */
 	g_signal_connect_after(ebox, "button-release-event",
 		G_CALLBACK(focus_sci), NULL);
-
-    /* switch tab by scrolling - GTK2 behaviour for GTK3 */
-	gtk_widget_add_events(GTK_WIDGET(ebox), GDK_SCROLL_MASK);
-	gtk_widget_add_events(GTK_WIDGET(this->priv->tab_label), GDK_SCROLL_MASK);
 
 	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 2);
 	gtk_box_pack_start(GTK_BOX(hbox), this->priv->tab_label, FALSE, FALSE, 0);

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -270,7 +270,10 @@ GtkWidget *ui_label_new_bold(const gchar *text);
 
 void ui_label_set_markup(GtkLabel *label, const gchar *format, ...) G_GNUC_PRINTF(2, 3);
 
+void ui_notebook_setup(GtkNotebook *nb);
+
 /* End of general widget functions */
+
 
 void ui_init_builder(void);
 


### PR DESCRIPTION
Add `ui_notebook_setup()` function which supports notebook tabs already present and any pages added over time. The tab label widget must either support events or be a label, in which case it will be reparented in an event box.