### PR TITLE
ctags: Matlab: ignore defs within block comments and allow spaces before function defs

### DIFF
--- a/ctags/parsers/geany_matlab.c
+++ b/ctags/parsers/geany_matlab.c
@@ -62,7 +62,8 @@ static void findMatlabTags (void)
 		for (i = 0  ;  line [i] != '\0'  &&  ! isspace (line [i])  ;  ++i)
 			;
 
-		if (strncmp ((const char *) line, "function", (size_t) 8) == 0)
+		if (strncmp ((const char *) line, "function", (size_t) 8) == 0
+			&& isspace (line [8]))
 		{
 			const unsigned char *cp = line + i;
 			const unsigned char *ptr = cp;
@@ -71,9 +72,12 @@ static void findMatlabTags (void)
 			while (isspace ((int) *cp))
 				++cp;
 
-			/* search for '=' character in the line */
+			/* search for '=' character in the line (ignoring comments) */
 			while (*ptr != '\0')
 			{
+				if (*ptr == '%')
+					break;
+
 				if (*ptr == '=')
 				{
 					eq=true;
@@ -82,25 +86,24 @@ static void findMatlabTags (void)
 				ptr++;
 			}
 
-			/* '=' was found => get the right most part of the line after '=' and before '%' */
+			/* '=' was found => get the first word of the line after '=' */
 			if (eq)
 			{
 				ptr++;
 				while (isspace ((int) *ptr))
 					++ptr;
 
-				while (*ptr != '\0' && *ptr != '%')
+				while (isalnum ((int) *ptr) || *ptr == '_')
 				{
 					vStringPut (name, (int) *ptr);
 					++ptr;
 				}
 			}
 
-			/* '=' was not found => get the right most part of the line after
-			 * 'function' and before '%' */
+			/* '=' was not found => get the first word of the line after "function" */
 			else
 			{
-				while (*cp != '\0' && *cp != '%')
+				while (isalnum ((int) *cp) || *cp == '_')
 				{
 					vStringPut (name, (int) *cp);
 					++cp;

--- a/ctags/parsers/geany_matlab.c
+++ b/ctags/parsers/geany_matlab.c
@@ -50,29 +50,30 @@ static void findMatlabTags (void)
 	{
 		int i, ic;
 
-		/* check for opening/closing block comments (`%{`...`%}`); may be nested */
-		for (i = 0; isspace ((int) line [i]); ++i)
-			;
+		/* trim leading whitespace */
+		while (isspace ((int) *line))
+			++line;
 
-		if (strncmp ((const char *) (line + i), "%{", 2) == 0)
+		/* check for opening/closing block comments (`%{`...`%}`); may be nested */
+		if (strncmp ((const char *) line, "%{", 2) == 0)
 		{
 			/* check if %{ appears on the line on its own (maybe with whitespace) */
-			for (ic = i + 2; isspace ((int) line [ic]); ++ic)
+			for (i = 2; isspace ((int) line [i]); ++i)
 				;
 
-			if (line [ic] == '\0')
+			if (line [i] == '\0')
 			{
 				++blkComm; /* block nesting has incremented by 1 level */
 				continue; /* skip to next line */
 			}
 		}
-		else if (blkComm > 0 && strncmp ((const char *) (line + i), "%}", 2) == 0)
+		else if (blkComm > 0 && strncmp ((const char *) line, "%}", 2) == 0)
 		{
 			/* check if %} appears on the line on its own (maybe with whitespace) */
-			for (ic = i+2; isspace ((int) line [ic]); ++ic)
+			for (i = 2; isspace ((int) line [i]); ++i)
 				;
 
-			if (line [ic] == '\0')
+			if (line [i] == '\0')
 			{
 				--blkComm; /* we've closed a nested block; when 0 we've left all nested comments */
 				continue; /* skip to next line */

--- a/tests/ctags/matlab_backtracking.m.tags
+++ b/tests/ctags/matlab_backtracking.m.tags
@@ -1,2 +1,2 @@
-backtrack(xc,d,fc,fnc,DDfnc,c,gamma,eps)Ì16Ö0
-function:   backtrack(xc,d,fc,fnc,DDfnc,c,gamma,eps)
+backtrackÌ16Ö0
+function:   backtrack

--- a/tests/ctags/matlab_test.m
+++ b/tests/ctags/matlab_test.m
@@ -1,4 +1,7 @@
 function [x,y,z] = func1 
 function x = func2 
 function func3 
+function y = func4(a, b, c)
+function func5   % this comment should be ignored --> X = FAIL5
+functionality = FAIL6; % this is not a function and should not be parsed
 

--- a/tests/ctags/matlab_test.m
+++ b/tests/ctags/matlab_test.m
@@ -1,3 +1,14 @@
+  %{  
+Block comments should be ignored
+function FAIL1
+    %{  
+        Block comments can be nested
+    %}  
+function FAIL2
+  %}  
+function [x] = func0
+% The line below is just a regular comment; it's not closing any block
+%}
 function [x,y,z] = func1 
 function x = func2 
 function func3 

--- a/tests/ctags/matlab_test.m.tags
+++ b/tests/ctags/matlab_test.m.tags
@@ -1,6 +1,6 @@
-func1 Ì16Ö0
-function:   func1 
-func2 Ì16Ö0
-function:   func2 
-func3 Ì16Ö0
-function:   func3 
+func1Ì16Ö0
+function:   func1
+func2Ì16Ö0
+function:   func2
+func3Ì16Ö0
+function:   func3

--- a/tests/ctags/matlab_test.m.tags
+++ b/tests/ctags/matlab_test.m.tags
@@ -1,3 +1,5 @@
+func0Ì16Ö0
+function:   func0
 func1Ì16Ö0
 function:   func1
 func2Ì16Ö0

--- a/tests/ctags/matlab_test.m.tags
+++ b/tests/ctags/matlab_test.m.tags
@@ -4,3 +4,7 @@ func2Ì16Ö0
 function:   func2
 func3Ì16Ö0
 function:   func3
+func4Ì16Ö0
+function:   func4
+func5Ì16Ö0
+function:   func5


### PR DESCRIPTION
Make the ctags parser ignore function definitions in Matlab files written within block comments, like:
```matlab
%{
function y = This(is, not, a, function, definition)
%}

function y = But(this, is)

%{ not a block comment ("%{" needs to be on a line on its own)
    function y = And(also, this)
%}
```
Block comments are useful for commenting out entire sections of code which may include function definitions, specially since they can be nested (which is also handled appropriately by this PR).

Additionally, this PR allows function declarations to be indented.  This is quite common when defining class methods within a class.

This PR is a continuation of PR #3358, which I understand was ready to merge but has been sitting there for a while.  So by merging this PR you also get that one.  Two for the price of one!
(I didn't make this a separate PR because it touches some of the same lines #3358 touches, so making it a separate PR would have led to merge conflicts in the future.  Each individual feature is implemented as a separate commit though.)