### PR TITLE
Enable translations in the "Various" tab in preferences dialog

### DIFF
--- a/src/stash.c
+++ b/src/stash.c
@@ -75,6 +75,10 @@
  * should be efficient enough.
  */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include "stash.h"
 
 #include "support.h" /* only for _("text") */


### PR DESCRIPTION
"config.h" is needed as it defines the GETTEXT_PACKAGE which is necessary to enable translations at all.

Fixes #3628.