### PR TITLE
Do not show charset "None" in the list of encodings

### DIFF
--- a/src/encodings.c
+++ b/src/encodings.c
@@ -278,7 +278,10 @@ gchar *encodings_to_string(const GeanyEncoding* enc)
 	g_return_val_if_fail(enc->name != NULL, NULL);
 	g_return_val_if_fail(enc->charset != NULL, NULL);
 
-	return g_strdup_printf("%s (%s)", enc->name, enc->charset);
+	if (enc->idx == GEANY_ENCODING_NONE)
+		return g_strdup(enc->name); // enc->charset is "None" and would be useless to display
+	else
+		return g_strdup_printf("%s (%s)", enc->name, enc->charset);
 }
 
 


### PR DESCRIPTION
The charset "None" would be shown for the encoding name "Without encoding" and so it would be rather
redundant and the special value "None" should be
translatable but isn't.

Closes #3624.