### PR TITLE
Less warnings

### DIFF
--- a/plugins/filebrowser.c
+++ b/plugins/filebrowser.c
@@ -526,8 +526,7 @@ static void on_external_open(GtkMenuItem *menuitem, gpointer user_data)
 		}
 	}
 
-	g_list_foreach(list, (GFunc) gtk_tree_path_free, NULL);
-	g_list_free(list);
+	g_list_free_full(list, (GDestroyNotify) gtk_tree_path_free);
 }
 
 
@@ -551,8 +550,7 @@ static void open_selected_files(GList *list, gboolean do_not_focus)
 	if (doc != NULL && ! do_not_focus)
 		keybindings_send_command(GEANY_KEY_GROUP_FOCUS, GEANY_KEYS_FOCUS_EDITOR);
 
-	g_slist_foreach(files, (GFunc) g_free, NULL);	/* free filenames */
-	g_slist_free(files);
+	g_slist_free_full(files, g_free);
 }
 
 
@@ -589,8 +587,7 @@ static void on_open_clicked(GtkMenuItem *menuitem, gpointer user_data)
 	else
 		open_selected_files(list, GPOINTER_TO_INT(user_data));
 
-	g_list_foreach(list, (GFunc) gtk_tree_path_free, NULL);
-	g_list_free(list);
+	g_list_free_full(list, (GDestroyNotify) gtk_tree_path_free);
 }
 
 
@@ -620,8 +617,7 @@ static void on_find_in_files(GtkMenuItem *menuitem, gpointer user_data)
 	else
 		dir = g_strdup(current_dir);
 
-	g_list_foreach(list, (GFunc) gtk_tree_path_free, NULL);
-	g_list_free(list);
+	g_list_free_full(list, (GDestroyNotify) gtk_tree_path_free);
 
 	SETPTR(dir, utils_get_utf8_from_locale(dir));
 	search_show_find_in_files_dialog(dir);

--- a/plugins/splitwindow.c
+++ b/plugins/splitwindow.c
@@ -249,7 +249,7 @@ static void on_doc_menu_item_clicked(gpointer item, GeanyDocument *doc)
 static void on_doc_show_menu(GtkMenuToolButton *button, GtkMenu *menu)
 {
 	/* clear the old menu items */
-	gtk_container_foreach(GTK_CONTAINER(menu), (GtkCallback) gtk_widget_destroy, NULL);
+	gtk_container_foreach(GTK_CONTAINER(menu), (GtkCallback) (void(*)(void)) gtk_widget_destroy, NULL);
 
 	ui_menu_add_document_items(menu, edit_window.editor->document,
 		G_CALLBACK(on_doc_menu_item_clicked));

--- a/src/build.c
+++ b/src/build.c
@@ -137,7 +137,7 @@ typedef enum
 
 static gpointer last_toolbutton_action = GBO_TO_POINTER(GEANY_GBO_BUILD);
 
-static BuildMenuItems menu_items = {NULL, {NULL, NULL, NULL, NULL}};
+static BuildMenuItems build_menu_items = {NULL, {NULL, NULL, NULL, NULL}};
 
 static struct
 {
@@ -179,8 +179,8 @@ void build_finalize(void)
 	g_free(build_info.dir);
 	g_free(build_info.custom_target);
 
-	if (menu_items.menu != NULL && GTK_IS_WIDGET(menu_items.menu))
-		gtk_widget_destroy(menu_items.menu);
+	if (build_menu_items.menu != NULL && GTK_IS_WIDGET(build_menu_items.menu))
+		gtk_widget_destroy(build_menu_items.menu);
 }
 
 
@@ -1385,11 +1385,11 @@ static void create_build_menu_item(GtkWidget *menu, GeanyKeyGroup *group, GtkAcc
 	{
 		g_signal_connect(item, "activate", G_CALLBACK(bs->cb), GRP_CMD_TO_POINTER(grp,cmd));
 	}
-	menu_items.menu_item[grp][cmd] = item;
+	build_menu_items.menu_item[grp][cmd] = item;
 }
 
 
-static void create_build_menu(BuildMenuItems *build_menu_items)
+static void create_build_menu(BuildMenuItems *menu_items)
 {
 	GtkWidget *menu;
 	GtkAccelGroup *accel_group = gtk_accel_group_new();
@@ -1397,10 +1397,10 @@ static void create_build_menu(BuildMenuItems *build_menu_items)
 	guint i, j;
 
 	menu = gtk_menu_new();
-	build_menu_items->menu_item[GEANY_GBG_FT] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_FT]);
-	build_menu_items->menu_item[GEANY_GBG_NON_FT] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_NON_FT]);
-	build_menu_items->menu_item[GEANY_GBG_EXEC] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_EXEC]);
-	build_menu_items->menu_item[GBG_FIXED] = g_new0(GtkWidget*, GBF_COUNT);
+	menu_items->menu_item[GEANY_GBG_FT] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_FT]);
+	menu_items->menu_item[GEANY_GBG_NON_FT] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_NON_FT]);
+	menu_items->menu_item[GEANY_GBG_EXEC] = g_new0(GtkWidget*, build_groups_count[GEANY_GBG_EXEC]);
+	menu_items->menu_item[GBG_FIXED] = g_new0(GtkWidget*, GBF_COUNT);
 
 	for (i = 0; build_menu_specs[i].build_grp != MENU_DONE; ++i)
 	{
@@ -1410,7 +1410,7 @@ static void create_build_menu(BuildMenuItems *build_menu_items)
 			GtkWidget *item = gtk_separator_menu_item_new();
 			gtk_widget_show(item);
 			gtk_container_add(GTK_CONTAINER(menu), item);
-			build_menu_items->menu_item[GBG_FIXED][bs->build_cmd] = item;
+			menu_items->menu_item[GBG_FIXED][bs->build_cmd] = item;
 		}
 		else if (bs->fix_label != NULL)
 		{
@@ -1434,7 +1434,7 @@ static void create_build_menu(BuildMenuItems *build_menu_items)
 			create_build_menu_item(menu, keygroup, accel_group, bs, lbl, bs->build_grp, bs->build_cmd);
 		}
 	}
-	build_menu_items->menu = menu;
+	menu_items->menu = menu;
 	gtk_widget_show(menu);
 	gtk_menu_item_set_submenu(GTK_MENU_ITEM(ui_lookup_widget(main_widgets.window, "menu_build1")), menu);
 }
@@ -1464,8 +1464,8 @@ void build_menu_update(GeanyDocument *doc)
 
 	g_return_if_fail(doc == NULL || doc->is_valid);
 
-	if (menu_items.menu == NULL)
-		create_build_menu(&menu_items);
+	if (build_menu_items.menu == NULL)
+		create_build_menu(&build_menu_items);
 	if (doc == NULL)
 		doc = document_get_current();
 	have_path = doc != NULL && doc->file_name != NULL;
@@ -1481,15 +1481,15 @@ void build_menu_update(GeanyDocument *doc)
 			case MENU_SEPARATOR:
 				if (vis == TRUE)
 				{
-					gtk_widget_show_all(menu_items.menu_item[GBG_FIXED][bs->build_cmd]);
+					gtk_widget_show_all(build_menu_items.menu_item[GBG_FIXED][bs->build_cmd]);
 					vis = FALSE;
 				}
 				else
-					gtk_widget_hide(menu_items.menu_item[GBG_FIXED][bs->build_cmd]);
+					gtk_widget_hide(build_menu_items.menu_item[GBG_FIXED][bs->build_cmd]);
 				break;
 			case MENU_NEXT_ERROR:
 			case MENU_PREV_ERROR:
-				gtk_widget_set_sensitive(menu_items.menu_item[GBG_FIXED][bs->build_cmd], have_errors);
+				gtk_widget_set_sensitive(build_menu_items.menu_item[GBG_FIXED][bs->build_cmd], have_errors);
 				vis |= TRUE;
 				break;
 			case MENU_COMMANDS:
@@ -1508,7 +1508,7 @@ void build_menu_update(GeanyDocument *doc)
 				}
 				for (cmd = bs->build_cmd; cmd < cmdcount; ++cmd)
 				{
-					GtkWidget *menu_item = menu_items.menu_item[grp][cmd];
+					GtkWidget *menu_item = build_menu_items.menu_item[grp][cmd];
 					const gchar *label;
 					bc = get_build_cmd(doc, grp, cmd, NULL);
 					if (bc)
@@ -2266,7 +2266,7 @@ BuildMenuItems *build_get_menu_items(gint filetype_idx)
 {
 	BuildMenuItems *items;
 
-	items = &menu_items;
+	items = &build_menu_items;
 	if (items->menu == NULL)
 		create_build_menu(items);
 	return items;

--- a/src/build.c
+++ b/src/build.c
@@ -771,7 +771,7 @@ static gchar *build_replace_placeholder(const GeanyDocument *doc, const gchar *s
 static void build_spawn_cmd(GeanyDocument *doc, const gchar *cmd, const gchar *dir)
 {
 	GError *error = NULL;
-	gchar *argv[] = { "/bin/sh", "-c", NULL, NULL };
+	const gchar *argv[] = { "/bin/sh", "-c", NULL, NULL };
 	gchar *working_dir;
 	gchar *utf8_working_dir;
 	gchar *cmd_string;
@@ -813,7 +813,7 @@ static void build_spawn_cmd(GeanyDocument *doc, const gchar *cmd, const gchar *d
 	build_info.file_type_id = (doc == NULL) ? GEANY_FILETYPES_NONE : doc->file_type->id;
 	build_info.message_count = 0;
 
-	if (!spawn_with_callbacks(working_dir, cmd, argv, NULL, 0, NULL, NULL, build_iofunc,
+	if (!spawn_with_callbacks(working_dir, cmd, (gchar **) argv, NULL, 0, NULL, NULL, build_iofunc,
 		GINT_TO_POINTER(0), 0, build_iofunc, GINT_TO_POINTER(1), 0, build_exit_cb, NULL,
 		&build_info.pid, &error))
 	{

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -163,9 +163,8 @@ static gboolean open_file_dialog_handle_response(GtkWidget *dialog, gint respons
 			{
 				document_open_files(filelist, ro, ft, charset);
 			}
-			g_slist_foreach(filelist, (GFunc) g_free, NULL);	/* free filenames */
+			g_slist_free_full(filelist, g_free);
 		}
-		g_slist_free(filelist);
 	}
 	if (app->project && !EMPTY(app->project->base_path))
 		gtk_file_chooser_remove_shortcut_folder(GTK_FILE_CHOOSER(dialog),

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -982,7 +982,7 @@ dialogs_show_input_full(const gchar *title, GtkWindow *parent,
 		g_signal_connect(data->entry, "insert-text", insert_text_cb, insert_text_cb_data);
 	g_signal_connect(data->entry, "activate", G_CALLBACK(on_input_entry_activate), dialog);
 	g_signal_connect(dialog, "show", G_CALLBACK(on_input_dialog_show), data->entry);
-	g_signal_connect_data(dialog, "response", G_CALLBACK(on_input_dialog_response), data, (GClosureNotify)g_free, 0);
+	g_signal_connect_data(dialog, "response", G_CALLBACK(on_input_dialog_response), data, CLOSURE_NOTIFY(g_free), 0);
 
 	if (persistent)
 	{

--- a/src/document.c
+++ b/src/document.c
@@ -1017,15 +1017,18 @@ static gboolean load_text_file(const gchar *locale_filename, const gchar *displa
 
 	if (filedata->readonly)
 	{
-		const gchar *warn_msg = _(
-			"The file \"%s\" could not be opened properly and has been truncated. " \
-			"This can occur if the file contains a NULL byte. " \
-			"Be aware that saving it can cause data loss.\nThe file was set to read-only.");
+		gchar *warn_msg = g_strdup_printf(_(
+			"The file \"%s\" could not be opened properly and has been truncated. "
+			"This can occur if the file contains a NULL byte. "
+			"Be aware that saving it can cause data loss.\nThe file was set to read-only."),
+			display_filename);
 
 		if (main_status.main_window_realized)
-			dialogs_show_msgbox(GTK_MESSAGE_WARNING, warn_msg, display_filename);
+			dialogs_show_msgbox(GTK_MESSAGE_WARNING, "%s", warn_msg);
 
-		ui_set_statusbar(TRUE, warn_msg, display_filename);
+		ui_set_statusbar(TRUE, "%s", warn_msg);
+
+		g_free(warn_msg);
 	}
 
 	return TRUE;

--- a/src/document.c
+++ b/src/document.c
@@ -115,9 +115,9 @@ static void document_redo_add(GeanyDocument *doc, guint type, gpointer data);
 static gboolean remove_page(guint page_num);
 static GtkWidget* document_show_message(GeanyDocument *doc, GtkMessageType msgtype,
 	void (*response_cb)(GtkWidget *info_bar, gint response_id, GeanyDocument *doc),
-	const gchar *btn_1, GtkResponseType response_1,
-	const gchar *btn_2, GtkResponseType response_2,
-	const gchar *btn_3, GtkResponseType response_3,
+	const gchar *btn_1, gint response_1,
+	const gchar *btn_2, gint response_2,
+	const gchar *btn_3, gint response_3,
 	const gchar *extra_text, const gchar *format, ...) G_GNUC_PRINTF(11, 12);
 
 
@@ -3452,9 +3452,9 @@ gboolean document_close_all(void)
  * */
 static GtkWidget* document_show_message(GeanyDocument *doc, GtkMessageType msgtype,
 	void (*response_cb)(GtkWidget *info_bar, gint response_id, GeanyDocument *doc),
-	const gchar *btn_1, GtkResponseType response_1,
-	const gchar *btn_2, GtkResponseType response_2,
-	const gchar *btn_3, GtkResponseType response_3,
+	const gchar *btn_1, gint response_1,
+	const gchar *btn_2, gint response_2,
+	const gchar *btn_3, gint response_3,
 	const gchar *extra_text, const gchar *format, ...)
 {
 	va_list args;

--- a/src/editor.c
+++ b/src/editor.c
@@ -233,7 +233,7 @@ static void add_kb(GKeyFile *keyfile, const gchar *group, gchar **keys)
 
 		gtk_accel_group_connect(snippet_accel_group, key, mods, 0,
 			g_cclosure_new_swap((GCallback)on_snippet_keybinding_activate,
-				g_strdup(keys[i]), (GClosureNotify)g_free));
+				g_strdup(keys[i]), CLOSURE_NOTIFY(g_free)));
 	}
 }
 

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -844,8 +844,7 @@ static void filetype_free(gpointer data, G_GNUC_UNUSED gpointer user_data)
 
 	if (ft->priv->error_regex)
 		g_regex_unref(ft->priv->error_regex);
-	g_slist_foreach(ft->priv->tag_files, (GFunc) g_free, NULL);
-	g_slist_free(ft->priv->tag_files);
+	g_slist_free_full(ft->priv->tag_files, g_free);
 
 	g_free(ft->priv);
 	g_free(ft);

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -882,11 +882,11 @@ static void open_cl_files(gint argc, gchar **argv)
 #endif
 		if (filename && ! main_handle_filename(filename))
 		{
-			const gchar *msg = _("Could not find file '%s'.");
+			gchar *msg = g_strdup_printf(_("Could not find file '%s'."), filename);
 
-			g_printerr(msg, filename);	/* also print to the terminal */
-			g_printerr("\n");
-			ui_set_statusbar(TRUE, msg, filename);
+			g_printerr("%s\n", msg);	/* also print to the terminal */
+			ui_set_statusbar(TRUE, "%s", msg);
+			g_free(msg);
 		}
 		g_free(filename);
 	}
@@ -1174,9 +1174,11 @@ gint main_lib(gint argc, gchar **argv)
 	ui_set_statusbar(TRUE, _("This is Geany %s."), main_get_version_string());
 	if (config_dir_result != 0)
 	{
-		const gchar *message = _("Configuration directory could not be created (%s).");
-		ui_set_statusbar(TRUE, message, g_strerror(config_dir_result));
-		g_warning(message, g_strerror(config_dir_result));
+		gchar *message = g_strdup_printf(_("Configuration directory could not be created (%s)."),
+				g_strerror(config_dir_result));
+		ui_set_statusbar(TRUE, "%s", message);
+		g_warning("%s", message);
+		g_free(message);
 	}
 #ifdef HAVE_SOCKET
 	if (socket_info.lock_socket == -1)

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -467,7 +467,7 @@ static void show_tab_bar_popup_menu(GdkEventButton *event, GeanyDocument *doc)
 		menu = gtk_menu_new();
 
 	/* clear the old menu items */
-	gtk_container_foreach(GTK_CONTAINER(menu), (GtkCallback) gtk_widget_destroy, NULL);
+	gtk_container_foreach(GTK_CONTAINER(menu), (GtkCallback) (void(*)(void)) gtk_widget_destroy, NULL);
 
 	ui_menu_add_document_items(GTK_MENU(menu), document_get_current(),
 		G_CALLBACK(tab_bar_menu_activate_cb));

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -45,14 +45,14 @@
 
 static const GtkTargetEntry drag_targets[] =
 {
-	{GEANY_DND_NOTEBOOK_TAB_TYPE, GTK_TARGET_SAME_APP | GTK_TARGET_SAME_WIDGET, 0}
+	{ (gchar *) GEANY_DND_NOTEBOOK_TAB_TYPE, GTK_TARGET_SAME_APP | GTK_TARGET_SAME_WIDGET, 0 }
 };
 
-static GtkTargetEntry files_drop_targets[] = {
-	{ "STRING",			0, 0 },
-	{ "UTF8_STRING",	0, 0 },
-	{ "text/plain",		0, 0 },
-	{ "text/uri-list",	0, 0 }
+static const GtkTargetEntry files_drop_targets[] = {
+	{ (gchar *) "STRING",			0, 0 },
+	{ (gchar *) "UTF8_STRING",		0, 0 },
+	{ (gchar *) "text/plain",		0, 0 },
+	{ (gchar *) "text/uri-list",	0, 0 }
 };
 
 static const gsize MAX_MRU_DOCS = 20;

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1297,9 +1297,11 @@ void plugins_init(void)
 
 
 /* Same as plugin_free(), except it does nothing for proxies-in-use, to be called on
- * finalize in a loop */
-static void plugin_free_leaf(Plugin *p)
+ * finalize in a loop through g_list_foreach() */
+static void plugin_free_leaf(gpointer data, gpointer user_data G_GNUC_UNUSED)
 {
+	Plugin *p = data;
+
 	if (p->proxied_count == 0)
 		plugin_free(p);
 }
@@ -1315,7 +1317,7 @@ void plugins_finalize(void)
 	/* Have to loop because proxys cannot be unloaded until after all their
 	 * plugins are unloaded as well (the second loop should should catch all the remaining ones) */
 	while (active_plugin_list != NULL)
-		g_list_foreach(active_plugin_list, (GFunc) plugin_free_leaf, NULL);
+		g_list_foreach(active_plugin_list, plugin_free_leaf, NULL);
 
 	g_strfreev(active_plugins_pref);
 }

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1108,8 +1108,7 @@ load_plugins_from_path(const gchar *path)
 		g_free(fname);
 	}
 
-	g_slist_foreach(list, (GFunc) g_free, NULL);
-	g_slist_free(list);
+	g_slist_free_full(list, g_free);
 
 	if (count)
 		geany_debug("Added %d plugin(s) in '%s'.", count, path);
@@ -1311,8 +1310,7 @@ void plugins_finalize(void)
 {
 	if (failed_plugins_list != NULL)
 	{
-		g_list_foreach(failed_plugins_list, (GFunc) g_free,	NULL);
-		g_list_free(failed_plugins_list);
+		g_list_free_full(failed_plugins_list, g_free);
 	}
 	/* Have to loop because proxys cannot be unloaded until after all their
 	 * plugins are unloaded as well (the second loop should should catch all the remaining ones) */

--- a/src/printing.c
+++ b/src/printing.c
@@ -602,9 +602,9 @@ static void print_external(GeanyDocument *doc)
 		/* /bin/sh -c emulates the system() call and makes complex commands possible
 		 * but only on non-win32 systems due to the lack of win32's shell capabilities */
 	#ifdef G_OS_UNIX
-		gchar *argv[] = { "/bin/sh", "-c", cmdline, NULL };
+		const gchar *argv[] = { "/bin/sh", "-c", cmdline, NULL };
 
-		if (!spawn_async(NULL, NULL, argv, NULL, NULL, &error))
+		if (!spawn_async(NULL, NULL, (gchar **) argv, NULL, NULL, &error))
 	#else
 		if (!spawn_async(NULL, cmdline, NULL, NULL, NULL, &error))
 	#endif

--- a/src/search.c
+++ b/src/search.c
@@ -1883,12 +1883,14 @@ static void search_finished(GPid child_pid, gint status, gpointer user_data)
 		{
 			gint count = gtk_tree_model_iter_n_children(
 				GTK_TREE_MODEL(msgwindow.store_msg), NULL) - 1;
-			gchar *text = ngettext(
+			gchar *text = g_strdup_printf(ngettext(
 						"Search completed with %d match.",
-						"Search completed with %d matches.", count);
+						"Search completed with %d matches.", count),
+						count);
 
-			msgwin_msg_add(COLOR_BLUE, -1, NULL, text, count);
-			ui_set_statusbar(FALSE, text, count);
+			msgwin_msg_add_string(COLOR_BLUE, -1, NULL, text);
+			ui_set_statusbar(FALSE, "%s", text);
+			g_free(text);
 			break;
 		}
 		case 1:

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -1481,7 +1481,7 @@ static void show_goto_popup(GeanyDocument *doc, GPtrArray *tags, gboolean have_b
 		item = g_object_new(GTK_TYPE_IMAGE_MENU_ITEM, "image", image, "child", box, "always-show-image", TRUE,
 					"tooltip-markup", tooltip, NULL);
 		g_signal_connect_data(item, "activate", G_CALLBACK(on_goto_popup_item_activate),
-		                      tm_tag_ref(tmtag), (GClosureNotify) tm_tag_unref, 0);
+		                      tm_tag_ref(tmtag), CLOSURE_NOTIFY(tm_tag_unref), 0);
 		gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
 
 		if (! first)

--- a/src/tagmanager/tm_ctags.c
+++ b/src/tagmanager/tm_ctags.c
@@ -320,7 +320,7 @@ static void rename_anon_tags(TMSourceFile *source_file)
 				if (!anon_counter_table)
 					anon_counter_table = g_new0(gint, 256);
 
-				anon_counter = ++anon_counter_table[kind];
+				anon_counter = ++anon_counter_table[(guchar) kind];
 
 				sprintf(buf, "anon_%s_%u", kind_name, anon_counter);
 				tag->name = g_strdup(buf);

--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -906,7 +906,12 @@ static gint sort_found_tags(gconstpointer a, gconstpointer b, gpointer user_data
 	 * followed by workspace tags,
 	 * followed by global tags */
 	if (t1->type & tm_tag_local_var_t && t2->type & tm_tag_local_var_t)
-		return info->sort_by_name ? g_strcmp0(t1->name, t2->name) : t2->line - t1->line;
+	{
+		if (info->sort_by_name)
+			return g_strcmp0(t1->name, t2->name);
+		else /* just like (t2->line - t1->line), but doesn't overflow converting to int */
+			return (t2->line > t1->line) ? 1 : ((t2->line < t1->line) ? -1 : 0);
+	}
 	else if (t1->type & tm_tag_local_var_t)
 		return -1;
 	else if (t2->type & tm_tag_local_var_t)

--- a/src/toolbar.c
+++ b/src/toolbar.c
@@ -1118,8 +1118,7 @@ void toolbar_configure(GtkWindow *parent)
 
 	gtk_widget_destroy(tbw->dialog);
 
-	g_slist_foreach(used_items, (GFunc) g_free, NULL);
-	g_slist_free(used_items);
+	g_slist_free_full(used_items, g_free);
 	g_list_free(all_items);
 	tb_editor_free_path(tbw);
 	g_free(tbw);

--- a/src/toolbar.c
+++ b/src/toolbar.c
@@ -601,7 +601,7 @@ typedef struct
 
 static const GtkTargetEntry tb_editor_dnd_targets[] =
 {
-	{ "GEANY_TB_EDITOR_ROW", 0, 0 }
+	{ (gchar *) "GEANY_TB_EDITOR_ROW", 0, 0 }
 };
 static const gint tb_editor_dnd_targets_len = G_N_ELEMENTS(tb_editor_dnd_targets);
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2576,33 +2576,6 @@ static void init_css_styles(void)
 	load_css_theme(theme_fn, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 	g_free(theme_fn);
 
-	// load themes to handle breakage between various GTK+ versions
-	const struct
-	{
-		guint min_version;
-		guint max_version;
-		const gchar *file;
-	}
-	css_files[] =
-	{
-		/* Unused now but can be used to load css for different GTK versions, such as
-		 * { 20, G_MAXUINT, "geany-3.20.css" },
-		 * { 0, 19, "geany-3.0.css" },
-		 */
-	};
-
-	guint gtk_version = gtk_get_minor_version();
-	for (guint i = 0; i < G_N_ELEMENTS(css_files); i++)
-	{
-		if (gtk_version >= css_files[i].min_version &&
-			gtk_version <= css_files[i].max_version)
-		{
-			theme_fn = g_build_filename(app->datadir, css_files[i].file, NULL);
-			load_css_theme(theme_fn, GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-			g_free(theme_fn);
-		}
-	}
-
 	// if the user provided a geany.css file in their config dir, try and load that
 	theme_fn = g_build_filename(app->configdir, "geany.css", NULL);
 	if (g_file_test(theme_fn, G_FILE_TEST_EXISTS))

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2256,11 +2256,11 @@ static void add_stock_icons(const GtkStockItem *items, gsize count)
 
 void ui_init_stock_items(void)
 {
-	GtkStockItem items[] =
+	const GtkStockItem items[] =
 	{
-		{ GEANY_STOCK_SAVE_ALL, N_("Save All"), 0, 0, GETTEXT_PACKAGE },
-		{ GEANY_STOCK_CLOSE_ALL, N_("Close All"), 0, 0, GETTEXT_PACKAGE },
-		{ GEANY_STOCK_BUILD, N_("Build"), 0, 0, GETTEXT_PACKAGE }
+		{ (gchar *) GEANY_STOCK_SAVE_ALL, (gchar *) N_("Save All"), 0, 0, (gchar *) GETTEXT_PACKAGE },
+		{ (gchar *) GEANY_STOCK_CLOSE_ALL, (gchar *) N_("Close All"), 0, 0, (gchar *) GETTEXT_PACKAGE },
+		{ (gchar *) GEANY_STOCK_BUILD, (gchar *) N_("Build"), 0, 0, (gchar *) GETTEXT_PACKAGE }
 	};
 
 	gtk_stock_add(items, G_N_ELEMENTS(items));

--- a/src/utils.h
+++ b/src/utils.h
@@ -219,6 +219,10 @@ gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len);
 
 #ifdef GEANY_PRIVATE
 
+/* Casts a GDestroyNotify to a GClosureNotify without a warning.
+ * This is kinda shady, but likely works with platforms where GTK does. */
+#define CLOSURE_NOTIFY(f) ((GClosureNotify) (void(*)(void)) (GDestroyNotify) (f))
+
 typedef enum
 {
 	RESOURCE_DIR_DATA,

--- a/src/vte.c
+++ b/src/vte.c
@@ -169,11 +169,11 @@ enum
 
 static const GtkTargetEntry dnd_targets[] =
 {
-  { "UTF8_STRING", 0, TARGET_UTF8_STRING },
-  { "TEXT", 0, TARGET_TEXT },
-  { "COMPOUND_TEXT", 0, TARGET_COMPOUND_TEXT },
-  { "STRING", 0, TARGET_STRING },
-  { "text/plain", 0, TARGET_TEXT_PLAIN },
+  { (gchar *) "UTF8_STRING", 0, TARGET_UTF8_STRING },
+  { (gchar *) "TEXT", 0, TARGET_TEXT },
+  { (gchar *) "COMPOUND_TEXT", 0, TARGET_COMPOUND_TEXT },
+  { (gchar *) "STRING", 0, TARGET_STRING },
+  { (gchar *) "text/plain", 0, TARGET_TEXT_PLAIN },
 };
 
 


### PR DESCRIPTION
With this, you should be able to build *src/* and *plugins/* warning-free with `CFLAGS="-Wall -Wextra -g -Og -Wno-unused-parameter -Wunreachable-code -Wformat=2 -Wundef -Wshadow -Wpointer-arith -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wnested-externs -Werror-implicit-function-declaration"` (or just `-Wall -Wextra -g -Og -Wno-unused-parameter -Wwrite-strings` to start with) but for some Lexilla prototype and one deprecated Lexilla call.

To review, go per-commit as it should be fairly trivial that way. Also, everything but maybe 12b30c5950eeccad2fed885745ff6cd0888d1d3a should not be controversial I think -- but please, raise any concern!