### PR TITLE
meson: Prevent showing console after running geany in Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
   linux-meson:
     name: Linux Meson Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/meson.build
+++ b/meson.build
@@ -887,7 +887,8 @@ executable('geany',
 	dependencies: deps,
 	build_rpath: meson.build_root(),
 	install_rpath: '$ORIGIN/../' + get_option('libdir'),
-	install: true
+	install: true,
+	win_subsystem: 'windows',
 )
 
 i18n = import('i18n')

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('geany', 'c', 'cpp',
-        meson_version: '>= 0.53',
+        meson_version: '>= 0.56',
         version: '2.1',
         default_options : ['c_std=c11', 'cpp_std=c++17'])
 


### PR DESCRIPTION
Previously, a console window is shown in background when geany.exe is executed. This change fixes the above issue by specifying _windows_ subsystem type.