### PR TITLE
Fix keyword colorization on filetype change

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -2824,6 +2824,9 @@ static void document_load_config(GeanyDocument *doc, GeanyFiletype *type,
 		editor_set_indentation_guides(doc->editor);
 		build_menu_update(doc);
 		queue_colourise(doc);
+		/* forces re-setting SCI_SETKEYWORDS which seems to be needed with
+		 * Scintilla 5 to colorize them properly */
+		doc->priv->keyword_hash = 0;
 		if (type->priv->symbol_list_sort_mode == SYMBOLS_SORT_USE_PREVIOUS)
 			doc->priv->symbol_list_sort_mode = interface_prefs.symbols_sort_mode;
 		else


### PR DESCRIPTION
When filetype is changed to a compatible filetype (such as C->C++ and then possibly back to C), colorization is lost. It seems that with Scintilla 5, when language-specific highlighting changes, SCI_SETKEYWORDS has to be called again to take effect.

By setting keyword_hash to 0 we force Geany to call sci_set_keywords() in document_highlight_tags() which fixes the problem.

Fixes #3550 