### PR TITLE
[RFC] API for LSP plugins

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -780,6 +780,7 @@ install_headers(
 	'src/toolbar.h',
 	'src/ui_utils.h',
 	'src/utils.h',
+	'src/lsp.h',
 	subdir: 'geany'
 )
 
@@ -819,6 +820,8 @@ libgeany = shared_library('geany',
 	'src/keyfile.h',
 	'src/log.c',
 	'src/log.h',
+	'src/lsp.c',
+	'src/lsp.h',
 	'src/libmain.c',
 	'src/main.h',
 	'src/geany.h',

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,6 +47,7 @@ geany_include_HEADERS = \
 	gtkcompat.h \
 	highlighting.h \
 	keybindings.h \
+	lsp.h \
 	main.h \
 	msgwindow.h \
 	navqueue.h \
@@ -86,6 +87,7 @@ libgeany_la_SOURCES = \
 	keyfile.c keyfile.h \
 	log.c log.h \
 	libmain.c main.h geany.h \
+	lsp.c lsp.h \
 	msgwindow.c msgwindow.h \
 	navqueue.c navqueue.h \
 	notebook.c notebook.h \

--- a/src/document.c
+++ b/src/document.c
@@ -2718,9 +2718,6 @@ void document_update_tags(GeanyDocument *doc)
 	buffer_ptr = (guchar *) SSM(doc->editor->sci, SCI_GETCHARACTERPOINTER, 0, 0);
 	tm_workspace_update_source_file_buffer(doc->tm_file, buffer_ptr, len);
 
-	if (G_UNLIKELY(main_status.opening_session_files || main_status.closing_all))
-		return;
-
 	sidebar_update_tag_list(doc, TRUE);
 	document_highlight_tags(doc);
 }

--- a/src/document.c
+++ b/src/document.c
@@ -2718,6 +2718,9 @@ void document_update_tags(GeanyDocument *doc)
 	buffer_ptr = (guchar *) SSM(doc->editor->sci, SCI_GETCHARACTERPOINTER, 0, 0);
 	tm_workspace_update_source_file_buffer(doc->tm_file, buffer_ptr, len);
 
+	if (G_UNLIKELY(main_status.opening_session_files || main_status.closing_all))
+		return;
+
 	sidebar_update_tag_list(doc, TRUE);
 	document_highlight_tags(doc);
 }

--- a/src/editor.c
+++ b/src/editor.c
@@ -320,7 +320,7 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 			editor_find_current_word(editor, editor_info.click_pos,
 				current_word, sizeof current_word, NULL);
 			if (*current_word)
-				return symbols_goto_tag(current_word, TRUE);
+				return symbols_goto_tag(current_word, editor_info.click_pos, TRUE);
 			else
 				keybindings_send_command(GEANY_KEY_GROUP_GOTO, GEANY_KEYS_GOTO_MATCHINGBRACE);
 			return TRUE;

--- a/src/editor.c
+++ b/src/editor.c
@@ -45,6 +45,7 @@
 #include "geanyobject.h"
 #include "highlighting.h"
 #include "keybindings.h"
+#include "lsp.h"
 #include "main.h"
 #include "prefs.h"
 #include "projectprivate.h"
@@ -671,8 +672,12 @@ static gboolean reshow_calltip(gpointer data)
 
 	g_return_val_if_fail(calltip.sci != NULL, FALSE);
 
-	SSM(calltip.sci, SCI_CALLTIPCANCEL, 0, 0);
 	doc = document_get_current();
+
+	if (lsp_calltips_available(doc))
+		return FALSE;
+
+	SSM(calltip.sci, SCI_CALLTIPCANCEL, 0, 0);
 
 	if (doc && doc->editor->sci == calltip.sci)
 	{
@@ -821,13 +826,15 @@ static void on_char_added(GeanyEditor *editor, SCNotification *nt)
 		case '(':
 		{
 			auto_close_chars(sci, pos, nt->ch);
-			/* show calltips */
-			editor_show_calltip(editor, --pos);
+			if (!lsp_calltips_available(editor->document))
+				/* show calltips */
+				editor_show_calltip(editor, --pos);
 			break;
 		}
 		case ')':
 		{	/* hide calltips */
-			if (SSM(sci, SCI_CALLTIPACTIVE, 0, 0))
+			if (SSM(sci, SCI_CALLTIPACTIVE, 0, 0) &&
+				!lsp_calltips_available(editor->document))
 			{
 				SSM(sci, SCI_CALLTIPCANCEL, 0, 0);
 			}
@@ -857,13 +864,15 @@ static void on_char_added(GeanyEditor *editor, SCNotification *nt)
 		case ':':	/* C/C++ class:: syntax */
 		/* tag autocompletion */
 		default:
-#if 0
-			if (! editor_start_auto_complete(editor, pos, FALSE))
-				request_reshowing_calltip(nt);
-#else
 			editor_start_auto_complete(editor, pos, FALSE);
-#endif
 	}
+
+	if (lsp_calltips_available(editor->document))
+		lsp_calltips_show(editor->document);
+
+	if (lsp_autocomplete_available(editor->document))
+		lsp_autocomplete_perform(editor->document);
+
 	check_line_breaking(editor, pos);
 }
 
@@ -1171,7 +1180,7 @@ static gboolean on_editor_notify(G_GNUC_UNUSED GObject *object, GeanyEditor *edi
 			break;
 
 		case SCN_CALLTIPCLICK:
-			if (nt->position > 0)
+			if (!lsp_calltips_available(doc) && nt->position > 0)
 			{
 				switch (nt->position)
 				{
@@ -2221,6 +2230,9 @@ gboolean editor_start_auto_complete(GeanyEditor *editor, gint pos, gboolean forc
 	GeanyFiletype *ft;
 
 	g_return_val_if_fail(editor != NULL, FALSE);
+
+	if (lsp_autocomplete_available(editor->document))
+		return FALSE;
 
 	if (! editor_prefs.auto_complete_symbols && ! force)
 		return FALSE;

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -39,6 +39,7 @@
 #include "filetypes.h"
 #include "geanyobject.h"
 #include "keybindingsprivate.h"
+#include "lsp.h"
 #include "main.h"
 #include "msgwindow.h"
 #include "navqueue.h"
@@ -2151,10 +2152,16 @@ static gboolean cb_func_editor_action(guint key_id)
 			sci_send_command(doc->editor->sci, SCI_LINETRANSPOSE);
 			break;
 		case GEANY_KEYS_EDITOR_AUTOCOMPLETE:
-			editor_start_auto_complete(doc->editor, sci_get_current_position(doc->editor->sci), TRUE);
+			if (lsp_autocomplete_available(doc))
+				lsp_autocomplete_perform(doc);
+			else
+				editor_start_auto_complete(doc->editor, sci_get_current_position(doc->editor->sci), TRUE);
 			break;
 		case GEANY_KEYS_EDITOR_CALLTIP:
-			editor_show_calltip(doc->editor, -1);
+			if (lsp_calltips_available(doc))
+				lsp_calltips_show(doc);
+			else
+				editor_show_calltip(doc->editor, -1);
 			break;
 		case GEANY_KEYS_EDITOR_CONTEXTACTION:
 			if (check_current_word(doc, FALSE))

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1975,7 +1975,7 @@ static void goto_tag(GeanyDocument *doc, gboolean definition)
 	gchar *text = get_current_word_or_sel(doc, FALSE);
 
 	if (text)
-		symbols_goto_tag(text, definition);
+		symbols_goto_tag(text, sci_get_current_position(doc->editor->sci), definition);
 	else
 		utils_beep();
 

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -1,0 +1,107 @@
+/*
+ *      lsp.c - this file is part of Geany, a fast and lightweight IDE
+ *
+ *      Copyright 2023 The Geany contributors
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along
+ *      with this program; if not, write to the Free Software Foundation, Inc.,
+ *      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "lsp.h"
+
+
+gboolean func_return_false(GeanyDocument *doc)
+{
+	return FALSE;
+}
+
+
+void func_args_doc(GeanyDocument *doc)
+{
+}
+
+
+void func_args_doc_bool(GeanyDocument *doc, gboolean dummy)
+{
+}
+
+
+static Lsp dummy_lsp = {
+	.autocomplete_available = func_return_false,
+	.autocomplete_perform = func_args_doc,
+
+	.calltips_available = func_return_false,
+	.calltips_show = func_args_doc,
+
+	.goto_available = func_return_false,
+	.goto_perform = func_args_doc_bool,
+};
+
+static Lsp *current_lsp = &dummy_lsp;
+
+
+GEANY_API_SYMBOL
+void lsp_register(Lsp *lsp)
+{
+	/* possibly, in the future if there's a need for multiple LSP plugins,
+	 * have a list of LSP clients and add/remove to/from the list */
+	current_lsp = lsp;
+}
+
+
+GEANY_API_SYMBOL
+void lsp_unregister(Lsp *lsp)
+{
+	current_lsp = &dummy_lsp;
+}
+
+
+/* allow LSP plugins not to implement all the functions (might happen if we
+ * add more in the future) and fall back to the dummy implementation */
+#define CALL_IF_EXISTS(f) (current_lsp->f ? current_lsp->f : dummy_lsp.f)
+
+gboolean lsp_autocomplete_available(GeanyDocument *doc)
+{
+	return CALL_IF_EXISTS(autocomplete_available)(doc);
+}
+
+
+void lsp_autocomplete_perform(GeanyDocument *doc)
+{
+	CALL_IF_EXISTS(autocomplete_perform)(doc);
+}
+
+
+gboolean lsp_calltips_available(GeanyDocument *doc)
+{
+	return CALL_IF_EXISTS(calltips_available)(doc);
+}
+
+
+void lsp_calltips_show(GeanyDocument *doc)
+{
+	CALL_IF_EXISTS(calltips_show)(doc);
+}
+
+
+gboolean lsp_goto_available(GeanyDocument *doc)
+{
+	return CALL_IF_EXISTS(goto_available)(doc);
+}
+
+
+void lsp_goto_perform(GeanyDocument *doc, gboolean definition)
+{
+	CALL_IF_EXISTS(goto_perform)(doc, definition);
+}

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -105,7 +105,7 @@ void func_args_doc(GeanyDocument *doc)
 }
 
 
-void func_args_doc_bool(GeanyDocument *doc, gboolean dummy)
+void func_args_doc_int_bool(GeanyDocument *doc, gint dummy1, gboolean dummy2)
 {
 }
 
@@ -123,7 +123,7 @@ static Lsp dummy_lsp = {
 	.calltips_show = func_args_doc,
 
 	.goto_available = func_return_false,
-	.goto_perform = func_args_doc_bool,
+	.goto_perform = func_args_doc_int_bool,
 
 	.doc_symbols_available = func_return_false,
 	.doc_symbols_request = func_args_doc_symcallback_ptr,
@@ -195,9 +195,9 @@ gboolean lsp_goto_available(GeanyDocument *doc)
 }
 
 
-void lsp_goto_perform(GeanyDocument *doc, gboolean definition)
+void lsp_goto_perform(GeanyDocument *doc, gint pos, gboolean definition)
 {
-	CALL_IF_EXISTS(goto_perform)(doc, definition);
+	CALL_IF_EXISTS(goto_perform)(doc, pos, definition);
 }
 
 

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -94,6 +94,12 @@ GPtrArray *func_return_ptrarr(GeanyDocument *doc)
 }
 
 
+const gchar *func_return_str(GeanyDocument *doc)
+{
+	return NULL;
+}
+
+
 void func_args_doc(GeanyDocument *doc)
 {
 }
@@ -121,7 +127,11 @@ static Lsp dummy_lsp = {
 
 	.doc_symbols_available = func_return_false,
 	.doc_symbols_request = func_args_doc_symcallback_ptr,
-	.doc_symbols_get_cached = func_return_ptrarr
+	.doc_symbols_get_cached = func_return_ptrarr,
+
+	.symbol_highlight_available = func_return_false,
+	.symbol_highlight_request = func_args_doc_symcallback_ptr,
+	.symbol_highlight_get_cached = func_return_str
 };
 
 static Lsp *current_lsp = &dummy_lsp;
@@ -206,4 +216,22 @@ void lsp_doc_symbols_request(GeanyDocument *doc, LspSymbolRequestCallback callba
 GPtrArray *lsp_doc_symbols_get_cached(GeanyDocument *doc)
 {
 	return CALL_IF_EXISTS(doc_symbols_get_cached)(doc);
+}
+
+
+gboolean lsp_symbol_highlight_available(GeanyDocument *doc)
+{
+	return CALL_IF_EXISTS(doc_symbols_available)(doc);
+}
+
+
+void lsp_symbol_highlight_request(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data)
+{
+	CALL_IF_EXISTS(symbol_highlight_request)(doc, callback, user_data);
+}
+
+
+const gchar *lsp_symbol_highlight_get_cached(GeanyDocument *doc)
+{
+	return CALL_IF_EXISTS(symbol_highlight_get_cached)(doc);
 }

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -21,9 +21,76 @@
 #include "lsp.h"
 
 
+typedef enum {
+	LspKindFile = 1,
+	LspKindModule,
+	LspKindNamespace,
+	LspKindPackage,
+	LspKindClass,
+	LspKindMethod,
+	LspKindProperty,
+	LspKindField,
+	LspKindConstructor,
+	LspKindEnum,
+	LspKindInterface,
+	LspKindFunction,
+	LspKindVariable,
+	LspKindConstant,
+	LspKindString,
+	LspKindNumber,
+	LspKindBoolean,
+	LspKindArray,
+	LspKindObject,
+	LspKindKey,
+	LspKindNull,
+	LspKindEnumMember,
+	LspKindStruct,
+	LspKindEvent,
+	LspKindOperator,
+	LspKindTypeParameter,
+	LSP_KIND_NUM = LspKindTypeParameter
+} LspSymbolKind;  /* note: enums different than in LspCompletionItemKind */
+
+
+static LspSymbolKind kind_icons[LSP_KIND_NUM] = {
+	TM_ICON_NAMESPACE,  /* LspKindFile */
+	TM_ICON_NAMESPACE,  /* LspKindModule */
+	TM_ICON_NAMESPACE,  /* LspKindNamespace */
+	TM_ICON_NAMESPACE,  /* LspKindPackage */
+	TM_ICON_CLASS,      /* LspKindClass */
+	TM_ICON_METHOD,     /* LspKindMethod */
+	TM_ICON_MEMBER,     /* LspKindProperty */
+	TM_ICON_MEMBER,     /* LspKindField */
+	TM_ICON_METHOD,     /* LspKindConstructor */
+	TM_ICON_STRUCT,     /* LspKindEnum */
+	TM_ICON_CLASS,      /* LspKindInterface */
+	TM_ICON_METHOD,     /* LspKindFunction */
+	TM_ICON_VAR,        /* LspKindVariable */
+	TM_ICON_MACRO,      /* LspKindConstant */
+	TM_ICON_OTHER,      /* LspKindString */
+	TM_ICON_OTHER,      /* LspKindNumber */
+	TM_ICON_OTHER,      /* LspKindBoolean */
+	TM_ICON_OTHER,      /* LspKindArray */
+	TM_ICON_OTHER,      /* LspKindObject */
+	TM_ICON_OTHER,      /* LspKindKey */
+	TM_ICON_OTHER,      /* LspKindNull */
+	TM_ICON_MEMBER,     /* LspKindEnumMember */
+	TM_ICON_STRUCT,     /* LspKindStruct */
+	TM_ICON_OTHER,      /* LspKindEvent */
+	TM_ICON_METHOD,     /* LspKindOperator */
+	TM_ICON_OTHER       /* LspKindTypeParameter */
+};
+
+
 gboolean func_return_false(GeanyDocument *doc)
 {
 	return FALSE;
+}
+
+
+GPtrArray *func_return_ptrarr(GeanyDocument *doc)
+{
+	return NULL;
 }
 
 
@@ -37,6 +104,11 @@ void func_args_doc_bool(GeanyDocument *doc, gboolean dummy)
 }
 
 
+void func_args_doc_symcallback_ptr(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data)
+{
+}
+
+
 static Lsp dummy_lsp = {
 	.autocomplete_available = func_return_false,
 	.autocomplete_perform = func_args_doc,
@@ -46,6 +118,10 @@ static Lsp dummy_lsp = {
 
 	.goto_available = func_return_false,
 	.goto_perform = func_args_doc_bool,
+
+	.doc_symbols_available = func_return_false,
+	.doc_symbols_request = func_args_doc_symcallback_ptr,
+	.doc_symbols_get_cached = func_return_ptrarr
 };
 
 static Lsp *current_lsp = &dummy_lsp;
@@ -64,6 +140,14 @@ GEANY_API_SYMBOL
 void lsp_unregister(Lsp *lsp)
 {
 	current_lsp = &dummy_lsp;
+}
+
+
+guint lsp_get_symbols_icon_id(guint kind)
+{
+	if (kind >= LspKindFile && kind <= LSP_KIND_NUM)
+		return kind_icons[kind - 1];
+	return TM_ICON_STRUCT;
 }
 
 
@@ -104,4 +188,22 @@ gboolean lsp_goto_available(GeanyDocument *doc)
 void lsp_goto_perform(GeanyDocument *doc, gboolean definition)
 {
 	CALL_IF_EXISTS(goto_perform)(doc, definition);
+}
+
+
+gboolean lsp_doc_symbols_available(GeanyDocument *doc)
+{
+	return CALL_IF_EXISTS(doc_symbols_available)(doc);
+}
+
+
+void lsp_doc_symbols_request(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data)
+{
+	CALL_IF_EXISTS(doc_symbols_request)(doc, callback, user_data);
+}
+
+
+GPtrArray *lsp_doc_symbols_get_cached(GeanyDocument *doc)
+{
+	return CALL_IF_EXISTS(doc_symbols_get_cached)(doc);
 }

--- a/src/lsp.h
+++ b/src/lsp.h
@@ -35,7 +35,7 @@ typedef struct {
 	void (*calltips_show)(GeanyDocument *doc);
 
 	gboolean (*goto_available)(GeanyDocument *doc);
-	void (*goto_perform)(GeanyDocument *doc, gboolean definition);
+	void (*goto_perform)(GeanyDocument *doc, gint pos, gboolean definition);
 
 	gboolean (*doc_symbols_available)(GeanyDocument *doc);
 	void (*doc_symbols_request)(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data);
@@ -64,7 +64,7 @@ gboolean lsp_calltips_available(GeanyDocument *doc);
 void lsp_calltips_show(GeanyDocument *doc);
 
 gboolean lsp_goto_available(GeanyDocument *doc);
-void lsp_goto_perform(GeanyDocument *doc, gboolean definition);
+void lsp_goto_perform(GeanyDocument *doc, gint pos, gboolean definition);
 
 gboolean lsp_doc_symbols_available(GeanyDocument *doc);
 void lsp_doc_symbols_request(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data);

--- a/src/lsp.h
+++ b/src/lsp.h
@@ -41,6 +41,10 @@ typedef struct {
 	void (*doc_symbols_request)(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data);
 	GPtrArray *(*doc_symbols_get_cached)(GeanyDocument *doc);
 
+	gboolean (*symbol_highlight_available)(GeanyDocument *doc);
+	void (*symbol_highlight_request)(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data);
+	const gchar *(*symbol_highlight_get_cached)(GeanyDocument *doc);
+
 	gchar _dummy[1024];
 } Lsp;
 
@@ -65,6 +69,10 @@ void lsp_goto_perform(GeanyDocument *doc, gboolean definition);
 gboolean lsp_doc_symbols_available(GeanyDocument *doc);
 void lsp_doc_symbols_request(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data);
 GPtrArray *lsp_doc_symbols_get_cached(GeanyDocument *doc);
+
+gboolean lsp_symbol_highlight_available(GeanyDocument *doc);
+void lsp_symbol_highlight_request(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data);
+const gchar *lsp_symbol_highlight_get_cached(GeanyDocument *doc);
 
 #endif /* GEANY_PRIVATE */
 

--- a/src/lsp.h
+++ b/src/lsp.h
@@ -34,6 +34,8 @@ typedef struct {
 
 	gboolean (*goto_available)(GeanyDocument *doc);
 	void (*goto_perform)(GeanyDocument *doc, gboolean definition);
+
+	gchar _dummy[1024];
 } Lsp;
 
 

--- a/src/lsp.h
+++ b/src/lsp.h
@@ -1,0 +1,59 @@
+/*
+ *      lsp.h - this file is part of Geany, a fast and lightweight IDE
+ *
+ *      Copyright 2023 The Geany contributors
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along
+ *      with this program; if not, write to the Free Software Foundation, Inc.,
+ *      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef GEANY_LSP_H
+#define GEANY_LSP_H 1
+
+#include "document.h"
+
+G_BEGIN_DECLS
+
+typedef struct {
+	gboolean (*autocomplete_available)(GeanyDocument *doc);
+	void (*autocomplete_perform)(GeanyDocument *doc);
+
+	gboolean (*calltips_available)(GeanyDocument *doc);
+	void (*calltips_show)(GeanyDocument *doc);
+
+	gboolean (*goto_available)(GeanyDocument *doc);
+	void (*goto_perform)(GeanyDocument *doc, gboolean definition);
+} Lsp;
+
+
+void lsp_register(Lsp *lsp);
+void lsp_unregister(Lsp *lsp);
+
+
+#ifdef GEANY_PRIVATE
+
+gboolean lsp_autocomplete_available(GeanyDocument *doc);
+void lsp_autocomplete_perform(GeanyDocument *doc);
+
+gboolean lsp_calltips_available(GeanyDocument *doc);
+void lsp_calltips_show(GeanyDocument *doc);
+
+gboolean lsp_goto_available(GeanyDocument *doc);
+void lsp_goto_perform(GeanyDocument *doc, gboolean definition);
+
+#endif /* GEANY_PRIVATE */
+
+G_END_DECLS
+
+#endif /* GEANY_LSP_H */

--- a/src/lsp.h
+++ b/src/lsp.h
@@ -25,6 +25,8 @@
 
 G_BEGIN_DECLS
 
+typedef void (*LspSymbolRequestCallback) (gpointer user_data);
+
 typedef struct {
 	gboolean (*autocomplete_available)(GeanyDocument *doc);
 	void (*autocomplete_perform)(GeanyDocument *doc);
@@ -34,6 +36,10 @@ typedef struct {
 
 	gboolean (*goto_available)(GeanyDocument *doc);
 	void (*goto_perform)(GeanyDocument *doc, gboolean definition);
+
+	gboolean (*doc_symbols_available)(GeanyDocument *doc);
+	void (*doc_symbols_request)(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data);
+	GPtrArray *(*doc_symbols_get_cached)(GeanyDocument *doc);
 
 	gchar _dummy[1024];
 } Lsp;
@@ -45,6 +51,8 @@ void lsp_unregister(Lsp *lsp);
 
 #ifdef GEANY_PRIVATE
 
+guint lsp_get_symbols_icon_id(guint kind);
+
 gboolean lsp_autocomplete_available(GeanyDocument *doc);
 void lsp_autocomplete_perform(GeanyDocument *doc);
 
@@ -53,6 +61,10 @@ void lsp_calltips_show(GeanyDocument *doc);
 
 gboolean lsp_goto_available(GeanyDocument *doc);
 void lsp_goto_perform(GeanyDocument *doc, gboolean definition);
+
+gboolean lsp_doc_symbols_available(GeanyDocument *doc);
+void lsp_doc_symbols_request(GeanyDocument *doc, LspSymbolRequestCallback callback, gpointer user_data);
+GPtrArray *lsp_doc_symbols_get_cached(GeanyDocument *doc);
 
 #endif /* GEANY_PRIVATE */
 

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -44,6 +44,7 @@
 #include "filetypesprivate.h"
 #include "geanyobject.h"
 #include "highlighting.h"
+#include "lsp.h"
 #include "main.h"
 #include "navqueue.h"
 #include "sciwrappers.h"
@@ -1688,6 +1689,14 @@ static gboolean goto_tag(const gchar *name, gboolean definition)
 
 gboolean symbols_goto_tag(const gchar *name, gboolean definition)
 {
+	GeanyDocument *doc = document_get_current();
+
+	if (lsp_goto_available(doc))
+	{
+		lsp_goto_perform(doc, definition);
+		return TRUE;
+	}
+
 	if (goto_tag(name, definition))
 		return TRUE;
 

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1709,13 +1709,13 @@ static gboolean goto_tag(const gchar *name, gboolean definition)
 }
 
 
-gboolean symbols_goto_tag(const gchar *name, gboolean definition)
+gboolean symbols_goto_tag(const gchar *name, gint pos, gboolean definition)
 {
 	GeanyDocument *doc = document_get_current();
 
 	if (lsp_goto_available(doc))
 	{
-		lsp_goto_perform(doc, definition);
+		lsp_goto_perform(doc, pos, definition);
 		return TRUE;
 	}
 

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -57,7 +57,7 @@ gint symbols_generate_global_tags(gint argc, gchar **argv, gboolean want_preproc
 
 void symbols_show_load_tags_dialog(void);
 
-gboolean symbols_goto_tag(const gchar *name, gboolean definition);
+gboolean symbols_goto_tag(const gchar *name, gint pos, gboolean definition);
 
 gint symbols_get_current_function(GeanyDocument *doc, const gchar **tagname);
 


### PR DESCRIPTION
This patch adds a simple API allowing LSP plugins to take control of certain Geany built-in features and disabling their implementation in Geany. Currently, autocompletion, calltips, and going to definition/declaration is supported.

Plugins should define the Lsp struct, fill the pointers to the functions implementing the features they override, and register themselves using the lsp_register() call. Similarly, they should unregister themselves using lsp_unregister() when they don't want to provide the Lsp features any more, or, latest, when the plugin gets unloaded.

Each of the currently supported features is implemented using two functions - one checking whether Lsp plugin will override Geany's behavior of this feature, and the other function implementing the feature. For instance for autocompletion:
- autocomplete_available(doc) should return TRUE if the plugin performs autocompletion for the doc's filetype. This function is used to deactivate Geany's autocompletion when the Lsp plugin supports it.
- autocomplete_perform(doc) calls the corresponding interface of the LSP server (which responds asynchronously so when autocomplete_perform() is executed, the results won't be available yet)

The Lsp struct is padded with an array large enough to allow additions of many more functions to the struct and allowing binary compatibility with older LSP plugin versions not implementing all the functions. It's just mandatory that all plugins zero-initialize the allocated Lsp struct (either by creating it on the heap or by allocating it using g_new0() or similar function). NULL pointers in this struct are handled gracefully.

The current implementation supports only a single LSP plugin. However, if in the future arises the need for more LSP plugins running in parallel (e.g. a specialized LSP plugin for certain language together with the current "generic" LSP plugin), the implementation could be extended to support a list of Lsp structs and trying to call the functions defined by them one by one. The current interface should already be sufficient to support such an implementation.