### PR TITLE
Improve tag-goto popup

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -486,7 +486,8 @@ static void hide_empty_rows(GtkTreeStore *store)
 }
 
 
-static const gchar *get_symbol_name(GeanyDocument *doc, const TMTag *tag, gboolean found_parent)
+static const gchar *get_symbol_name(GeanyDocument *doc, const TMTag *tag, gboolean include_scope,
+	gboolean include_line)
 {
 	gchar *utf8_name;
 	const gchar *scope = tag->scope;
@@ -517,7 +518,7 @@ static const gchar *get_symbol_name(GeanyDocument *doc, const TMTag *tag, gboole
 		g_string_truncate(buffer, 0);
 
 	/* check first char of scope is a wordchar */
-	if (!found_parent && scope &&
+	if (include_scope && scope &&
 		strpbrk(scope, GEANY_WORDCHARS) == scope)
 	{
 		const gchar *sep = tm_parser_scope_separator_printable(tag->lang);
@@ -530,14 +531,15 @@ static const gchar *get_symbol_name(GeanyDocument *doc, const TMTag *tag, gboole
 	if (! doc_is_utf8)
 		g_free(utf8_name);
 
-	g_string_append_printf(buffer, " [%lu]", tag->line);
+	if (include_line)
+		g_string_append_printf(buffer, " [%lu]", tag->line);
 
 	return buffer->str;
 }
 
 
 // Returns NULL if the tag is not a variable or callable
-static gchar *get_symbol_tooltip(GeanyDocument *doc, const TMTag *tag)
+static gchar *get_symbol_tooltip(GeanyDocument *doc, const TMTag *tag, gboolean include_scope)
 {
 	gchar *utf8_name = tm_parser_format_function(tag->lang, tag->name,
 		tag->arglist, tag->var_type, tag->scope);
@@ -545,7 +547,8 @@ static gchar *get_symbol_tooltip(GeanyDocument *doc, const TMTag *tag)
 	if (!utf8_name && tag->var_type &&
 		tag->type & (tm_tag_field_t | tm_tag_member_t | tm_tag_variable_t | tm_tag_externvar_t))
 	{
-		utf8_name = tm_parser_format_variable(tag->lang, tag->name, tag->var_type);
+		gchar *scope = include_scope ? tag->scope : NULL;
+		utf8_name = tm_parser_format_variable(tag->lang, tag->name, tag->var_type, scope);
 	}
 
 	/* encodings_convert_to_utf8_from_charset() fails with charset "None", so skip conversion
@@ -949,8 +952,8 @@ static void update_tree_tags(GeanyDocument *doc, GList **tags)
 
 					/* only update fields that (can) have changed (name that holds line
 					 * number, tooltip, and the tag itself) */
-					name = get_symbol_name(doc, found, parent_name != NULL);
-					tooltip = get_symbol_tooltip(doc, found);
+					name = get_symbol_name(doc, found, parent_name == NULL, TRUE);
+					tooltip = get_symbol_tooltip(doc, found, FALSE);
 					gtk_tree_store_set(store, &iter,
 							SYMBOLS_COLUMN_NAME, name,
 							SYMBOLS_COLUMN_TOOLTIP, tooltip,
@@ -1006,8 +1009,8 @@ static void update_tree_tags(GeanyDocument *doc, GList **tags)
 			expand = ! gtk_tree_model_iter_has_child(model, parent);
 
 			/* insert the new element */
-			name = get_symbol_name(doc, tag, parent_name != NULL);
-			tooltip = get_symbol_tooltip(doc, tag);
+			name = get_symbol_name(doc, tag, parent_name == NULL, TRUE);
+			tooltip = get_symbol_tooltip(doc, tag, FALSE);
 			gtk_tree_store_insert_with_values(store, &iter, parent, 0,
 					SYMBOLS_COLUMN_NAME, name,
 					SYMBOLS_COLUMN_TOOLTIP, tooltip,
@@ -1509,20 +1512,29 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 		GtkWidget *image;
 		gchar *fname = short_names[i];
 		gchar *text;
-		gchar *sym = get_symbol_tooltip(doc, tmtag);
+		gchar *tooltip;
+		gchar *sym = get_symbol_tooltip(doc, tmtag, TRUE);
 
 		if (!sym)
+			sym = g_strdup(get_symbol_name(doc, tmtag, TRUE, FALSE));
+		if (!sym)
 			sym = g_strdup("");
+
 		if (! first && have_best)
-			/* For translators: it's the filename and line number of a symbol in the goto-symbol popup menu */
-			text = g_markup_printf_escaped(_("<b>%s:%lu:</b> %s"), fname, tmtag->line, sym);
+			/* For translators: it's the filename, line number, and signature of a symbol in the goto-symbol popup menu */
+			text = g_markup_printf_escaped(_("<i><b>%s:%lu</b></i><small><tt>  %s</tt></small>"), fname, tmtag->line, sym);
 		else
-			/* For translators: it's the filename and line number of a symbol in the goto-symbol popup menu */
-			text = g_markup_printf_escaped(_("<i>%s:%lu:</i> %s"), fname, tmtag->line, sym);
+			/* For translators: it's the filename, line number, and signature of a symbol in the goto-symbol popup menu */
+			text = g_markup_printf_escaped(_("<i>%s:%lu</i><small><tt>  %s</tt></small>"), fname, tmtag->line, sym);
+
+		/* For translators: it's the filename, line number, and signature of a symbol in the goto-symbol popup menu */
+		tooltip = g_markup_printf_escaped(_("<i>%s:%lu</i>\n<small><tt>%s</tt></small>"), fname, tmtag->line, sym);
 
 		g_free(sym);
 		image = gtk_image_new_from_pixbuf(symbols_icons[get_tag_class(tmtag)].pixbuf);
-		label = g_object_new(GTK_TYPE_LABEL, "label", text, "use-markup", TRUE, "xalign", 0.0, NULL);
+		label = g_object_new(GTK_TYPE_LABEL, "label", text, "use-markup", TRUE, "xalign", 0.0,
+					"tooltip-markup", tooltip, "max-width-chars", 80,
+					"ellipsize", PANGO_ELLIPSIZE_END, NULL);
 		item = g_object_new(GTK_TYPE_IMAGE_MENU_ITEM, "image", image, "child", label, "always-show-image", TRUE, NULL);
 		g_signal_connect_data(item, "activate", G_CALLBACK(on_goto_popup_item_activate),
 		                      tm_tag_ref(tmtag), (GClosureNotify) tm_tag_unref, 0);

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1523,14 +1523,11 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 			sym = g_strdup("");
 
 		if (! first && have_best)
-			/* For translators: it's the filename and the line number of a symbol in the goto-symbol popup menu */
-			text = g_markup_printf_escaped(_("<b>%s:%lu</b>"), fname, tmtag->line);
+			text = g_markup_printf_escaped("<b>%s:%lu</b>", fname, tmtag->line);
 		else
-			/* For translators: it's the filename and the line number of a symbol in the goto-symbol popup menu */
-			text = g_markup_printf_escaped(_("%s:%lu"), fname, tmtag->line);
+			text = g_markup_printf_escaped("%s:%lu", fname, tmtag->line);
 
-		/* For translators: it's the filename, line number, and signature of a symbol in the goto-symbol popup menu */
-		tooltip = g_markup_printf_escaped(_("%s:%lu\n<small><tt>%s</tt></small>"), fname, tmtag->line, sym);
+		tooltip = g_markup_printf_escaped("%s:%lu\n<small><tt>%s</tt></small>", fname, tmtag->line, sym);
 
 		image = gtk_image_new_from_pixbuf(symbols_icons[get_tag_class(tmtag)].pixbuf);
 		box = g_object_new(GTK_TYPE_BOX, "orientation", GTK_ORIENTATION_HORIZONTAL, "spacing", 12, NULL);

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -1517,21 +1517,33 @@ gboolean tm_parser_enable_kind(TMParserType lang, gchar kind)
 }
 
 
-gchar *tm_parser_format_variable(TMParserType lang, const gchar *name, const gchar *type)
+gchar *tm_parser_format_variable(TMParserType lang, const gchar *name, const gchar *type,
+	const gchar *scope)
 {
+	gchar *ret, *name_full;
+
 	if (!type)
 		return NULL;
+
+	if (scope)
+		name_full = g_strconcat(scope, tm_parser_scope_separator_printable(lang),
+			name, NULL);
+	else
+		name_full = g_strdup(name);
 
 	switch (lang)
 	{
 		case TM_PARSER_GO:
-			return g_strconcat(name, " ", type, NULL);
+			ret = g_strconcat(name_full, " ", type, NULL);
 		case TM_PARSER_PASCAL:
 		case TM_PARSER_PYTHON:
-			return g_strconcat(name, ": ", type, NULL);
+			ret = g_strconcat(name_full, ": ", type, NULL);
 		default:
-			return g_strconcat(type, " ", name, NULL);
+			ret = g_strconcat(type, " ", name_full, NULL);
 	}
+
+	g_free(name_full);
+	return ret;
 }
 
 

--- a/src/tagmanager/tm_parser.h
+++ b/src/tagmanager/tm_parser.h
@@ -161,7 +161,8 @@ gboolean tm_parser_enable_role(TMParserType lang, gchar kind);
 
 gboolean tm_parser_enable_kind(TMParserType lang, gchar kind);
 
-gchar *tm_parser_format_variable(TMParserType lang, const gchar *name, const gchar *type);
+gchar *tm_parser_format_variable(TMParserType lang, const gchar *name, const gchar *type,
+	const gchar *scope);
 
 gchar *tm_parser_format_function(TMParserType lang, const gchar *fname, const gchar *args,
 	const gchar *retval, const gchar *scope);


### PR DESCRIPTION
OK, so here's my take on #3542. I realized that I actually liked most of the stuff, it was just a matter of different presentation and some implementation details.

I think from the discussion in #3542 it was clear that most people wanted to see the path and line number and to to be able to distinguish it from the signature easily - the core thing was to use a different font for the file name (italics) and for the signature (small monospaced font). For the tooltip, I just separated these two by a newline.

In more details, this is what I did:

1. Show signature for all tag types using get_symbol_name() when get_symbol_tooltip() returns NULL. Modify get_symbol_name() to drop line number when needed. (More or less taken over the complete implementation from Colomban)

2. Add scope information to the signature both when using get_symbol_name() and get_symbol_tooltip(). (Based on Nick's idea)

3. Truncate the length of the popup to at most 80 characters (More or less taken over the complete implementation from Nick)

4. Improve formatting of entries in the popup so individual pieces of information are easier to distinguish:
- file name and line number are always in italics
- the following signature is in small monospaced font

5. Add tooltip to every entry (based on Nick's implementation).
- split the tooltip into two lines - the first line shows the file and the line number, the second line the signature
- both of the lines are formatted in the same way as described in (4)

(Thanks to Nick Treleaven and Colomban Wendling for the original implementation.)

@b4n @ntrel @elextr @kugel- What do you think? (Pinging about everyone, this will be one of those features where we'll all have a different opinion and hate each other with passion ;-)

The result looks something like this:

<img width="995" alt="Screenshot 2023-08-23 at 22 40 37" src="https://github.com/geany/geany/assets/713965/7ddc4946-06fa-4424-8969-e7ef8801c300">
