### PR TITLE
Change default tab_label_length from 99999 to 1000

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2394,7 +2394,7 @@ void ui_init_prefs(void)
 	stash_group_add_boolean(group, &interface_prefs.warn_on_project_close,
 		"warn_on_project_close", TRUE);
 	stash_group_add_spin_button_integer(group, &interface_prefs.tab_label_len,
-		"tab_label_length", 99999, "spin_tab_label_len");
+		"tab_label_length", 1000, "spin_tab_label_len");
 }
 
 


### PR DESCRIPTION
The whole value 99999 doesn't fit into the entry which looks ugly and, to me, somehow a rounded value like 1000 (which is still sufficient in terms of "unlimited" number of characters in a tab) looks more pleasing.

I'm adding this nit-picky change for consideration for 2.0 since it should be low-risk, and, also, because once the default value "99999" gets written to user's config files, it will stay there forever even if we change it in future releases.

Now:
<img width="812" alt="Screenshot 2023-10-18 at 10 59 21" src="https://github.com/geany/geany/assets/713965/fb12a455-10e0-4e74-bb82-f283ac3856c3">

After:
<img width="812" alt="Screenshot 2023-10-18 at 10 59 02" src="https://github.com/geany/geany/assets/713965/653b9751-6bdb-4eb0-9bfb-d00c0b265a35">
