### PR TITLE
Bump GTK version requirement to 3.24

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -204,10 +204,7 @@ Coding
   them down into smaller static functions where possible. This makes code
   much easier to read and maintain.
 * Use GLib types and functions - gint not int, g_free() not free().
-* Your code should build against GLib 2.32 and GTK 3.0. At least for the
-  moment, we want to keep the minimum requirement for GTK at 3.0 (of
-  course, you can use the GTK_CHECK_VERSION macro to protect code using
-  later versions).
+* Your code should build against GLib 2.32 and GTK 3.24.
 * Variables should be declared (and initialized) as close as practical
   to their first use. This reduces the chances of intervening code being
   inserted between declaration and use, where the variable may be

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -126,8 +126,6 @@ nobase_dist_pkgdata_DATA = \
 	snippets.conf \
 	ui_toolbar.xml \
 	geany.glade \
-	geany-3.0.css \
-	geany-3.20.css \
 	geany.css
 
 nobase_pkgdata_DATA = \

--- a/data/geany-3.0.css
+++ b/data/geany-3.0.css
@@ -1,8 +1,0 @@
-/* make close button on the editor's tabs smaller */
-#geany-close-tab-button {
-	-GtkWidget-focus-padding: 0;
-	-GtkWidget-focus-line-width: 0;
-	-GtkButton-default-border: 0;
-	-GtkButton-default-outside-border: 0;
-	-GtkButton-inner-border: 0;
-}

--- a/data/geany-3.20.css
+++ b/data/geany-3.20.css
@@ -1,9 +1,0 @@
-/* make close button on the editor's tabs smaller */
-#geany-close-tab-button {
-	outline-offset: 0;
-	outline-width: 0;
-	margin: 0;
-	margin-left: 0.5em;
-	min-width: 0;
-	min-height: 0;
-}

--- a/data/geany.css
+++ b/data/geany.css
@@ -4,14 +4,12 @@
 #geany-close-tab-button {
 	padding: 0;
 }
-#geany-close-tab-button GtkImage /* GTK < 3.20 */,
-#geany-close-tab-button image /* GTK >= 3.20 */ {
+#geany-close-tab-button image {
 	padding: 0;
 }
 
 /* use monospaced font in search entries for easier reading of regexp (#1907117) */
-#GeanyDialogSearch GtkEntry /* GTK < 3.20 */,
-#GeanyDialogSearch entry /* GTK >= 3.20 */ {
+#GeanyDialogSearch entry {
 	font-family: monospace;
 }
 
@@ -20,8 +18,7 @@
 	color: #fff;
 	background: #ff6666;
 }
-#geany-search-entry-no-match:selected /* GTK < 3.20 */,
-#geany-search-entry-no-match selection /* GTK >= 3.20 */ {
+#geany-search-entry-no-match selection {
 	color: #fff;
 	background-color: #771111;
 }

--- a/data/geany.css
+++ b/data/geany.css
@@ -2,6 +2,12 @@
 
 /* make close button on the editor's tabs smaller */
 #geany-close-tab-button {
+	outline-offset: 0;
+	outline-width: 0;
+	margin: 0;
+	margin-left: 0.5em;
+	min-width: 0;
+	min-height: 0;
 	padding: 0;
 }
 #geany-close-tab-button image {

--- a/data/meson.build
+++ b/data/meson.build
@@ -15,8 +15,6 @@ misc = [
     'snippets.conf',
     'ui_toolbar.xml',
     'geany.glade',
-    'geany-3.0.css',
-    'geany-3.20.css',
     'geany.css',
 ]
 install_data(sources: misc, install_dir: cdata.get('GEANY_DATA_DIR'))

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -103,7 +103,7 @@ Installation
 Requirements
 ------------
 
-You will need the GTK (>= 2.24) libraries and their dependencies
+You will need the GTK (>= 3.24) libraries and their dependencies
 (Pango, GLib and ATK). Your distro should provide packages for these,
 usually installed by default. For Windows, you can download an installer
 from the website which bundles these libraries.
@@ -120,7 +120,7 @@ Source compilation
 ------------------
 
 Compiling Geany is quite easy.
-To do so, you need the GTK (>= 2.24) libraries and header files.
+To do so, you need the GTK (>= 3.24) libraries and header files.
 You also need the Pango, GLib and ATK libraries and header files.
 All these files are available at http://www.gtk.org, but very often
 your distro will provide development packages to save the trouble of

--- a/geany.nsi.in
+++ b/geany.nsi.in
@@ -154,7 +154,6 @@ Section "!Program Files" SEC01
 	File "${GEANY_RELEASE_DIR}\data\GPL-2"
 	File "${GEANY_RELEASE_DIR}\data\filetype_extensions.conf"
 	File "${GEANY_RELEASE_DIR}\data\geany.glade"
-	File "${GEANY_RELEASE_DIR}\data\geany-3.20.css"
 	File "${GEANY_RELEASE_DIR}\data\geany.css"
 	File "${GEANY_RELEASE_DIR}\data\snippets.conf"
 	File "${GEANY_RELEASE_DIR}\data\ui_toolbar.xml"

--- a/m4/geany-gtk.m4
+++ b/m4/geany-gtk.m4
@@ -2,7 +2,7 @@ dnl GEANY_CHECK_GTK
 dnl Checks whether the GTK stack is available and new enough. Sets GTK_CFLAGS and GTK_LIBS.
 AC_DEFUN([GEANY_CHECK_GTK],
 [
-	gtk_modules="gtk+-3.0 >= 3.0 glib-2.0 >= 2.32"
+	gtk_modules="gtk+-3.0 >= 3.24 glib-2.0 >= 2.32"
 	gtk_modules_private="gio-2.0 >= 2.32 gmodule-no-export-2.0 gthread-2.0"
 
 	PKG_CHECK_MODULES([GTK], [$gtk_modules $gtk_modules_private])

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ prefix = get_option('prefix')
 deps_in = [
 	['glib-2.0',    '2.32'],
 	['gmodule-2.0', '2.32'],
-	['gtk+-3.0',    '3.0']
+	['gtk+-3.0',    '3.24']
 ]
 
 deps = []

--- a/plugins/splitwindow.c
+++ b/plugins/splitwindow.c
@@ -256,32 +256,6 @@ static void on_doc_show_menu(GtkMenuToolButton *button, GtkMenu *menu)
 }
 
 
-/* Blocks the ::show-menu signal if the menu's parent toggle button was inactive in the previous run.
- * This is a hack to workaround https://bugzilla.gnome.org/show_bug.cgi?id=769287
- * and should NOT be used for any other version than 3.15.9 to 3.21.4, although the code tries and
- * not block a legitimate signal in case the GTK version in use has been patched */
-static void show_menu_gtk316_fix(GtkMenuToolButton *button, gpointer data)
-{
-	/* we assume only a single menu can popup at once, so reentrency isn't an issue.
-	 * if it was, we could use custom data on the button, but it shouldn't be required */
-	static gboolean block_next = FALSE;
-
-	if (block_next)
-	{
-		g_signal_stop_emission_by_name(button, "show-menu");
-		block_next = FALSE;
-	}
-	else
-	{
-		GtkWidget *menu = gtk_menu_tool_button_get_menu(button);
-		GtkWidget *parent = gtk_menu_get_attach_widget(GTK_MENU(menu));
-
-		if (parent && GTK_IS_TOGGLE_BUTTON(parent) && ! gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(parent)))
-			block_next = TRUE;
-	}
-}
-
-
 static GtkWidget *create_toolbar(void)
 {
 	GtkWidget *toolbar, *item;
@@ -300,9 +274,6 @@ static GtkWidget *create_toolbar(void)
 
 	item = gtk_menu_new();
 	gtk_menu_tool_button_set_menu(GTK_MENU_TOOL_BUTTON(tool_item), item);
-	/* hack for https://bugzilla.gnome.org/show_bug.cgi?id=769287 */
-	if (! gtk_check_version(3, 15, 9) && gtk_check_version(3, 21, 4+1))
-		g_signal_connect(tool_item, "show-menu", G_CALLBACK(show_menu_gtk316_fix), NULL);
 	g_signal_connect(tool_item, "show-menu", G_CALLBACK(on_doc_show_menu), item);
 
 	tool_item = gtk_tool_item_new();

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -815,20 +815,6 @@ gboolean dialogs_show_unsaved_file(GeanyDocument *doc)
 }
 
 
-/* Use GtkFontChooserDialog on GTK3.2 for consistency, and because
- * GtkFontSelectionDialog is somewhat broken on 3.4 */
-#if GTK_CHECK_VERSION(3, 2, 0)
-#	undef GTK_FONT_SELECTION_DIALOG
-#	define GTK_FONT_SELECTION_DIALOG				GTK_FONT_CHOOSER_DIALOG
-
-#	define gtk_font_selection_dialog_new(title) \
-		gtk_font_chooser_dialog_new((title), NULL)
-#	define gtk_font_selection_dialog_get_font_name(dlg) \
-		gtk_font_chooser_get_font(GTK_FONT_CHOOSER(dlg))
-#	define gtk_font_selection_dialog_set_font_name(dlg, font) \
-		gtk_font_chooser_set_font(GTK_FONT_CHOOSER(dlg), (font))
-#endif
-
 static void
 on_font_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 {
@@ -841,8 +827,8 @@ on_font_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		{
 			gchar *fontname;
 
-			fontname = gtk_font_selection_dialog_get_font_name(
-				GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel));
+			fontname = gtk_font_chooser_get_font(
+				GTK_FONT_CHOOSER(ui_widgets.open_fontsel));
 			ui_set_editor_font(fontname);
 			g_free(fontname);
 
@@ -863,7 +849,7 @@ void dialogs_show_open_font(void)
 	{
 		GtkWidget *apply_button;
 
-		ui_widgets.open_fontsel = gtk_font_selection_dialog_new(_("Choose font"));;
+		ui_widgets.open_fontsel = gtk_font_chooser_dialog_new(_("Choose font"), NULL);
 		gtk_container_set_border_width(GTK_CONTAINER(ui_widgets.open_fontsel), 4);
 		gtk_window_set_modal(GTK_WINDOW(ui_widgets.open_fontsel), TRUE);
 		gtk_window_set_destroy_with_parent(GTK_WINDOW(ui_widgets.open_fontsel), TRUE);
@@ -883,8 +869,8 @@ void dialogs_show_open_font(void)
 
 		gtk_window_set_transient_for(GTK_WINDOW(ui_widgets.open_fontsel), GTK_WINDOW(main_widgets.window));
 	}
-	gtk_font_selection_dialog_set_font_name(
-		GTK_FONT_SELECTION_DIALOG(ui_widgets.open_fontsel), interface_prefs.editor_font);
+	gtk_font_chooser_set_font(
+		GTK_FONT_CHOOSER(ui_widgets.open_fontsel), interface_prefs.editor_font);
 	/* We make sure the dialog is visible. */
 	gtk_window_present(GTK_WINDOW(ui_widgets.open_fontsel));
 }

--- a/src/editor.c
+++ b/src/editor.c
@@ -4960,14 +4960,6 @@ static ScintillaObject *create_new_sci(GeanyEditor *editor)
 	/* input method editor's candidate window behaviour */
 	SSM(sci, SCI_SETIMEINTERACTION, editor_prefs.ime_interaction, 0);
 
-#ifdef GDK_WINDOWING_QUARTZ
-# if ! GTK_CHECK_VERSION(3,16,0)
-	/* "retina" (HiDPI) display support on OS X - requires disabling buffered draw
-	 * on older GTK versions */
-	SSM(sci, SCI_SETBUFFEREDDRAW, 0, 0);
-# endif
-#endif
-
 	/* only connect signals if this is for the document notebook, not split window */
 	if (editor->sci == NULL)
 	{

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2585,8 +2585,10 @@ static void init_css_styles(void)
 	}
 	css_files[] =
 	{
-		{ 20, G_MAXUINT, "geany-3.20.css" },
-		{ 0, 19, "geany-3.0.css" },
+		/* Unused now but can be used to load css for different GTK versions, such as
+		 * { 20, G_MAXUINT, "geany-3.20.css" },
+		 * { 0, 19, "geany-3.0.css" },
+		 */
 	};
 
 	guint gtk_version = gtk_get_minor_version();

--- a/src/vte.c
+++ b/src/vte.c
@@ -718,7 +718,6 @@ static GtkWidget *vte_create_popup_menu(void)
 {
 	GtkWidget *menu, *item;
 	GtkAccelGroup *accel_group;
-	gboolean show_im_menu = TRUE;
 
 	menu = gtk_menu_new();
 
@@ -773,30 +772,7 @@ static GtkWidget *vte_create_popup_menu(void)
 
 	msgwin_menu_add_common_items(GTK_MENU(menu));
 
-	/* VTE 2.91 doesn't have IM context items, and GTK >= 3.10 doesn't show them anyway */
-	if (! vf->vte_terminal_im_append_menuitems || gtk_check_version(3, 10, 0) == NULL)
-		show_im_menu = FALSE;
-	else /* otherwise, query the setting */
-		g_object_get(gtk_settings_get_default(), "gtk-show-input-method-menu", &show_im_menu, NULL);
-
-	if (! show_im_menu)
-		vte_config.im_submenu = NULL;
-	else
-	{
-		item = gtk_separator_menu_item_new();
-		gtk_widget_show(item);
-		gtk_container_add(GTK_CONTAINER(menu), item);
-
-		/* the IM submenu should always be the last item to be consistent with other GTK popup menus */
-		vte_config.im_submenu = gtk_menu_new();
-
-		item = gtk_image_menu_item_new_with_mnemonic(_("_Input Methods"));
-		gtk_widget_show(item);
-		gtk_container_add(GTK_CONTAINER(menu), item);
-
-		gtk_menu_item_set_submenu(GTK_MENU_ITEM(item), vte_config.im_submenu);
-		/* submenu populated after vte realized */
-	}
+	vte_config.im_submenu = NULL;
 
 	return menu;
 }


### PR DESCRIPTION
This is needed for https://github.com/geany/geany/pull/3316. I tried to remove all related GTK_CHECK_VERSION() except the one that #3316 eliminates to avoid merge conflicts.