### PR TITLE
CI: Fix version parsing and calculating for 2.0

### DIFF
--- a/scripts/ci_mingw64_geany.sh
+++ b/scripts/ci_mingw64_geany.sh
@@ -145,17 +145,16 @@ patch_version_information() {
 		MAJOR="${BASH_REMATCH[1]}"
 		MINOR="${BASH_REMATCH[2]}"
 		PATCH="${BASH_REMATCH[4]}"
-		if [[ "${MINOR}" = "0" && (-z "${PATCH}" || "${PATCH}" = "0") ]]; then
-			MAJOR="$((MAJOR-1))"
-			MINOR="99"
+		if [ -z "${PATCH}" ] || [ "${PATCH}" = "0" ]; then
+			if [ "${MINOR}" = "0" ]; then
+				MAJOR="$((MAJOR-1))"
+				MINOR="99"
+			else
+				MINOR="$((MINOR-1))"
+			fi
 			PATCH="99"
 		else
-			if [[ -z "${PATCH}" || "${PATCH}" = "0" ]]; then
-				MINOR="$((MINOR-1))"
-				PATCH="99"
-			else
-				PATCH="$((PATCH-1))"
-			fi
+			PATCH="$((PATCH-1))"
 		fi
 	else
 		echo "Could not extract or parse version tag" >&2

--- a/scripts/ci_mingw64_geany.sh
+++ b/scripts/ci_mingw64_geany.sh
@@ -145,11 +145,17 @@ patch_version_information() {
 		MAJOR="${BASH_REMATCH[1]}"
 		MINOR="${BASH_REMATCH[2]}"
 		PATCH="${BASH_REMATCH[4]}"
-		if [ -z "${PATCH}" ] || [ "${PATCH}" = "0" ]; then
-			MINOR="$((MINOR-1))"
-			PATCH="90"
+		if [[ "${MINOR}" = "0" && (-z "${PATCH}" || "${PATCH}" = "0") ]]; then
+			MAJOR="$((MAJOR-1))"
+			MINOR="99"
+			PATCH="99"
 		else
-			PATCH="$((PATCH-1))"
+			if [[ -z "${PATCH}" || "${PATCH}" = "0" ]]; then
+				MINOR="$((MINOR-1))"
+				PATCH="99"
+			else
+				PATCH="$((PATCH-1))"
+			fi
 		fi
 	else
 		echo "Could not extract or parse version tag" >&2


### PR DESCRIPTION
The previous logic failed on 2.0 to make the new version number 1.99.99. This is fixed now even though the code is not perfect or good at all but should work well enough for its purposes.