### PR TITLE
Prefix generated scope field by the "scope:" prefix

### DIFF
--- a/scripts/create_tags_helper.py
+++ b/scripts/create_tags_helper.py
@@ -36,7 +36,11 @@ def format_tag(tagname, kind, signature, parent, return_type=None):
         signature_field = ''
 
     if parent:
-        parent_field = f'\tclass:{parent}'
+        # 'class' below should be a valid kind of the parent tag. But the Geany
+        # parsing code ignores the value when prefixed by 'scope' (corresponds
+        # to sZ ctags field) so this code is usable also for languages without
+        # the 'class' kind
+        parent_field = f'\tscope:class:{parent}'
     else:
         parent_field = ''
 


### PR DESCRIPTION
By default, ctags generates scope information using
```
parent_kind:A::B::C
```
where `A::B::C` is the scope of the parent tag. This is a bit problematic when parsing such fields because we have to compare the `parent_kind` value against all valid kinds of the language and if it matches, it means that what follows is the scope. This slows down parsing of such tags and also requires that `parent_kind` is really a valid kind for the given languages.

ctags can also add extra "scope:" prefix to this field when using the sZ field specification option on the command line:
```
scope:parent_kind:A::B::C
```
This way, the scope field can be detected easily by comparing against "scope:" which speeds up parsing. Also, the parsing code doesn't care about the value behind "scope:" so "class" can be used also for languages that don't have the "class" kind.

I haven't regenerated the tag files to avoid a big diff but the result will add "scope:" for every tag's scope field and this should be done separately.

By the way, this could help anyone reviewing #3049 understand what's going on. Parsing scope fields with the `scope:` prefix happens here:

https://github.com/techee/geany/blob/f49b19f3bfe61cf7ae27075f28ec5bd7c570a1ba/src/tagmanager/tm_source_file.c#L349

If scope is not obtained this way, the code tries to go through all the fields which weren't parsed before and check if they start with a kind name of that language. If they do, the field is considered to be scope, see:

https://github.com/techee/geany/blob/f49b19f3bfe61cf7ae27075f28ec5bd7c570a1ba/src/tagmanager/tm_source_file.c#L399