### PR TITLE
[msgwin] Reset compiler/messages treeview width at start of build/search

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -792,6 +792,8 @@ static void build_spawn_cmd(GeanyDocument *doc, const gchar *cmd, const gchar *d
 	working_dir = utils_get_locale_from_utf8(utf8_working_dir);
 
 	gtk_list_store_clear(msgwindow.store_compiler);
+	// reset width after any long error messages
+	gtk_tree_view_columns_autosize(GTK_TREE_VIEW(msgwindow.tree_compiler));
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_COMPILER);
 	msgwin_compiler_add(COLOR_BLUE, _("%s (in directory: %s)"), cmd, utf8_working_dir);
 	g_free(utf8_working_dir);

--- a/src/search.c
+++ b/src/search.c
@@ -1562,6 +1562,15 @@ fail:
 }
 
 
+static void reset_msgwin(void)
+{
+	gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_MESSAGE);
+	gtk_list_store_clear(msgwindow.store_msg);
+	// reset width after any long messages
+	gtk_tree_view_columns_autosize(GTK_TREE_VIEW(msgwindow.tree_msg));
+}
+
+
 static GString *get_grep_options(void)
 {
 	GString *gstr = g_string_new("-nHI");	/* line numbers, filenames, ignore binaries */
@@ -1708,9 +1717,7 @@ search_find_in_files(const gchar *utf8_search_text, const gchar *utf8_dir, const
 			return FALSE;
 		}
 	}
-
-	gtk_list_store_clear(msgwindow.store_msg);
-	gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_MESSAGE);
+	reset_msgwin();
 
 	/* we can pass 'enc' without strdup'ing it here because it's a global const string and
 	 * always exits longer than the lifetime of this function */
@@ -2214,9 +2221,7 @@ void search_find_usage(const gchar *search_text, const gchar *original_search_te
 		utils_beep();
 		return;
 	}
-
-	gtk_notebook_set_current_page(GTK_NOTEBOOK(msgwindow.notebook), MSG_MESSAGE);
-	gtk_list_store_clear(msgwindow.store_msg);
+	reset_msgwin();
 
 	if (! in_session)
 	{	/* use current document */


### PR DESCRIPTION
If the previous build had a long error message, I have to scroll to the right. The next time I run a build command, the treeview is still scrolled to the right and I can't see all the normal length messages until I manually scroll back to the left. This pull resets the size of the treeview when a build is started, and the same for the Messages tab.