### PR TITLE
Bump Geany ABI to mitigate Scintilla 5.1.5 changes

### DIFF
--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -68,7 +68,7 @@ G_BEGIN_DECLS
  * Changing this forces all plugins to be recompiled before Geany can load them. */
 /* This should usually stay the same if fields are only appended, assuming only pointers to
  * structs and not structs themselves are declared by plugins. */
-#define GEANY_ABI_VERSION (72 << GEANY_ABI_SHIFT)
+#define GEANY_ABI_VERSION (73 << GEANY_ABI_SHIFT)
 
 
 /** Defines a function to check the plugin is safe to load.


### PR DESCRIPTION
This is to mitigate this change in Scintilla 5.1.5:

> When calling SCI_GETTEXT, SCI_GETSELTEXT, and SCI_GETCURLINE with a NULL buffer argument to discover the length that should be allocated, do not include the terminating NUL in the returned value. The value returned is 1 less than previous versions of Scintilla. Applications should allocate a buffer 1 more than this to accommodate the NUL. The wParam (length) argument to SCI_GETTEXT and SCI_GETCURLINE also omits the NUL. This is more consistent with other APIs.

While it doesn't prevent simple recompilation of existing plugins without fixing the possible problems in them, at least it doesn't allow users using binary releases to load old, unfixed plugins.