### PR TITLE
Do not enable Scintilla's Change History by default

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -275,7 +275,7 @@ static void init_pref_groups(void)
 		"radio_virtualspace_always", GEANY_VIRTUAL_SPACE_ALWAYS,
 		NULL);
 	stash_group_add_toggle_button(group, &editor_prefs.change_history_markers,
-		"change_history_markers", TRUE, "check_change_history_markers");
+		"change_history_markers", FALSE, "check_change_history_markers");
 	stash_group_add_toggle_button(group, &editor_prefs.change_history_indicators,
 		"change_history_indicators", FALSE, "check_change_history_indicators");
 	stash_group_add_toggle_button(group, &editor_prefs.autocomplete_doc_words,


### PR DESCRIPTION
* It looks either a bit confusing or to have some bugs (without having investigated deeply, it did things I didn't understand);
* It marks all lines when reloading a file (instead of resetting to a blank slate);
* If marker margin is not visible, it can render the editor unreadable with the default settings;
* I don't see any obvious use case given its current behavior that warrants a so visible feature by default;
* I don't think the feature is obvious at first glance, which could easily lead users to wonder what that line is about.  It also looks similar to other editor's VCS commit status indicator (including git-changebar Geany plugin) display, yet behaves very differently, possibly increasing confusion.

So for now, I think it's better to have it disabled by default.

See also discussion starting at https://github.com/geany/geany/pull/3551#issuecomment-1751809855
Opinions @kugel- @eht16 @techee @elextr @ntrel and everyone else?