### PR TITLE
Autotools: regenerate gmo files when po files are updated

### DIFF
--- a/po/Rules-gmo
+++ b/po/Rules-gmo
@@ -1,0 +1,12 @@
+# Make sure the gmo files are regenerated when the po files are updated,
+# without the need for manually calling `make update-gmo` or `make ll.gmo`.
+# See e.g. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=400453#24, I
+# couldn't find any canonical info on this.
+
+DISTFILES.common += Rules-gmo
+
+# Make sure changing this files updates the generated Makefile
+Makefile: Rules-gmo
+
+# Just make the gmo files a default dependency, the rest is done automatically.
+all-yes: $(GMOFILES)


### PR DESCRIPTION
Make sure the gmo files are regenerated when the corresponding po files are updated, not to have stale translations after updating a po file.

This behavior most likely changed with the switch from GLib gettext infrastructure to to plain gettext one in 32977676a90244e0410524614757d2cf214bae43.

I had a hard time finding a rationale for the behavior of not automatically updating the gmo files when their source changed; all I could find is [this](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=400453#24) which suggests it's intentional.  Still, at least with our configuration of `PO_DEPENDS_ON_POT=no`, which means po files are not updated all the time, the point seems moot and does more harm than good.

Fix this by manually adding the correct dependency to the main target so the gmo files are updated automatically when the po changes. The only case where I can see it performing "useless" work is when calling update-po, which will effectively update all po files, and thus rebuild all gmo files.  But that doesn't sound like any kind of problem, and rather expected.