### PR TITLE
Update URLs to use https consistenly

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -98,10 +98,10 @@ See `Committing`_ for more information.
 
 Windows tools
 -------------
-* Git: http://git-scm.com/ and http://msysgit.github.io/
-* diff, grep, etc: http://mingw.org/ or http://unxutils.sourceforge.net/
+* Git: https://git-scm.com/ and https://gitforwindows.org/
+* diff, grep, etc: https://www.msys2.org/ or https://unxutils.sourceforge.net/
 
-See also the 'Building on Windows' document on the website.
+See also the Geany wiki on how to build Geany on Windows at https://wiki.geany.org/howtos/win32/msys2.
 
 File organization
 -----------------
@@ -497,7 +497,7 @@ Libraries
 ---------
 We try to use an unmodified version of Scintilla - any new lexers or
 other changes should be passed on to the maintainers at
-http://scintilla.org. We normally update to a new Scintilla release
+https://scintilla.org. We normally update to a new Scintilla release
 shortly after one is made. See also scintilla/README.
 
 We use an unmodified subset of universal-ctags sources
@@ -539,7 +539,7 @@ first (scintilla or ctags).
 If you want to reuse an existing lexer and/or tag parser, making a
 custom filetype is probably easier - it doesn't require any
 changes to the source code. Follow instructions in the manual:
-http://geany.org/manual/index.html#custom-filetypes. Don't forget to
+https://geany.org/manual/index.html#custom-filetypes. Don't forget to
 update the ``[Groups]`` section in ``filetype_extensions.conf``.
 
 .. warning::

--- a/README.I18N
+++ b/README.I18N
@@ -74,7 +74,7 @@ translation issues and will contact the maintainer of the translation you want
 to update to avoid any conflicts.
 
 Some translation statistics can be found at:
-http://i18n.geany.org/
+https://i18n.geany.org/
 
 
 I18n mailing list
@@ -84,7 +84,7 @@ There is also a mailing list dedicated to translation issues. Please visit
 https://www.geany.org/Support/MailingList#geany-i18 for more information.
 
 
-[1] http://i18n.geany.org/
-[2] http://www.poedit.net/
-[3] https://www.geany.org/Support/MailingList#geany-i18
+[1] https://i18n.geany.org/
+[2] https://www.poedit.net/
+[3] https://www.geany.org/support/mailing-lists/#geany-i18n
 [4] Frank Lanitz <frank(at)frank(dot)uvena(dot)de>

--- a/data/filedefs/filetypes.Clojure.conf
+++ b/data/filedefs/filetypes.Clojure.conf
@@ -30,7 +30,7 @@ comment_single=;
 comment_use_indent=true
 
 # context action command (please see Geany's main documentation for details)
-context_action_cmd=xdg-open "http://clojure.github.com/clojure/clojure.core-api.html#clojure.core/%s"
+context_action_cmd=xdg-open "https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/%s"
 
 [indentation]
 width=2

--- a/data/filedefs/filetypes.Groovy.conf
+++ b/data/filedefs/filetypes.Groovy.conf
@@ -2,9 +2,9 @@
 stringeol=string_1
 
 [keywords]
-# http://docs.groovy-lang.org/docs/next/html/documentation/#_keywords
+# https://docs.groovy-lang.org/docs/next/html/documentation/#_keywords
 primary=as assert break case catch class const continue def default do else enum extends false finally for goto if implements import in instanceof interface new null package return super switch this throw throws trait true try while
-# http://groovy-lang.org/objectorientation.html#_primitive_types
+# https://groovy-lang.org/objectorientation.html#_primitive_types
 secondary=boolean byte char double float int long short void
 # documentation keywords for javadoc
 doccomment=author deprecated exception param return see serial serialData serialField since throws todo version

--- a/data/filedefs/filetypes.julia
+++ b/data/filedefs/filetypes.julia
@@ -2,7 +2,7 @@
 #
 # For complete documentation of this file, please see Geany's main documentation
 #
-# Keywords from pygment lexer (http://pygments.org/)
+# Keywords from pygment lexer (https://pygments.org/)
 # and from vim parser (https://github.com/JuliaEditorSupport/julia-vim/)
 #
 

--- a/data/templates/files/main.md
+++ b/data/templates/files/main.md
@@ -43,9 +43,9 @@ Use either one of this methods:
 
 # Using hyperlinks
 
-This is [an example](http://example.com/ "Title") inline link.
+This is [an example](https://example.com/ "Title") inline link.
 
-[This link](http://example.net/) has no title attribute.
+[This link](https://example.net/) has no title attribute.
 
 # References
 

--- a/data/ui_toolbar.xml
+++ b/data/ui_toolbar.xml
@@ -2,7 +2,7 @@
 <!--
 This is Geany's toolbar UI definition.
 The DTD can be found at
-http://library.gnome.org/devel/gtk/stable/GtkUIManager.html#GtkUIManager.description.
+https://docs.gtk.org/gtk3/class.UIManager.html.
 
 You can re-order all items and freely add and remove available actions.
 You cannot add new actions which are not listed in the documentation.

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -122,7 +122,7 @@ Source compilation
 Compiling Geany is quite easy.
 To do so, you need the GTK (>= 2.24) libraries and header files.
 You also need the Pango, GLib and ATK libraries and header files.
-All these files are available at http://www.gtk.org, but very often
+All these files are available at https://www.gtk.org, but very often
 your distro will provide development packages to save the trouble of
 building these yourself.
 
@@ -691,7 +691,7 @@ Unicode Byte-Order-Mark (BOM)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Furthermore, Geany detects a Unicode Byte Order Mark (see
-http://en.wikipedia.org/wiki/Byte_Order_Mark for details). Of course,
+https://en.wikipedia.org/wiki/Byte_Order_Mark for details). Of course,
 this feature is only available if the opened file is in a Unicode
 encoding. The Byte Order Mark helps to detect the encoding of a file,
 e.g. whether it is UTF-16LE or UTF-16BE and so on. On Unix-like systems
@@ -959,12 +959,12 @@ For example a context action can be used to open API documentation
 in a browser window, the command to open the PHP API documentation
 would be::
 
-    firefox "http://www.php.net/%s"
+    firefox "https://www.php.net/%s"
 
 when executing the command, the %s is substituted by the word near
 the cursor position or by the current selection. If the cursor is at
 the word "echo", a browser window will open(assumed your browser is
-called firefox) and it will open the address: http://www.php.net/echo.
+called firefox) and it will open the address: https://www.php.net/echo.
 
 
 Autocompletion
@@ -1730,7 +1730,7 @@ CTags format
 This is the format that ctags generates, and that is used by Vim.
 This format is compatible with the format historically used by Vi.
 
-The format is described at http://ctags.sourceforge.net/FORMAT, but
+The format is described at https://ctags.sourceforge.net/FORMAT, but
 for the full list of existing extensions please refer to ctags.
 However, note that Geany may actually only honor a subset of the
 existing extensions.
@@ -2477,7 +2477,7 @@ Grep
 .. note::
     For Windows users: at the time of writing it is recommended to use
     the grep.exe from the UnxUtils project
-    (http://sourceforge.net/projects/unxutils). The grep.exe from the
+    (https://sourceforge.net/projects/unxutils). The grep.exe from the
     Mingw project for instance might not work with Geany at the moment.
 
 Commands
@@ -4346,7 +4346,7 @@ context_action_cmd
     position or by the current selection.
 
     Hint: for PHP files the following could be quite useful:
-    context_action_cmd=firefox "http://www.php.net/%s"
+    context_action_cmd=firefox "https://www.php.net/%s"
 
     *Example:* ``context_action_cmd=devhelp -s "%s"``
 
@@ -5380,7 +5380,7 @@ inside the *doc* subdirectory. To generate a PDF file, configure with
 PDF file is named geany-|(version)|.pdf and is located inside the *doc*
 subdirectory.
 
-__ http://docutils.sourceforge.net/rst.html
+__ https://docutils.sourceforge.net/rst.html
 
 After you are happy with your changes, create a patch e.g. by using::
 

--- a/doc/plugins.dox
+++ b/doc/plugins.dox
@@ -86,7 +86,7 @@ https://www.geany.org/Support/PluginWishlist to get an idea about what users wis
 
 For authors of plugins for Geany, we created a dedicated @a geany-plugins project
 on Sourceforge and GitHub to ease development of plugins and help new authors.
-All information about this project you can find at http://plugins.geany.org/
+All information about this project you can find at https://plugins.geany.org/
 
 To add a new plugin to this project, get in touch with the people on the
 geany-devel-mailing list and create a fork of the geany-plugins project
@@ -106,7 +106,7 @@ If you don't want your plugin to be part of the geany-plugins project it is also
 Just skip the part about forking geany-plugins and sending a pull request.
 In this case it is of course also a good idea to post some kind of announcement
 to geany-devel and maybe to the main geany mailing list -- it's up to you.
-You can also ask for your plugin to be listed on the http://plugins.geany.org/
+You can also ask for your plugin to be listed on the https://plugins.geany.org/
 website as a third party plugin, helping Geany user to know about your plugin.
 
 At time of writing, there are some plugins already available in the

--- a/doc/pluginsignals.c
+++ b/doc/pluginsignals.c
@@ -238,7 +238,7 @@ signal void (*update_editor_menu)(GObject *obj, const gchar *word, gint pos, Gea
  *
  * E.g. Character added, fold level changes, clicks to the line number margin.
  * A detailed description of possible notifications and the SCNotification can be found at
- * http://www.scintilla.org/ScintillaDoc.html#Notifications.
+ * https://www.scintilla.org/ScintillaDoc.html#Notifications.
  *
  * If you connect to this signal, you must check @c nt->nmhdr.code for the notification type
  * to prevent handling unwanted notifications. This is important because for instance SCN_UPDATEUI

--- a/geany.nsi.in
+++ b/geany.nsi.in
@@ -359,7 +359,7 @@ SectionEnd
 ; helper functions  ;
 ;;;;;;;;;;;;;;;;;;;;;
 
-; (from http://jabref.svn.sourceforge.net/viewvc/jabref/trunk/jabref/src/windows/nsis/setup.nsi)
+; (from https://github.com/JabRef/jabref/blob/c93c9f68746f387d00c34b6c416fcedf7967095a/src/windows/nsis/setup.nsi)
 !macro IsUserAdmin Result UName
 	ClearErrors
 	UserInfo::GetName
@@ -383,7 +383,7 @@ done:
 Function .onInit
 	StrCpy "$StartmenuFolder" "Geany"
 
-	; (from http://jabref.svn.sourceforge.net/viewvc/jabref/trunk/jabref/src/windows/nsis/setup.nsi)
+	; (from https://github.com/JabRef/jabref/blob/c93c9f68746f387d00c34b6c416fcedf7967095a/src/windows/nsis/setup.nsi)
 	; If the user does *not* have administrator privileges, abort
 	StrCpy $Answer ""
 	StrCpy $UserName ""

--- a/geany_private.rc
+++ b/geany_private.rc
@@ -15,7 +15,7 @@ FILETYPE			VFT_APP
 	BLOCK "StringFileInfo"
 	{
 		// U.S. English, Multilingual
-		// (see http://msdn.microsoft.com/en-us/library/aa381049%28VS.85%29.aspx)
+		// (see https://msdn.microsoft.com/en-us/library/aa381049%28VS.85%29.aspx)
 		BLOCK "040904E4"
 		{
 			VALUE "CompanyName", ""

--- a/plugins/demoplugin.c
+++ b/plugins/demoplugin.c
@@ -52,7 +52,7 @@ static gboolean on_editor_notify(GObject *object, GeanyEditor *editor,
 	GeanyData *geany_data = plugin->geany_data;
 
 	/* For detailed documentation about the SCNotification struct, please see
-	 * http://www.scintilla.org/ScintillaDoc.html#Notifications. */
+	 * https://www.scintilla.org/ScintillaDoc.html#Notifications. */
 	switch (nt->nmhdr.code)
 	{
 		case SCN_UPDATEUI:

--- a/scripts/create_py_tags.py
+++ b/scripts/create_py_tags.py
@@ -3,7 +3,7 @@
 # Author:  Enrico Tröger
 # License: GPL v2 or later
 #
-# (based on the script at http://svn.python.org/view/*checkout*/python/trunk/Tools/scripts/ptags.py)
+# (based on the script at https://github.com/python/cpython/blob/83eb827247dd28b13fd816936c74c162e9f52a2d/Tools/scripts/ptags.py)
 #
 # This script should be run in the top source directory.
 #

--- a/scripts/gen-api-gtkdoc.py
+++ b/scripts/gen-api-gtkdoc.py
@@ -100,7 +100,7 @@ class DoxygenProcess(object):
     def __init__(self):
         self.at = None
 
-    # http://stackoverflow.com/questions/4624062/get-all-text-inside-a-tag-in-lxml
+    # https://stackoverflow.com/questions/4624062/get-all-text-inside-a-tag-in-lxml
     @staticmethod
     def stringify_children(node):
         from lxml.etree import tostring

--- a/src/editor.c
+++ b/src/editor.c
@@ -1103,7 +1103,7 @@ static gboolean on_editor_notify(G_GNUC_UNUSED GObject *object, GeanyEditor *edi
 			/* Visible lines are only laid out accurately just before painting,
 			 * so we need to only call editor_scroll_to_line here, because the document
 			 * may have line wrapping and folding enabled.
-			 * http://scintilla.sourceforge.net/ScintillaDoc.html#LineWrapping
+			 * https://scintilla.sourceforge.io/ScintillaDoc.html#LineWrapping
 			 * This is important e.g. when loading a session and switching pages
 			 * and having the cursor scroll in view. */
 			 /* FIXME: Really we want to do this just before painting, not after it

--- a/src/geanywraplabel.c
+++ b/src/geanywraplabel.c
@@ -20,7 +20,7 @@
 
 /*
  * A GtkLabel subclass that can wrap to any width, unlike GtkLabel which has a fixed wrap point.
- * (inspired by libview's WrapLabel, http://view.sourceforge.net)
+ * (inspired by libview's WrapLabel, https://view.sourceforge.net/)
  */
 
 #ifdef HAVE_CONFIG_H

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1016,7 +1016,7 @@ static GtkWidget *create_dialog(void)
 	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(tree), FALSE);
 
 	text_renderer = gtk_cell_renderer_text_new();
-	/* we can't use "weight-set", see http://bugzilla.gnome.org/show_bug.cgi?id=355214 */
+	/* we can't use "weight-set", see https://bugzilla.gnome.org/show_bug.cgi?id=355214 */
 	column = gtk_tree_view_column_new_with_attributes(
 		NULL, text_renderer, "text", 0, "weight", 2, NULL);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -20,13 +20,13 @@
 
 /** @file sciwrappers.h
  * Wrapper functions for the Scintilla editor widget @c SCI_* messages.
- * You should also check the http://scintilla.org documentation, as it is more detailed.
+ * You should also check the https://scintilla.org documentation, as it is more detailed.
  *
  * To get Scintilla notifications, use the
  * @link pluginsignals.c @c "editor-notify" signal @endlink.
  *
  * @note These functions were originally from the cssed project
- * (http://cssed.sf.net, thanks).
+ * (https://sourceforge.net/projects/cssed/, thanks).
  * @see scintilla_send_message().
  */
 
@@ -1219,7 +1219,7 @@ void sci_set_readonly(ScintillaObject *sci, gboolean readonly)
 /** Sends Scintilla commands without any parameters.
  * @param sci The Scintilla @c GtkWidget.
  * @param cmd @c SCI_COMMAND.
- * @see http://scintilla.org for the documentation.
+ * @see https://scintilla.org for the documentation.
  *
  *  @since 0.16
  */

--- a/src/tagmanager/tm_source_file.c
+++ b/src/tagmanager/tm_source_file.c
@@ -86,7 +86,7 @@ static int get_path_max(const char *path)
 
 
 #if defined(G_OS_WIN32) && !defined(HAVE_REALPATH)
-/* realpath implementation for Windows found at http://bugzilla.gnome.org/show_bug.cgi?id=342926
+/* realpath implementation for Windows found at https://bugzilla.gnome.org/show_bug.cgi?id=342926
  * this one is better than e.g. liberty's lrealpath because this one uses Win32 API and works
  * with special chars within the filename */
 static char *realpath (const char *pathname, char *resolved_path)
@@ -304,7 +304,7 @@ static gboolean init_tag_from_file_alt(TMTag *tag, TMSourceFile *file, FILE *fp)
 }
 
 /*
- CTags tag file format (http://ctags.sourceforge.net/FORMAT)
+ CTags tag file format (https://ctags.sourceforge.net/FORMAT)
 */
 static gboolean init_tag_from_file_ctags(TMTag *tag, TMSourceFile *file, FILE *fp, TMParserType lang)
 {

--- a/src/toolbar.c
+++ b/src/toolbar.c
@@ -887,7 +887,7 @@ static void tb_editor_write_markup(TBEditorWidget *tbw)
 	/* <ui> must be the first tag, otherwise gtk_ui_manager_add_ui_from_string() will fail. */
 	const gchar *template = "<ui>\n<!--\n\
 This is Geany's toolbar UI definition.\nThe DTD can be found at \n\
-http://library.gnome.org/devel/gtk/stable/GtkUIManager.html#GtkUIManager.description.\n\n\
+https://docs.gtk.org/gtk3/class.UIManager.html.\n\n\
 You can re-order all items and freely add and remove available actions.\n\
 You cannot add new actions which are not listed in the documentation.\n\
 Everything you add or change must be inside the /ui/toolbar/ path.\n\n\

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -3056,7 +3056,7 @@ gboolean ui_is_keyval_enter_or_return(guint keyval)
 
 
 /** Reads an integer from the GTK default settings registry
- * (see http://library.gnome.org/devel/gtk/stable/GtkSettings.html).
+ * (see https://docs.gtk.org/gtk3/class.Settings.html).
  * @param property_name The property to read.
  * @param default_value The default value in case the value could not be read.
  * @return The value for the property if it exists, otherwise the @a default_value.


### PR DESCRIPTION
Most URLs just needed to prefixed with https.
Some other URLs were outdated or broken and
got updated to the recent location.