### PR TITLE
macOS: use ".so" extension for plugins instead of ".dylib"

### DIFF
--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -12,12 +12,18 @@ plugins = [
 	'SplitWindow'
 ]
 
+plugin_suffix = []
+if (host_machine.system() == 'darwin')
+	plugin_suffix = 'so'  # use "so" instead of "dylib" so Geany finds plugins correctly
+endif
+
 foreach plugin : plugins
 	id = plugin.to_lower()
 	skip_install = id.startswith('demo')
 	shared_module(id,
 		id + '.c',
 		name_prefix: '', # "lib" seems to be the default prefix
+		name_suffix: plugin_suffix,
 		link_with: libgeany,
 		include_directories: plugin_inc,
 		c_args: [def_cflags, '-DG_LOG_DOMAIN="'+plugin+'"'],


### PR DESCRIPTION
Geany currently loads only plugins with the ".so" extension on macOS. This extension is still needed since we use autotools for geany-plugins which also generate ".so".

I tested it and it does nothing on linux while on macOS it changes the extension correctly to ".so".

Unless it's a big a problem, I'd like to have this merged for 2.0 so I can use meson for the build.

Fixes #3606.
