### PR TITLE
Fix blooper leading to incorrect variable formatting

### DIFF
--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -1535,11 +1535,14 @@ gchar *tm_parser_format_variable(TMParserType lang, const gchar *name, const gch
 	{
 		case TM_PARSER_GO:
 			ret = g_strconcat(name_full, " ", type, NULL);
+			break;
 		case TM_PARSER_PASCAL:
 		case TM_PARSER_PYTHON:
 			ret = g_strconcat(name_full, ": ", type, NULL);
+			break;
 		default:
 			ret = g_strconcat(type, " ", name_full, NULL);
+			break;
 	}
 
 	g_free(name_full);


### PR DESCRIPTION
188038a06a1050308fd7621f11147883d7e5b8fc extended the formatting options, but a blooper made it effectively ignore the language-specific rules, always using the default one.  This affects formatting for Go, Pascal and Python, as well as introducing memory leaks for those.

(I wouldn't have noticed yet without GCC's implicit fallthrough warnings)