### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+# Before applying suggested PRs, make sure that the new versions of any
+# updated actions are allowed in
+# https://github.com/organizations/geany/settings/actions
+# Versions are pinned and restricted for security reasons.
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will cause dependabot to open PRs to bump any actions, such as "checkout" when never major versions are released.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file