### PR TITLE
Fix in-file encoding detection

### DIFF
--- a/src/encodings.c
+++ b/src/encodings.c
@@ -326,7 +326,7 @@ void encodings_select_radio_item(const gchar *charset)
 static GRegex *regex_compile(const gchar *pattern)
 {
 	GError *error = NULL;
-	GRegex *regex = g_regex_new(pattern, G_REGEX_CASELESS, 0, &error);
+	GRegex *regex = g_regex_new(pattern, G_REGEX_CASELESS | G_REGEX_RAW, 0, &error);
 
 	if (!regex)
 	{


### PR DESCRIPTION
This PR fixes a problem with in-file encoding detection described in #3777 where detection fails when the first 512 bytes isn't a valid UTF-8 string. The solution is to treat the first 512 bytes as raw bytes.