### PR TITLE
Add 'Open Terminal' and 'Open Directory' to right click menu

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -208,6 +208,204 @@
     <property name="stock">gtk-add</property>
     <property name="icon_size">1</property>
   </object>
+  <object class="GtkImage" id="image4056">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-new</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4057">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">geany-save-all</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4058">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-revert-to-saved</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4059">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-revert-to-saved</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4060">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-close</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4061">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">geany-close-all</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4062">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-cut</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4063">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-copy</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4064">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-indent</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4065">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-unindent</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4066">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-add</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4067">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-add</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4068">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-add</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4069">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-preferences</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4070">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-preferences</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4071">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-find</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4072">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-find-and-replace</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4073">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-go-down</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4074">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-go-up</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4075">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-jump-to</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4076">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-select-font</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4077">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-new</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4078">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-open</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4079">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-close</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4080">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-refresh</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4081">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-file</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4082">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-select-color</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image4083">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-help</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image5">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-print</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image6">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-find</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image7">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-new</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image8">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="stock">gtk-directory</property>
+    <property name="icon_size">1</property>
+  </object>
+  <object class="GtkImage" id="image9">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">utilities-terminal</property>
+    <property name="icon_size">1</property>
+  </object>
   <object class="GtkMenu" id="edit_menu1">
     <property name="can-focus">False</property>
     <child>
@@ -478,6 +676,28 @@
       </object>
     </child>
     <child>
+      <object class="GtkImageMenuItem" id="menu_open_terminal">
+        <property name="label" translatable="yes">Open Ter_minal</property>
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
+        <property name="image">image9</property>
+        <property name="use-stock">False</property>
+        <signal name="activate" handler="on_menu_open_terminal_activate" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="menu_open_directory">
+        <property name="label" translatable="yes">Open Di_rectory</property>
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="use-underline">True</property>
+        <property name="image">image8</property>
+        <property name="use-stock">False</property>
+        <signal name="activate" handler="on_menu_open_directory_activate" swapped="no"/>
+      </object>
+    </child>
+    <child>
       <object class="GtkImageMenuItem" id="menu_open_selected_file2">
         <property name="label" translatable="yes">Open Selected F_ile</property>
         <property name="visible">True</property>
@@ -530,192 +750,6 @@
         <signal name="activate" handler="on_context_action1_activate" swapped="no"/>
       </object>
     </child>
-  </object>
-  <object class="GtkImage" id="image4056">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-new</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4057">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">geany-save-all</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4058">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-revert-to-saved</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4059">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-revert-to-saved</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4060">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-close</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4061">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">geany-close-all</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4062">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-cut</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4063">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-copy</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4064">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-indent</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4065">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-unindent</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4066">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-add</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4067">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-add</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4068">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-add</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4069">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-preferences</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4070">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-preferences</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4071">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-find</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4072">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-find-and-replace</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4073">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-go-down</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4074">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-go-up</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4075">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-jump-to</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4076">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-select-font</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4077">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-new</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4078">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-open</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4079">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-close</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4080">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-refresh</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4081">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-file</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4082">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-select-color</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4083">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-help</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image5">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-print</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image6">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-find</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image7">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-new</property>
-    <property name="icon-size">1</property>
   </object>
   <object class="GtkListStore" id="indent_mode_list">
     <columns>
@@ -3951,17 +3985,6 @@
                                     <property name="can-focus">False</property>
                                     <property name="label-xalign">0</property>
                                     <property name="shadow-type">none</property>
-                                    <child type="label">
-                                      <object class="GtkCheckButton" id="check_line_end">
-                                        <property name="label" translatable="yes">Show line endings</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text" translatable="yes">Shows the line ending character</property>
-                                        <property name="use-underline">True</property>
-                                        <property name="draw-indicator">True</property>
-                                      </object>
-                                    </child>
                                     <child>
                                       <object class="GtkAlignment">
                                         <property name="visible">True</property>
@@ -3978,6 +4001,17 @@
                                             <property name="draw-indicator">True</property>
                                           </object>
                                         </child>
+                                      </object>
+                                    </child>
+                                    <child type="label">
+                                      <object class="GtkCheckButton" id="check_line_end">
+                                        <property name="label" translatable="yes">Show line endings</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Shows the line ending character</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                     </child>
                                   </object>
@@ -4903,7 +4937,7 @@
                               <object class="GtkTable" id="table1">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="n-rows">3</property>
+                                <property name="n-rows">4</property>
                                 <property name="n-columns">3</property>
                                 <property name="column-spacing">6</property>
                                 <property name="row-spacing">3</property>
@@ -4929,8 +4963,8 @@
                                     <property name="xalign">0</property>
                                   </object>
                                   <packing>
-                                    <property name="top-attach">1</property>
-                                    <property name="bottom-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                     <property name="x-options">GTK_FILL</property>
                                     <property name="y-options"/>
                                   </packing>
@@ -4961,8 +4995,8 @@
                                   <packing>
                                     <property name="left-attach">1</property>
                                     <property name="right-attach">2</property>
-                                    <property name="top-attach">1</property>
-                                    <property name="bottom-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                     <property name="y-options"/>
                                   </packing>
                                 </child>
@@ -5002,8 +5036,8 @@
                                   <packing>
                                     <property name="left-attach">2</property>
                                     <property name="right-attach">3</property>
-                                    <property name="top-attach">1</property>
-                                    <property name="bottom-attach">2</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="bottom-attach">3</property>
                                     <property name="x-options">GTK_FILL</property>
                                     <property name="y-options"/>
                                   </packing>
@@ -5017,8 +5051,8 @@
                                     <property name="xalign">0</property>
                                   </object>
                                   <packing>
-                                    <property name="top-attach">2</property>
-                                    <property name="bottom-attach">3</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
                                     <property name="x-options">GTK_FILL</property>
                                     <property name="y-options"/>
                                   </packing>
@@ -5033,8 +5067,8 @@
                                   <packing>
                                     <property name="left-attach">1</property>
                                     <property name="right-attach">2</property>
-                                    <property name="top-attach">2</property>
-                                    <property name="bottom-attach">3</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
                                     <property name="y-options"/>
                                   </packing>
                                 </child>
@@ -5054,8 +5088,61 @@
                                   <packing>
                                     <property name="left-attach">2</property>
                                     <property name="right-attach">3</property>
-                                    <property name="top-attach">2</property>
-                                    <property name="bottom-attach">3</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="bottom-attach">4</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="label27">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">File Manager:</property>
+                                    <property name="mnemonic-widget">entry_file_manager</property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="x-options">GTK_FILL</property>
+                                    <property name="y-options"/>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="entry_file_manager">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Path to your file manager of choice (%d is substituted with the directory to open)</property>
+                                    <property name="primary-icon-activatable">False</property>
+                                    <property name="secondary-icon-activatable">False</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="right-attach">2</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
+                                    <property name="y-options"/>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton" id="button_file_manager">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <child>
+                                      <object class="GtkImage" id="image10">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="stock">gtk-open</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="right-attach">3</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="bottom-attach">2</property>
                                     <property name="x-options">GTK_FILL</property>
                                     <property name="y-options"/>
                                   </packing>
@@ -8057,10 +8144,10 @@
                           <object class="GtkImageMenuItem" id="project_new_from_folder1">
                             <property name="label" translatable="yes">New from _Folder...</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="use_underline">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="use-underline">True</property>
                             <property name="image">image7</property>
-                            <property name="use_stock">False</property>
+                            <property name="use-stock">False</property>
                             <signal name="activate" handler="on_project_new_from_folder1_activate" swapped="no"/>
                           </object>
                         </child>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2536,9 +2536,13 @@ Tool paths
 ``````````
 
 Terminal
-    The command to execute a script in a terminal.  Occurrences of %c
+    The command to execute a script in a terminal. Occurrences of %c
     in the command are substituted with the run script name, see
     `Terminal emulators`_.
+
+File Manager
+	The command to use to open a file manager. Occurences of %d
+	are substituted with a directory in which to open it.
 
 Browser
     The location of your web browser executable.

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1432,6 +1432,80 @@ static void on_menu_project1_activate(GtkMenuItem *menuitem, gpointer user_data)
 						g_queue_get_length(ui_prefs.recent_projects_queue) > 0);
 }
 
+void on_menu_open_terminal_activate(GtkMenuItem *menuitem, gpointer user_data)
+{
+	gchar *doc_dir;
+	gchar *cmd_locale;
+	GError *error = NULL;
+
+	cmd_locale = utils_get_locale_from_utf8(tool_prefs.term_cmd);
+	utils_str_replace_all(&cmd_locale, "%c", "");
+
+	doc_dir = utils_get_current_file_dir_utf8();
+
+	/* If the current document is untitled, launch in the home directory */
+	if (!doc_dir)
+	{
+		doc_dir = utils_get_utf8_from_locale(g_get_home_dir());
+
+		if (EMPTY(doc_dir))
+		{
+			doc_dir = NULL;
+		}
+	}
+
+	if (!spawn_async(doc_dir, cmd_locale, NULL, NULL, NULL, &error))
+	{
+		gchar *cmd_utf8 = utils_get_utf8_from_locale(cmd_locale);
+
+		ui_set_statusbar(TRUE, _("Cannot launch terminal (%s: %s). Check the"
+		"Terminal setting in Tool Preferences"), cmd_utf8, error->message);
+
+		g_free(cmd_utf8);
+		g_error_free(error);
+	}
+
+	g_free(cmd_locale);
+	g_free(doc_dir);
+}
+
+void on_menu_open_directory_activate(GtkMenuItem *menuitem, gpointer user_data)
+{
+	gchar *doc_dir, *doc_dir_locale;
+	gchar *cmd_locale;
+	GError *error = NULL;
+
+	cmd_locale = utils_get_locale_from_utf8(tool_prefs.file_manager_cmd);
+
+	doc_dir = utils_get_current_file_dir_utf8();
+	doc_dir_locale = (doc_dir ? utils_get_locale_from_utf8(doc_dir)
+		: g_strdup(g_get_home_dir()));
+
+	if (doc_dir_locale)
+	{
+		utils_str_replace_all(&cmd_locale, "%d", "\"%d\"");
+		utils_str_replace_all(&cmd_locale, "%d", doc_dir_locale);
+	}
+	else
+	{
+		utils_str_replace_all(&cmd_locale, "%d", "");
+	}
+
+	if (!spawn_async(NULL, cmd_locale, NULL, NULL, NULL, &error))
+	{
+		gchar *cmd_utf8 = utils_get_utf8_from_locale(cmd_locale);
+
+		ui_set_statusbar(TRUE, _("Cannot launch file manager (%s: %s). Check the"
+		"File Manager setting in Tool Preferences"), cmd_utf8, error->message);
+
+		g_free(cmd_utf8);
+		g_error_free(error);
+	}
+
+	g_free(doc_dir_locale);
+	g_free(doc_dir);
+	g_free(cmd_locale);
+}
 
 void on_menu_open_selected_file1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -152,6 +152,10 @@ void on_project_close1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_project_properties1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
+void on_menu_open_terminal_activate(GtkMenuItem *menuitem, gpointer user_data);
+
+void on_menu_open_directory_activate(GtkMenuItem *menuitem, gpointer user_data);
+
 void on_menu_open_selected_file1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_remove_markers1_activate(GtkMenuItem *menuitem, gpointer user_data);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -73,37 +73,40 @@
 
 /* some default settings which are used at the very first start of Geany to fill
  * the configuration file */
-#define GEANY_MAX_SYMBOLLIST_HEIGHT		10
-#define GEANY_MIN_SYMBOLLIST_CHARS		4
-#define GEANY_MSGWIN_HEIGHT				208
-#define GEANY_DISK_CHECK_TIMEOUT		30
-#define GEANY_DEFAULT_TOOLS_MAKE		"make"
+#define GEANY_MAX_SYMBOLLIST_HEIGHT			10
+#define GEANY_MIN_SYMBOLLIST_CHARS			4
+#define GEANY_MSGWIN_HEIGHT					208
+#define GEANY_DISK_CHECK_TIMEOUT			30
+#define GEANY_DEFAULT_TOOLS_MAKE			"make"
 #ifdef G_OS_WIN32
-#define GEANY_DEFAULT_TOOLS_TERMINAL	"cmd.exe /Q /C %c"
+#define GEANY_DEFAULT_TOOLS_TERMINAL		"cmd.exe /Q /C %c"
+#define GEANY_DEFAULT_TOOLS_FILE_MANAGER	"explorer.exe %d"
 #elif defined(__APPLE__)
-#define GEANY_DEFAULT_TOOLS_TERMINAL	"open -a terminal %c"
+#define GEANY_DEFAULT_TOOLS_TERMINAL		"open -a terminal %c"
+#define GEANY_DEFAULT_TOOLS_FILE_MANAGER	"open %d"
 #else
-#define GEANY_DEFAULT_TOOLS_TERMINAL	"xterm -e \"/bin/sh %c\""
+#define GEANY_DEFAULT_TOOLS_TERMINAL		"xterm -e \"/bin/sh %c\""
+#define GEANY_DEFAULT_TOOLS_FILE_MANAGER	"xdg-open %d"
 #endif
 #ifdef __APPLE__
-#define GEANY_DEFAULT_TOOLS_BROWSER		"open -a safari"
-#define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Helvetica Medium 12"
-#define GEANY_DEFAULT_FONT_MSG_WINDOW	"Menlo Medium 12"
-#define GEANY_DEFAULT_FONT_EDITOR		"Menlo Medium 12"
+#define GEANY_DEFAULT_TOOLS_BROWSER			"open -a safari"
+#define GEANY_DEFAULT_FONT_SYMBOL_LIST		"Helvetica Medium 12"
+#define GEANY_DEFAULT_FONT_MSG_WINDOW		"Menlo Medium 12"
+#define GEANY_DEFAULT_FONT_EDITOR			"Menlo Medium 12"
 #else
 /* Browser chosen by GTK */
-#define GEANY_DEFAULT_TOOLS_BROWSER		""
-#define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Sans 9"
-#define GEANY_DEFAULT_FONT_MSG_WINDOW	"Monospace 9"
-#define GEANY_DEFAULT_FONT_EDITOR		"Monospace 10"
+#define GEANY_DEFAULT_TOOLS_BROWSER			""
+#define GEANY_DEFAULT_FONT_SYMBOL_LIST		"Sans 9"
+#define GEANY_DEFAULT_FONT_MSG_WINDOW		"Monospace 9"
+#define GEANY_DEFAULT_FONT_EDITOR			"Monospace 10"
 #endif
-#define GEANY_DEFAULT_TOOLS_PRINTCMD	"lpr"
-#define GEANY_DEFAULT_TOOLS_GREP		"grep"
-#define GEANY_DEFAULT_MRU_LENGTH		10
-#define GEANY_TOGGLE_MARK				"~ "
-#define GEANY_MAX_AUTOCOMPLETE_WORDS	30
-#define GEANY_MAX_SYMBOLS_UPDATE_FREQ	250
-#define GEANY_DEFAULT_FILETYPE_REGEX    "-\\*-\\s*([^\\s]+)\\s*-\\*-"
+#define GEANY_DEFAULT_TOOLS_PRINTCMD		"lpr"
+#define GEANY_DEFAULT_TOOLS_GREP			"grep"
+#define GEANY_DEFAULT_MRU_LENGTH			10
+#define GEANY_TOGGLE_MARK					"~ "
+#define GEANY_MAX_AUTOCOMPLETE_WORDS		30
+#define GEANY_MAX_SYMBOLS_UPDATE_FREQ		250
+#define GEANY_DEFAULT_FILETYPE_REGEX    	"-\\*-\\s*([^\\s]+)\\s*-\\*-"
 
 
 static gchar *scribble_text = NULL;
@@ -609,6 +612,7 @@ static void save_dialog_prefs(GKeyFile *config)
 
 	/* tools settings */
 	g_key_file_set_string(config, "tools", "terminal_cmd", tool_prefs.term_cmd ? tool_prefs.term_cmd : "");
+	g_key_file_set_string(config, "tools", "file_manager_cmd", tool_prefs.file_manager_cmd ? tool_prefs.file_manager_cmd : "");
 	g_key_file_set_string(config, "tools", "browser_cmd", tool_prefs.browser_cmd ? tool_prefs.browser_cmd : "");
 	g_key_file_set_string(config, "tools", "grep_cmd", tool_prefs.grep_cmd ? tool_prefs.grep_cmd : "");
 	g_key_file_set_string(config, PACKAGE, "context_action_cmd", tool_prefs.context_action_cmd);
@@ -1055,6 +1059,7 @@ static void load_dialog_prefs(GKeyFile *config)
 			SETPTR(cmd, g_strdup(GEANY_DEFAULT_TOOLS_TERMINAL));
 	}
 	tool_prefs.term_cmd = cmd;
+	tool_prefs.file_manager_cmd = utils_get_setting_string(config, "tools", "file_manager_cmd", GEANY_DEFAULT_TOOLS_FILE_MANAGER);
 	tool_prefs.browser_cmd = utils_get_setting_string(config, "tools", "browser_cmd", GEANY_DEFAULT_TOOLS_BROWSER);
 	tool_prefs.grep_cmd = utils_get_setting_string(config, "tools", "grep_cmd", GEANY_DEFAULT_TOOLS_GREP);
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -661,6 +661,9 @@ static void prefs_init_dialog(void)
 	if (tool_prefs.term_cmd)
 		gtk_entry_set_text(GTK_ENTRY(ui_lookup_widget(ui_widgets.prefs_dialog, "entry_com_term")), tool_prefs.term_cmd);
 
+	if (tool_prefs.file_manager_cmd)
+		gtk_entry_set_text(GTK_ENTRY(ui_lookup_widget(ui_widgets.prefs_dialog, "entry_file_manager")), tool_prefs.file_manager_cmd);
+
 	if (tool_prefs.browser_cmd)
 		gtk_entry_set_text(GTK_ENTRY(ui_lookup_widget(ui_widgets.prefs_dialog, "entry_browser")), tool_prefs.browser_cmd);
 
@@ -1136,6 +1139,10 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "entry_com_term");
 		g_free(tool_prefs.term_cmd);
 		tool_prefs.term_cmd = g_strdup(gtk_entry_get_text(GTK_ENTRY(widget)));
+
+		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "entry_file_manager");
+		g_free(tool_prefs.file_manager_cmd);
+		tool_prefs.file_manager_cmd = g_strdup(gtk_entry_get_text(GTK_ENTRY(widget)));
 
 		widget = ui_lookup_widget(ui_widgets.prefs_dialog, "entry_browser");
 		g_free(tool_prefs.browser_cmd);
@@ -1723,6 +1730,7 @@ void prefs_show_dialog(void)
 				"entry_toggle_mark",
 			/*	"entry_com_make", */
 				"entry_com_term",
+				"entry_file_manager",
 				"entry_browser",
 				"entry_grep",
 				"entry_contextaction",
@@ -1774,6 +1782,10 @@ void prefs_show_dialog(void)
 			NULL,
 			GTK_FILE_CHOOSER_ACTION_OPEN,
 			GTK_ENTRY(ui_lookup_widget(ui_widgets.prefs_dialog, "entry_com_term")));
+		ui_setup_open_button_callback(ui_lookup_widget(ui_widgets.prefs_dialog, "button_file_manager"),
+			NULL,
+			GTK_FILE_CHOOSER_ACTION_OPEN,
+			GTK_ENTRY(ui_lookup_widget(ui_widgets.prefs_dialog, "entry_file_manager")));
 		ui_setup_open_button_callback(ui_lookup_widget(ui_widgets.prefs_dialog, "button_browser"),
 			NULL,
 			GTK_FILE_CHOOSER_ACTION_OPEN,

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -48,8 +48,9 @@ GeanyPrefs;
 /** Tools preferences */
 typedef struct GeanyToolPrefs
 {
-	gchar			*browser_cmd;			/**< web browser command */
 	gchar			*term_cmd;				/**< terminal emulator command */
+	gchar			*file_manager_cmd;		/**< file manager command */
+	gchar			*browser_cmd;			/**< web browser command */
 	gchar			*grep_cmd;				/**< grep command */
 	gchar			*context_action_cmd;	/**< context action command */
 }


### PR DESCRIPTION
Hi, I'd like to propose the addition of two items in the right click menu, to open a terminal or file manager in the same directory as the current file. I often utilize these in my workflow versus the integrated terminal and tree browser, when I require something a bit more complex or something that's not one-off. But please do let me know if you also find them useful; suggestions for adjustments are welcome.

The right-click menu:

<img src="https://github.com/geany/geany/assets/31203804/ecacd2b2-7b96-49fa-b91e-118e0af9c336" width=30%>

For the file manager command to use, I took the initiative of adding a new entry in Preferences/Tools. For the terminal, I utilized the Terminal command that's already present.

<img src="https://github.com/geany/geany/assets/31203804/2a649b9a-a6c5-4316-99f9-231952273690" width=60%>

