### PR TITLE
Replace utils_make_human_readable_str() with g_format_size()

### DIFF
--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -1195,7 +1195,7 @@ void dialogs_show_file_properties(GeanyDocument *doc)
 	gtk_label_set_text(GTK_LABEL(label), doc->file_type->title);
 
 	label = ui_lookup_widget(dialog, "file_size_label");
-	file_size = utils_make_human_readable_str(filesize, 1, 0);
+	file_size = g_format_size(filesize);
 	gtk_label_set_text(GTK_LABEL(label), file_size);
 	g_free(file_size);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -948,55 +948,6 @@ void utils_beep(void)
 }
 
 
-/* taken from busybox, thanks */
-gchar *utils_make_human_readable_str(guint64 size, gulong block_size,
-									 gulong display_unit)
-{
-	/* The code will adjust for additional (appended) units. */
-	static const gchar zero_and_units[] = { '0', 0, 'K', 'M', 'G', 'T' };
-	static const gchar fmt[] = "%Lu %c%c";
-	static const gchar fmt_tenths[] = "%Lu.%d %c%c";
-
-	guint64 val;
-	gint frac;
-	const gchar *u;
-	const gchar *f;
-
-	u = zero_and_units;
-	f = fmt;
-	frac = 0;
-
-	val = size * block_size;
-	if (val == 0)
-		return g_strdup(u);
-
-	if (display_unit)
-	{
-		val += display_unit/2;	/* Deal with rounding. */
-		val /= display_unit;	/* Don't combine with the line above!!! */
-	}
-	else
-	{
-		++u;
-		while ((val >= 1024) && (u < zero_and_units + sizeof(zero_and_units) - 1))
-		{
-			f = fmt_tenths;
-			++u;
-			frac = ((((gint)(val % 1024)) * 10) + (1024 / 2)) / 1024;
-			val /= 1024;
-		}
-		if (frac >= 10)
-		{		/* We need to round up here. */
-			++val;
-			frac = 0;
-		}
-	}
-
-	/* If f==fmt then 'frac' and 'u' are ignored. */
-	return g_strdup_printf(f, val, frac, *u, 'b');
-}
-
-
 /* converts a color representation using gdk_color_parse(), with additional
  * support of the "0x" prefix as a synonym for "#" */
 gboolean utils_parse_color(const gchar *spec, GdkColor *color)

--- a/src/utils.h
+++ b/src/utils.h
@@ -281,9 +281,6 @@ gchar *utils_get_current_file_dir_utf8(void);
 
 void utils_beep(void);
 
-gchar *utils_make_human_readable_str(guint64 size, gulong block_size,
-									 gulong display_unit);
-
 gboolean utils_parse_color(const gchar *spec, GdkColor *color);
 
 gint utils_color_to_bgr(const GdkColor *color);


### PR DESCRIPTION
This allows removing a needlessly complex and tricky function (I dare you understanding what it actually does the first time around) in which we even introduced subtle (but luckily invisible for now) bugs over time as it was probably not understood properly, and more sensitive to breakage than it ought to be.

It also actually improves results, as we unit for bytes, and proper translation for the units.

Note that this switches to SI units, which is probably actually better.

We could use `g_format_size_full(..., G_FORMAT_SIZE_IEC_UNITS)` if we wanted to keep EIC units though.

---

If it doesn't transpire enough through my rant above, kills `utils_make_human_readable_str()` which is more "look, I'm clever" than actually neat.  It is utterly non-obvious by having conditional format strings with different number of arguments, yet passing the same ones to the formatter… and no, it's not simply discarding the last one.  Plus, over time types were carelessly changed making things ever more shady, yet somehow calling conventions saved us all this time.

Anyway, since GLib 2.30 (old enough for our current requirements) we can use a ready-made version that even gives better results.

I actually stumbled on this gem trying to hunt GCC warnings, and it was one of those `-Wformat-nonliteral` ones.  This one is easy enough: just nuke it out of the sky!