### PR TITLE
Link to libiconv explicitly for Windows/mingw64 builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,7 @@ AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE], ["$PACKAGE"], [Gettext package.])
 AM_COND_IF([MINGW],
   [pkgdatadir='${prefix}/data'],
   [pkgdatadir='${datarootdir}/geany'])
+AM_COND_IF([MINGW],[LIBS="$LIBS -liconv"])
 AC_SUBST([GEANY_DATA_DIR], [$(eval echo $(eval echo $pkgdatadir))])
 AC_SUBST([pkgdatadir])
 


### PR DESCRIPTION
This was removed in e465a2b456e7c0aba6aefc1c4b406b8089386d1a erroneously but it still needed on Windows/mingw64 builds.