### PR TITLE
Hide autocompletion and calltip popups when code scrolled

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -500,6 +500,12 @@ static void on_update_ui(GeanyEditor *editor, G_GNUC_UNUSED SCNotification *nt)
 	ScintillaObject *sci = editor->sci;
 	gint pos = sci_get_current_position(sci);
 
+	if (nt->updated & (SC_UPDATE_H_SCROLL | SC_UPDATE_V_SCROLL))
+	{
+		SSM(sci, SCI_CALLTIPCANCEL, 0, 0);
+		SSM(sci, SCI_AUTOCCANCEL, 0, 0);
+	}
+
 	/* since Scintilla 2.24, SCN_UPDATEUI is also sent on scrolling though we don't need to handle
 	 * this and so ignore every SCN_UPDATEUI events except for content and selection changes */
 	if (! (nt->updated & SC_UPDATE_CONTENT) && ! (nt->updated & SC_UPDATE_SELECTION))


### PR DESCRIPTION
When autocompletion or calltip popup is displayed and the user scrolls the editor window (e.g. using a mouse wheel), these popups are still displayed and become detached from the original point which is quite ugly.

We can just simply dismiss them when the window scrolls.