### PR TITLE
Icon names, and symbolic.  Makes Adwaita 43 happy.

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8368,8 +8368,8 @@
                             <property name="can-focus">True</property>
                             <property name="tooltip-text" translatable="yes">Filter the symbol list using the entered text. Separate multiple filters with a space.</property>
                             <property name="invisible-char">•</property>
-                            <property name="primary-icon-stock">gtk-find</property>
-                            <property name="secondary-icon-stock">gtk-clear</property>
+                            <property name="primary-icon-name">edit-find-symbolic</property>
+                            <property name="secondary-icon-name">edit-clear-symbolic</property>
                             <property name="primary-icon-activatable">False</property>
                             <signal name="activate" handler="on_entry_tagfilter_activate" swapped="no"/>
                             <signal name="changed" handler="on_entry_tagfilter_changed" swapped="no"/>

--- a/src/build.c
+++ b/src/build.c
@@ -1898,7 +1898,7 @@ static RowWidgets *build_add_dialog_row(GeanyDocument *doc, GtkTable *table, gui
 			GTK_FILL | GTK_EXPAND, entry_x_padding, entry_y_padding);
 	}
 	column++;
-	clearicon = gtk_image_new_from_stock(GTK_STOCK_CLEAR, GTK_ICON_SIZE_MENU);
+	clearicon = gtk_image_new_from_icon_name("edit-clear-symbolic", GTK_ICON_SIZE_MENU);
 	clear = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(clear), clearicon);
 	g_signal_connect(clear, "clicked", G_CALLBACK(on_clear_dialog_row), roww);
@@ -1995,7 +1995,7 @@ GtkWidget *build_commands_table(GeanyDocument *doc, GeanyBuildSource dst, BuildT
 	}
 	gtk_table_attach(table, fields->fileregex, DC_ENTRIES + 1, DC_CLEAR, row, row + 1, GTK_FILL,
 		GTK_FILL | GTK_EXPAND, entry_x_padding, entry_y_padding);
-	clearicon = gtk_image_new_from_stock(GTK_STOCK_CLEAR, GTK_ICON_SIZE_MENU);
+	clearicon = gtk_image_new_from_icon_name("edit-clear-symbolic", GTK_ICON_SIZE_MENU);
 	clear = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(clear), clearicon);
 	g_signal_connect_swapped(clear, "clicked",
@@ -2029,7 +2029,7 @@ GtkWidget *build_commands_table(GeanyDocument *doc, GeanyBuildSource dst, BuildT
 	}
 	gtk_table_attach(table, fields->nonfileregex, DC_ENTRIES + 1, DC_CLEAR, row, row + 1, GTK_FILL,
 		GTK_FILL | GTK_EXPAND, entry_x_padding, entry_y_padding);
-	clearicon = gtk_image_new_from_stock(GTK_STOCK_CLEAR, GTK_ICON_SIZE_MENU);
+	clearicon = gtk_image_new_from_icon_name("edit-clear-symbolic", GTK_ICON_SIZE_MENU);
 	clear = gtk_button_new();
 	gtk_button_set_image(GTK_BUTTON(clear), clearicon);
 	g_signal_connect_swapped(clear, "clicked",

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -763,7 +763,7 @@ static gint run_unsaved_dialog(const gchar *msg, const gchar *msg2)
 	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", msg2);
 	gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
 
-	button = ui_button_new_with_image(GTK_STOCK_CLEAR, _("_Don't save"));
+	button = ui_button_new_with_icon_name("edit-clear-symbolic", _("_Don't save"));
 	gtk_dialog_add_action_widget(GTK_DIALOG(dialog), button, GTK_RESPONSE_NO);
 	gtk_widget_show(button);
 

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -649,7 +649,7 @@ static GtkWidget *create_message_popup_menu(gint type)
 
 	message_popup_menu = gtk_menu_new();
 
-	clear = gtk_image_menu_item_new_from_stock(GTK_STOCK_CLEAR, NULL);
+	clear = ui_image_menu_item_new_with_icon_name("edit-clear-symbolic", _("_Clear"));
 	gtk_widget_show(clear);
 	gtk_container_add(GTK_CONTAINER(message_popup_menu), clear);
 	g_signal_connect(clear, "activate",

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -645,7 +645,7 @@ on_hide_message_window(GtkMenuItem *menuitem, gpointer user_data)
 
 static GtkWidget *create_message_popup_menu(gint type)
 {
-	GtkWidget *message_popup_menu, *clear, *copy, *copy_all, *image;
+	GtkWidget *message_popup_menu, *clear, *copy, *copy_all;
 
 	message_popup_menu = gtk_menu_new();
 
@@ -655,21 +655,15 @@ static GtkWidget *create_message_popup_menu(gint type)
 	g_signal_connect(clear, "activate",
 		G_CALLBACK(on_message_treeview_clear_activate), GINT_TO_POINTER(type));
 
-	copy = gtk_image_menu_item_new_with_mnemonic(_("C_opy"));
+	copy = ui_image_menu_item_new_with_icon_name("edit-copy", _("C_opy"));
 	gtk_widget_show(copy);
 	gtk_container_add(GTK_CONTAINER(message_popup_menu), copy);
-	image = gtk_image_new_from_stock(GTK_STOCK_COPY, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(copy), image);
 	g_signal_connect(copy, "activate",
 		G_CALLBACK(on_compiler_treeview_copy_activate), GINT_TO_POINTER(type));
 
-	copy_all = gtk_image_menu_item_new_with_mnemonic(_("Copy _All"));
+	copy_all = ui_image_menu_item_new_with_icon_name("edit-copy", _("Copy _All"));
 	gtk_widget_show(copy_all);
 	gtk_container_add(GTK_CONTAINER(message_popup_menu), copy_all);
-	image = gtk_image_new_from_stock(GTK_STOCK_COPY, GTK_ICON_SIZE_MENU);
-	gtk_widget_show(image);
-	gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(copy_all), image);
 	g_signal_connect(copy_all, "activate",
 		G_CALLBACK(on_compiler_treeview_copy_all_activate), GINT_TO_POINTER(type));
 

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -649,7 +649,13 @@ static GtkWidget *create_message_popup_menu(gint type)
 
 	message_popup_menu = gtk_menu_new();
 
-	clear = ui_image_menu_item_new_with_icon_name("edit-clear-symbolic", _("_Clear"));
+	/* this is a hack not to add a new translation and use GtkStock's one */
+	GtkStockItem stock_item;
+	const gchar *clear_label = _("_Clear");
+	if (gtk_stock_lookup(GTK_STOCK_CLEAR, &stock_item))
+		clear_label = stock_item.label;
+
+	clear = ui_image_menu_item_new_with_icon_name("edit-clear-symbolic", clear_label);
 	gtk_widget_show(clear);
 	gtk_container_add(GTK_CONTAINER(message_popup_menu), clear);
 	g_signal_connect(clear, "activate",

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -746,7 +746,7 @@ gint notebook_new_tab(GeanyDocument *this)
 		gtk_button_set_focus_on_click(GTK_BUTTON(btn), FALSE);
 		gtk_widget_set_name(btn, "geany-close-tab-button");
 
-		image = gtk_image_new_from_stock(GTK_STOCK_CLOSE, GTK_ICON_SIZE_MENU);
+		image = gtk_image_new_from_icon_name("window-close-symbolic", GTK_ICON_SIZE_MENU);
 		gtk_container_add(GTK_CONTAINER(btn), image);
 
 		align = gtk_alignment_new(1.0, 0.5, 0.0, 0.0);

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1902,7 +1902,7 @@ static void pm_show_dialog(GtkMenuItem *menuitem, gpointer user_data)
 
 	/* filter */
 	pm_widgets.filter_entry = filter_entry = gtk_entry_new();
-	gtk_entry_set_icon_from_stock(GTK_ENTRY(filter_entry), GTK_ENTRY_ICON_PRIMARY, GTK_STOCK_FIND);
+	gtk_entry_set_icon_from_icon_name(GTK_ENTRY(filter_entry), GTK_ENTRY_ICON_PRIMARY, "edit-find-symbolic");
 	ui_entry_add_clear_icon(GTK_ENTRY(filter_entry));
 	g_signal_connect(filter_entry, "changed", G_CALLBACK(on_pm_tree_filter_entry_changed_cb), NULL);
 	g_signal_connect(filter_entry, "icon-release",

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1581,6 +1581,26 @@ ui_image_menu_item_new(const gchar *stock_id, const gchar *label)
 }
 
 
+/* Creates a @c GtkImageMenuItem with a named icon and a custom label.
+ * @param icon_name The icon name.
+ * @param label Menu item label, can include mnemonics.
+ * @return @transfer{floating} The new @c GtkImageMenuItem.
+ */
+GtkWidget *
+ui_image_menu_item_new_with_icon_name(const gchar *icon_name, const gchar *label)
+{
+	return g_object_new(GTK_TYPE_IMAGE_MENU_ITEM,
+			"label", label,
+			"use-underline", TRUE,
+			"image", g_object_new(GTK_TYPE_IMAGE,
+					"icon-name", icon_name,
+					"icon-size", GTK_ICON_SIZE_MENU,
+					"visible", TRUE,
+					NULL),
+			NULL);
+}
+
+
 static void entry_clear_icon_release_cb(GtkEntry *entry, gint icon_pos,
 										GdkEvent *event, gpointer data)
 {

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1602,7 +1602,7 @@ static void entry_clear_icon_release_cb(GtkEntry *entry, gint icon_pos,
 GEANY_API_SYMBOL
 void ui_entry_add_clear_icon(GtkEntry *entry)
 {
-	g_object_set(entry, "secondary-icon-stock", GTK_STOCK_CLEAR,
+	g_object_set(entry, "secondary-icon-name", "edit-clear-symbolic",
 		"secondary-icon-activatable", TRUE, NULL);
 	g_signal_connect(entry, "icon-release", G_CALLBACK(entry_clear_icon_release_cb), NULL);
 }

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1561,6 +1561,24 @@ GtkWidget *ui_button_new_with_image(const gchar *stock_id, const gchar *text)
 }
 
 
+/* Creates a @c GtkButton with custom text and a named icon similar to
+ * @c gtk_button_new_from_icon_name().
+ * @param icon_name The icon name.
+ * @param text Button label text, can include mnemonics.
+ *
+ * @return @transfer{floating} The new @c GtkButton.
+ */
+GtkWidget *ui_button_new_with_icon_name(const gchar *icon_name, const gchar *text)
+{
+	return g_object_new(GTK_TYPE_BUTTON,
+			"label", text,
+			"use-underline", TRUE,
+			"visible", TRUE,
+			"image", gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_BUTTON),
+			NULL);
+}
+
+
 /** Creates a @c GtkImageMenuItem with a stock image and a custom label.
  * @param stock_id Stock image ID, e.g. @c GTK_STOCK_OPEN.
  * @param label Menu item label, can include mnemonics.

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -117,6 +117,8 @@ void ui_add_document_sensitive(GtkWidget *widget);
 
 GtkWidget *ui_image_menu_item_new(const gchar *stock_id, const gchar *label);
 
+GtkWidget *ui_image_menu_item_new_with_icon_name(const gchar *icon_name, const gchar *label);
+
 GtkWidget *ui_lookup_widget(GtkWidget *widget, const gchar *widget_name);
 
 void ui_progress_bar_start(const gchar *text);

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -113,6 +113,8 @@ GtkWidget *ui_path_box_new(const gchar *title, GtkFileChooserAction action, GtkE
 
 GtkWidget *ui_button_new_with_image(const gchar *stock_id, const gchar *text);
 
+GtkWidget *ui_button_new_with_icon_name(const gchar *icon_name, const gchar *text);
+
 void ui_add_document_sensitive(GtkWidget *widget);
 
 GtkWidget *ui_image_menu_item_new(const gchar *stock_id, const gchar *label);


### PR DESCRIPTION
See #3613.
Some of the changes here make sense, some don't really but are still needed not to look terrible with Adwaita 43.  See each commit for details.

@techee @eht16 that's kind of how it looks to dodge the Adwaita 43 issues I could see.