### PR TITLE
Update instructions for new lexer modules

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -587,6 +587,7 @@ LexFoo.cxx. Try the official Scintilla project first.
 
 When adding a lexer, update:
 
+* meson.build
 * scintilla/Makefile.am
 * scintilla/lexilla/src/Lexilla.cxx - add the lexer module in AddGeanyLexers()
 

--- a/HACKING
+++ b/HACKING
@@ -588,7 +588,7 @@ LexFoo.cxx. Try the official Scintilla project first.
 When adding a lexer, update:
 
 * scintilla/Makefile.am
-* scintilla/src/Catalogue.cxx - add a LINK_LEXER command *manually*
+* scintilla/lexilla/src/Lexilla.cxx - add the lexer module in AddGeanyLexers()
 
 For syntax highlighting, you will need to edit highlighting.c and
 highlightingmappings.h and add the following things:


### PR DESCRIPTION
The mentioned file `scintilla/src/Catalogue.cxx` was removed in Scintilla/Lexilla v5 (7694aa5acb730fb7d0bbd1b4212140e63d315215) – maybe it's time to update the documentation? 😳