### PR TITLE
Encodings UI improvements

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -4567,22 +4567,6 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkCheckButton" id="check_open_encoding">
-                                <property name="label" translatable="yes">Use fixed encoding when opening non-Unicode files</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="tooltip-text" translatable="yes">This option disables the automatic detection of the file encoding when opening non-Unicode files and opens the file with the specified encoding (usually not needed)</property>
-                                <property name="use-underline">True</property>
-                                <property name="draw-indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkVBox" id="vbox45">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2470,12 +2470,12 @@ Open new documents from the command-line
 Default encoding (new files)
     The type of file encoding you wish to use when creating files.
 
-Used fixed encoding when opening files
-    Assume all files you are opening are using the type of encoding specified below.
-
 Default encoding (existing files)
-    Opens all files with the specified encoding instead of auto-detecting it.
-    Use this option when it's not possible for Geany to detect the exact encoding.
+    Selects the encoding used when opening existing files. If set to something
+    other than *Detect from file*, all files will be opened with the specified
+    encoding instead of auto-detecting it.
+    Use a specific encoding when it's not possible for Geany to detect the
+    correct one.
 
 Default end of line characters
     The end of line characters to which should be used for new files.

--- a/src/encodings.c
+++ b/src/encodings.c
@@ -59,12 +59,24 @@ static gboolean pregs_loaded = FALSE;
 GeanyEncoding encodings[GEANY_ENCODINGS_MAX];
 
 
+static gboolean conversion_supported(const gchar *to, const gchar *from)
+{
+	GIConv conv = g_iconv_open(to, from);
+	if (conv == (GIConv) -1)
+		return FALSE;
+
+	g_iconv_close(conv);
+	return TRUE;
+}
+
+
 #define fill(Order, Group, Idx, Charset, Name) \
 		encodings[Idx].idx = Idx; \
 		encodings[Idx].order = Order; \
 		encodings[Idx].group = Group; \
 		encodings[Idx].charset = Charset; \
-		encodings[Idx].name = Name;
+		encodings[Idx].name = Name; \
+		encodings[Idx].supported = FALSE;
 
 static void init_encodings(void)
 {
@@ -140,6 +152,19 @@ static void init_encodings(void)
 	fill(14,	EASTASIAN,		GEANY_ENCODING_UHC,				"UHC",				_("Korean"));
 
 	fill(0,		NONE,			GEANY_ENCODING_NONE,			"None",				_("Without encoding"));
+
+	/* fill the flags member */
+	for (guint i = 0; i < G_N_ELEMENTS(encodings); i++)
+	{
+		if (i == GEANY_ENCODING_NONE || conversion_supported("UTF-8", encodings[i].charset))
+			encodings[i].supported = TRUE;
+		else
+		{
+			/* geany_debug() doesn't really work at this point, unless G_MESSAGES_DEBUG
+			 * is set explicitly by the caller, but that's better than nothing */
+			geany_debug("Encoding %s is not supported by the system", encodings[i].charset);
+		}
+	}
 }
 
 

--- a/src/encodings.c
+++ b/src/encodings.c
@@ -503,7 +503,8 @@ void encodings_init(void)
 					}
 					else
 						item = gtk_menu_item_new_with_label(label);
-					gtk_widget_show(item);
+					if (encodings[i].supported)
+						gtk_widget_show(item);
 					gtk_container_add(GTK_CONTAINER(submenus[encodings[i].group]), item);
 					g_signal_connect(item, "activate", cb_func[k],
 							(gpointer) encodings[i].charset);
@@ -574,6 +575,9 @@ GtkTreeStore *encodings_encoding_store_new(gboolean has_detect)
 	for (i = 0; i < GEANY_ENCODINGS_MAX; i++)
 	{
 		gchar *encoding_string;
+
+		if (! encodings[i].supported)
+			continue;
 
 		switch (encodings[i].group)
 		{

--- a/src/encodings.c
+++ b/src/encodings.c
@@ -770,7 +770,7 @@ static gchar *encodings_convert_to_utf8_with_suggestion(const gchar *buffer, gss
 			else
 				continue;
 		}
-		else if (i >= 0)
+		else if (i >= 0 && encodings[i].supported)
 			charset = encodings[i].charset;
 		else /* in this case we have i == -2, continue to increase i and go ahead */
 			continue;

--- a/src/encodingsprivate.h
+++ b/src/encodingsprivate.h
@@ -46,6 +46,7 @@ typedef struct GeanyEncoding
 	GeanyEncodingGroup      group; /* Internally used member for grouping */
 	const gchar            *charset; /* String representation of the encoding, e.g. "ISO-8859-3" */
 	const gchar            *name; /* Translatable and descriptive name of the encoding, e.g. "South European" */
+	gboolean                supported; /* Whether this encoding is supported on the system */
 }
 GeanyEncoding;
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -89,7 +89,6 @@ static void on_show_notebook_tabs_toggled(GtkToggleButton *togglebutton, gpointe
 static void on_enable_plugins_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_use_folding_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_check_line_end_toggled(GtkToggleButton *togglebutton, gpointer user_data);
-static void on_open_encoding_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_sidebar_visible_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_prefs_print_radio_button_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 static void on_prefs_print_page_header_toggled(GtkToggleButton *togglebutton, gpointer user_data);
@@ -533,18 +532,11 @@ static void prefs_init_dialog(void)
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_new_encoding");
 	ui_encodings_combo_box_set_active_encoding(GTK_COMBO_BOX(widget), file_prefs.default_new_encoding);
 
-	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_open_encoding");
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget),
-			(file_prefs.default_open_encoding >= 0) ? TRUE : FALSE);
-	on_open_encoding_toggled(GTK_TOGGLE_BUTTON(widget), NULL);
-
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_open_encoding");
 	if (file_prefs.default_open_encoding >= 0)
-	{
 		ui_encodings_combo_box_set_active_encoding(GTK_COMBO_BOX(widget), file_prefs.default_open_encoding);
-	}
 	else
-		ui_encodings_combo_box_set_active_encoding(GTK_COMBO_BOX(widget), GEANY_ENCODING_UTF_8);
+		ui_encodings_combo_box_set_active_encoding(GTK_COMBO_BOX(widget), GEANY_ENCODINGS_MAX);
 
 	widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_eol");
 	if (file_prefs.default_eol_character >= 0 && file_prefs.default_eol_character < 3)
@@ -1006,13 +998,9 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_new_encoding");
 		file_prefs.default_new_encoding = ui_encodings_combo_box_get_active_encoding(GTK_COMBO_BOX(widget));
 
-		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "check_open_encoding");
-		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)))
-		{
-			widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_open_encoding");
-			file_prefs.default_open_encoding = ui_encodings_combo_box_get_active_encoding(GTK_COMBO_BOX(widget));
-		}
-		else
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_open_encoding");
+		file_prefs.default_open_encoding = ui_encodings_combo_box_get_active_encoding(GTK_COMBO_BOX(widget));
+		if (file_prefs.default_open_encoding >= GEANY_ENCODINGS_MAX)
 			file_prefs.default_open_encoding = -1;
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "combo_eol");
@@ -1547,15 +1535,6 @@ static void on_enable_plugins_toggled(GtkToggleButton *togglebutton, gpointer us
 }
 
 
-static void on_open_encoding_toggled(GtkToggleButton *togglebutton, gpointer user_data)
-{
-	gboolean sens = gtk_toggle_button_get_active(togglebutton);
-
-	gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "eventbox3"), sens);
-	gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "label_open_encoding"), sens);
-}
-
-
 static void on_sidebar_visible_toggled(GtkToggleButton *togglebutton, gpointer user_data)
 {
 	gboolean sens = gtk_toggle_button_get_active(togglebutton);
@@ -1664,23 +1643,24 @@ void prefs_show_dialog(void)
 		{
 			struct {
 				const gchar *combo, *renderer;
+				gboolean has_detect;
 			} names[] = {
-				{ "combo_new_encoding", "combo_new_encoding_renderer" },
-				{ "combo_open_encoding", "combo_open_encoding_renderer" }
+				{ "combo_new_encoding", "combo_new_encoding_renderer", FALSE },
+				{ "combo_open_encoding", "combo_open_encoding_renderer", TRUE }
 			};
 			guint i;
-			GtkTreeStore *encoding_list = encodings_encoding_store_new(FALSE);
 
 			for (i = 0; i < G_N_ELEMENTS(names); i++)
 			{
+				GtkTreeStore *encoding_list = encodings_encoding_store_new(names[i].has_detect);
 				GtkWidget *combo = ui_lookup_widget(ui_widgets.prefs_dialog, names[i].combo);
 
 				gtk_cell_layout_set_cell_data_func(GTK_CELL_LAYOUT(combo),
 						ui_builder_get_object(names[i].renderer),
 						encodings_encoding_store_cell_data_func, NULL, NULL);
 				gtk_combo_box_set_model(GTK_COMBO_BOX(combo), GTK_TREE_MODEL(encoding_list));
+				g_object_unref(encoding_list);
 			}
-			g_object_unref(encoding_list);
 		}
 
 		/* init the eol character combo box */
@@ -1813,8 +1793,6 @@ void prefs_show_dialog(void)
 				"toggled", G_CALLBACK(on_use_folding_toggled), NULL);
 		g_signal_connect(ui_lookup_widget(ui_widgets.prefs_dialog, "check_line_end"),
 				"toggled", G_CALLBACK(on_check_line_end_toggled), NULL);
-		g_signal_connect(ui_lookup_widget(ui_widgets.prefs_dialog, "check_open_encoding"),
-				"toggled", G_CALLBACK(on_open_encoding_toggled), NULL);
 		g_signal_connect(ui_lookup_widget(ui_widgets.prefs_dialog, "check_sidebar_visible"),
 				"toggled", G_CALLBACK(on_sidebar_visible_toggled), NULL);
 


### PR DESCRIPTION
An offspring of #3716, with small things on the improvement side rather than fixes.

* Merge 2 controls in the prefs dialog (no functional change intended, but gets rid of a checkbox and some UI code)
* Don't display unsupported encodings in the encoding menus and combo boxes (e.g. [ISO-8859-8-I](https://en.wikipedia.org/wiki/ISO-8859-8-I) and [HZ](https://en.wikipedia.org/wiki/HZ_(character_encoding)) are commonly unsupported on Linux, and I hear [ISO-IR-111](https://en.wikipedia.org/wiki/ISO-IR-111) usually isn't available on Windows)
* Don't try unsupported encodings when guessing encoding (because it's useless) -- yeah I know that's not UI, I lied