### PR TITLE
Mark tags as "local" only for files with a known C/C++ source extension

### DIFF
--- a/src/tagmanager/tm_ctags.c
+++ b/src/tagmanager/tm_ctags.c
@@ -119,7 +119,7 @@ static gboolean init_tag(TMTag *tag, TMSourceFile *file, const tagEntryInfo *tag
 
 	tag->name = g_strdup(tag_entry->name);
 	tag->type = type;
-	tag->local = tag_entry->isFileScope;
+	tag->local = tag_entry->isFileScope && file->trust_file_scope;
 	tag->flags = tm_tag_flag_none_t;
 	if (isTagExtraBitMarked(tag_entry, XTAG_ANONYMOUS))
 		tag->flags |= tm_tag_flag_anon_t;

--- a/src/tagmanager/tm_source_file.c
+++ b/src/tagmanager/tm_source_file.c
@@ -609,6 +609,25 @@ static gboolean tm_source_file_init(TMSourceFile *source_file, const char *file_
 	else
 		source_file->lang = tm_ctags_get_named_lang(name);
 
+	source_file->trust_file_scope = TRUE;
+
+	if (source_file->lang == TM_PARSER_C || source_file->lang == TM_PARSER_CPP)
+	{
+		const gchar **ext;
+		const gchar *common_src_exts[] =
+			{".c", ".C", ".cc", ".cp", ".cpp", ".cxx", ".c++", ".CPP", ".CXX", NULL};
+
+		source_file->trust_file_scope = FALSE;
+		for (ext = common_src_exts; *ext; ext++)
+		{
+			if (g_str_has_suffix(source_file->short_name, *ext))
+			{
+				source_file->trust_file_scope = TRUE;
+				break;
+			}
+		}
+	}
+
 	return TRUE;
 }
 

--- a/src/tagmanager/tm_source_file.h
+++ b/src/tagmanager/tm_source_file.h
@@ -35,6 +35,7 @@ typedef struct TMSourceFile
 	char *file_name; /**< Full file name (inc. path) */
 	char *short_name; /**< Just the name of the file (without the path) */
 	GPtrArray *tags_array; /**< Sorted tag array obtained by parsing the object. @elementtype{TMTag} */
+	gboolean trust_file_scope;
 } TMSourceFile;
 
 GType tm_source_file_get_type(void);


### PR DESCRIPTION
After some more thinking about it, we can fix #3454 very easily by ourselves by checking whether the tag originates from a source file with a known/common C/C++ extension - if not, always set "local" to FALSE.

The first patch adds `is_c_source` flag to TMSourceFile to indicate whether the file has one of the known C/C++ extensions, the second patch uses this flag and for C/C++ sources sets "local" to TRUE only when this flag is set (in addition to ctag's isFileScope flag).

@b4n Does this fix look OK to you?

Fixes #3454.