### PR TITLE
Fix copying comma in cxxTokenCopy

### DIFF
--- a/ctags/parsers/cxx/cxx_parser_function.c
+++ b/ctags/parsers/cxx/cxx_parser_function.c
@@ -1063,7 +1063,7 @@ bool cxxParserLookForFunctionSignature(
 							pParamInfo
 						)
 					)
-						goto next_token;
+					goto next_token;
 
 			}
 

--- a/ctags/parsers/cxx/cxx_token.c
+++ b/ctags/parsers/cxx/cxx_token.c
@@ -117,7 +117,7 @@ CXXToken * cxxTokenCopy(CXXToken * pToken)
 	pRetToken->oFilePosition = pToken->oFilePosition;
 	pRetToken->eType = pToken->eType;
 	pRetToken->eKeyword = pToken->eKeyword;
-	pToken->bFollowedBySpace = pToken->bFollowedBySpace;
+	pRetToken->bFollowedBySpace = pToken->bFollowedBySpace;
 	vStringCat(pRetToken->pszWord,pToken->pszWord);
 
 	return pRetToken;

--- a/ctags/parsers/geany_c.c
+++ b/ctags/parsers/geany_c.c
@@ -6,6 +6,8 @@
 *
 *   This module contains functions for parsing and scanning C, C++, C#, D and Java
 *   source files.
+*
+*   *** This file is not used for C and C++, see cxx/cxx.c ***
 */
 
 /*


### PR DESCRIPTION
`cxx` changes backported from ctags.
I'm not sure if this actually fixes anything but it's an obvious mistake.
Also add warning that `geany_c.c` is not used for C & C++.