### PR TITLE
Disable autocompletion for most non-programming/non-scripting languages

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -2226,7 +2226,9 @@ gboolean editor_start_auto_complete(GeanyEditor *editor, gint pos, gboolean forc
 
 	g_return_val_if_fail(editor != NULL, FALSE);
 
-	if (! editor_prefs.auto_complete_symbols && ! force)
+	ft = editor->document->file_type;
+
+	if ((! editor_prefs.auto_complete_symbols || tm_parser_disable_autocomplete(ft->lang)) && ! force)
 		return FALSE;
 
 	/* If we are at the beginning of the document, we skip autocompletion as we can't determine the
@@ -2235,7 +2237,6 @@ gboolean editor_start_auto_complete(GeanyEditor *editor, gint pos, gboolean forc
 		return FALSE;
 
 	sci = editor->sci;
-	ft = editor->document->file_type;
 
 	lexer = sci_get_lexer(sci);
 	style = sci_get_style_at(sci, pos - 2);

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -1644,6 +1644,29 @@ const gchar *tm_parser_scope_separator_printable(TMParserType lang)
 }
 
 
+gboolean tm_parser_disable_autocomplete(TMParserType lang)
+{
+	switch (lang)
+	{
+		case TM_PARSER_ABC:
+		case TM_PARSER_ASCIIDOC:
+		case TM_PARSER_BIBTEX:
+		case TM_PARSER_CONF:
+		case TM_PARSER_DIFF:
+		case TM_PARSER_DOCBOOK:
+		case TM_PARSER_HTML:
+		case TM_PARSER_JSON:
+		case TM_PARSER_LATEX:
+		case TM_PARSER_MARKDOWN:
+		case TM_PARSER_REST:
+		case TM_PARSER_TXT2TAGS:
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+
 gboolean tm_parser_has_full_scope(TMParserType lang)
 {
 	switch (lang)

--- a/src/tagmanager/tm_parser.h
+++ b/src/tagmanager/tm_parser.h
@@ -170,6 +170,8 @@ const gchar *tm_parser_scope_separator(TMParserType lang);
 
 const gchar *tm_parser_scope_separator_printable(TMParserType lang);
 
+gboolean tm_parser_disable_autocomplete(TMParserType lang);
+
 gboolean tm_parser_has_full_scope(TMParserType lang);
 
 gboolean tm_parser_langs_compatible(TMParserType lang, TMParserType other);


### PR DESCRIPTION
For languages like Markdown tag manager is used to display an outline of the document in the sidebar but the generated tags aren't really meant for autocompletion where they don't make much sense. Without this patch typing a word from e.g. a heading of markdown invokes the autocompletion popup anywhere in the edited text which is quite annoying.

Apart from languages that use tags for the sidebar outline (ABC, asciidoc, bibtex, ini/conf, diff, docbook, latex, markdown, rest, txt2tags, HTML), there's also JSON where autocompletion doesn't really work because tags are generated for json strings such as keys but autocompletion doesn't work inside strings currently so when one types ", the following string doesn't get autocompleted.

This is how the current behavior looks like for LaTeX:

<img width="565" alt="Screenshot 2023-10-04 at 23 17 44" src="https://github.com/geany/geany/assets/713965/2c023c53-9f6c-4448-8125-9c5f4ed89baf">

and this is for Markdown:

<img width="601" alt="Screenshot 2023-10-04 at 23 13 55" src="https://github.com/geany/geany/assets/713965/c24056e5-fa59-444d-b280-3059178f1c4d">

I'm not sure if it's related to the changes made in this release or if it behaved this way before too but since it's quite annoying and the patch is hopefully a low-risk one, it could be worth considering for Geany 2.0.