### PR TITLE
Update meson.build also on version bumps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('geany', 'c', 'cpp',
         meson_version: '>= 0.53',
-        version: '1.38',
+        version: '2.0',
         default_options : ['c_std=c11', 'cpp_std=c++17'])
 
 gnome = import('gnome')

--- a/scripts/version-bump
+++ b/scripts/version-bump
@@ -23,6 +23,7 @@ s/^\(#define VER_FILEVERSION_STR  *\)[^ ].*$/\1"'"$VER"'"/
 ' -i geany_private.rc
 
 sed -e 's/^\(AC_INIT([^,]*, *\[\)[^]]*\(\],\)/\1'"$VER"'\2/' -i configure.ac
+sed -e 's/^\( *version: *\)[^,]*\(,\)/\1'"\'$VER\'"'\2/' -i meson.build
 sed -e 's/^\(#define GEANY_CODENAME[	]*"\)[^"]*\("\)/\1'"$CODENAME"'\2/' -i src/geany.h
 
 sed -e '


### PR DESCRIPTION
We missed to update `scripts/version-bump` for Meson and so `meson.build` still thought we are about to release Geany 1.38 :smile:.