### PR TITLE
Enable EOL-filled Markdown headings

### DIFF
--- a/data/filedefs/filetypes.markdown
+++ b/data/filedefs/filetypes.markdown
@@ -30,3 +30,6 @@ mime_type=text/x-markdown
 symbol_list_sort_mode=1
 
 
+[lexer_properties]
+# apply heading style to entire line
+lexer.markdown.header.eolfill=1


### PR DESCRIPTION
#### Before

![markd-headings-current-git](https://github.com/geany/geany/assets/59004801/025b0f7c-598d-4214-bb8d-4e286818e732)

#### After
*with `lexer.markdown.header.eolfill=1`*

![markd-headings-git-eolfill](https://github.com/geany/geany/assets/59004801/94920a1c-9ff5-45a5-b7c2-a48f0ec467de)


Ref. https://github.com/geany/geany/issues/2026#issuecomment-1166210507