### PR TITLE
Remove "Use Windows native dialogs" GUI setting

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -1311,22 +1311,6 @@
                                     <property name="position">3</property>
                                   </packing>
                                 </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="check_native_windows_dialogs">
-                                    <property name="label" translatable="yes">Use Windows native dialogs</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Defines whether to use the Windows native dialogs or whether to use the GTK default dialogs</property>
-                                    <property name="use-underline">True</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">4</property>
-                                  </packing>
-                                </child>
                               </object>
                             </child>
                           </object>

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1751,9 +1751,6 @@ void prefs_show_dialog(void)
 		vte_append_preferences_tab();
 #endif
 
-#ifndef G_OS_WIN32
-		gtk_widget_hide(ui_lookup_widget(ui_widgets.prefs_dialog, "check_native_windows_dialogs"));
-#endif
 		ui_setup_open_button_callback(ui_lookup_widget(ui_widgets.prefs_dialog, "startup_path_button"), NULL,
 			GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, GTK_ENTRY(ui_lookup_widget(ui_widgets.prefs_dialog, "startup_path_entry")));
 		ui_setup_open_button_callback(ui_lookup_widget(ui_widgets.prefs_dialog, "extra_plugin_path_button"), NULL,


### PR DESCRIPTION
This is a left-over from #3219 and should have been removed already.

Fixes #3627.