### PR TITLE
Fix startup files order when placing tabs next to the current one

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -1356,14 +1356,12 @@ static gboolean open_session_file(gchar **tmp, guint len)
  * for all files opened within this function */
 void configuration_open_files(GPtrArray *session_files)
 {
-	gint i;
 	gboolean failure = FALSE;
 
 	/* necessary to set it to TRUE for project session support */
 	main_status.opening_session_files++;
 
-	i = file_prefs.tab_order_ltr ? 0 : (session_files->len - 1);
-	while (TRUE)
+	for (guint i = 0; i < session_files->len; i++)
 	{
 		gchar **tmp = g_ptr_array_index(session_files, i);
 		guint len;
@@ -1374,19 +1372,6 @@ void configuration_open_files(GPtrArray *session_files)
 				failure = TRUE;
 		}
 		g_strfreev(tmp);
-
-		if (file_prefs.tab_order_ltr)
-		{
-			i++;
-			if (i >= (gint)session_files->len)
-				break;
-		}
-		else
-		{
-			i--;
-			if (i < 0)
-				break;
-		}
 	}
 
 	g_ptr_array_free(session_files, TRUE);

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -764,16 +764,21 @@ gint notebook_new_tab(GeanyDocument *this)
 
 	document_update_tab_label(this);
 
-	if (file_prefs.tab_order_beside)
+	if (main_status.opening_session_files)
+		cur_page = -1; /* last page */
+	else if (file_prefs.tab_order_beside)
+	{
 		cur_page = gtk_notebook_get_current_page(GTK_NOTEBOOK(main_widgets.notebook));
+		if (file_prefs.tab_order_ltr)
+			cur_page++;
+	}
+	else if (file_prefs.tab_order_ltr)
+		cur_page = -1; /* last page */
 	else
-		cur_page = file_prefs.tab_order_ltr ? -2 /* hack: -2 + 1 = -1, last page */ : 0;
-	if (file_prefs.tab_order_ltr)
-		tabnum = gtk_notebook_insert_page_menu(GTK_NOTEBOOK(main_widgets.notebook), vbox,
-			ebox, NULL, cur_page + 1);
-	else
-		tabnum = gtk_notebook_insert_page_menu(GTK_NOTEBOOK(main_widgets.notebook), vbox,
-			ebox, NULL, cur_page);
+		cur_page = 0;
+
+	tabnum = gtk_notebook_insert_page_menu(GTK_NOTEBOOK(main_widgets.notebook), vbox,
+		ebox, NULL, cur_page);
 
 	tab_count_changed();
 


### PR DESCRIPTION
When the `tab_order_beside` option is enabled, tabs are opened on either side of the active tab, depending on `tab_order_ltr`, rather than at either end.

However, when loading startup files we don't switch to the last opened document right away, but postpone this to the very end.  This affects the order tabs are loaded, as the active one is always the first one at this stage.

Rather than over-complicating the loading order to compensate the various options' effect, temporarily revert to an set of options that is easy to handle, and restore it after loading is finished.  This also simplifies the existing logic as a basic forward iteration is now enough.

Fixes #3609.