### PR TITLE
Fix crash opening an AsciiDoc document

### DIFF
--- a/scintilla/lexilla/src/Lexilla.cxx
+++ b/scintilla/lexilla/src/Lexilla.cxx
@@ -172,6 +172,7 @@ static void AddGeanyLexers()
 	catalogueLexilla.AddLexerModules({
 		&lmAbaqus,
 		&lmAda,
+		&lmAsciidoc,
 		&lmAsm,
 		&lmAU3,
 		&lmBash,

--- a/scintilla/scintilla_changes.patch
+++ b/scintilla/scintilla_changes.patch
@@ -62,7 +62,7 @@ diff --git scintilla/lexilla/src/Lexilla.cxx scintilla/lexilla/src/Lexilla.cxx
 index cd4b23617..af4a73db4 100644
 --- scintilla/lexilla/src/Lexilla.cxx
 +++ scintilla/lexilla/src/Lexilla.cxx
-@@ -167,8 +167,67 @@
+@@ -167,8 +167,68 @@
  
  CatalogueModules catalogueLexilla;
  
@@ -71,6 +71,7 @@ index cd4b23617..af4a73db4 100644
 +	catalogueLexilla.AddLexerModules({
 +		&lmAbaqus,
 +		&lmAda,
++		&lmAsciidoc,
 +		&lmAsm,
 +		&lmAU3,
 +		&lmBash,

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -701,7 +701,14 @@ void sci_set_lexer(ScintillaObject *sci, guint lexer_id)
 	gint old = sci_get_lexer(sci);
 
 	/* TODO, LexerNameFromID() is already deprecated */
-	ILexer5 *lexer = CreateLexer(LexerNameFromID(lexer_id));
+	const char *lexer_name = LexerNameFromID(lexer_id);
+	if (! lexer_name)
+	{
+		g_warning("Failed to find lexer for ID %u", lexer_id);
+		return;
+	}
+
+	ILexer5 *lexer = CreateLexer(lexer_name);
 
 	SSM(sci, SCI_SETILEXER, 0, (uintptr_t) lexer);
 


### PR DESCRIPTION
@elextr one for you: not only is it AsciiDoc, but it's also a candidate for very-last-minute fix :smile: 

@elextr @techee @eht16 I think we ought to do something for 2.0 here, because indeed hitting this crash is as easy as trying to open e.g. `foo.asciidoc`…