### PR TITLE
Fix Find in Files invalid directory error

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8824,7 +8824,7 @@
                   <object class="GtkEntry" id="entry_project_dialog_file_patterns">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="tooltip-text" translatable="yes">Space separated list of file patterns used for the find in files dialog (e.g. *.c *.h)</property>
+                    <property name="tooltip-text" translatable="yes">Space separated list of file patterns used for the Find in Files dialog (e.g. *.c *.h)</property>
                     <property name="invisible-char">•</property>
                     <property name="primary-icon-activatable">False</property>
                   </object>

--- a/src/search.c
+++ b/src/search.c
@@ -1628,7 +1628,7 @@ on_find_in_files_dialog_response(GtkDialog *dialog, gint response,
 			ui_encodings_combo_box_get_active_encoding(GTK_COMBO_BOX(fif_dlg.encoding_combo));
 
 		if (!g_file_test(locale_dir, G_FILE_TEST_IS_DIR))
-			dialogs_show_msgbox(GTK_MESSAGE_ERROR, _("Invalid directory for find in files."));
+			dialogs_show_msgbox(GTK_MESSAGE_ERROR, _("Invalid directory for Find in Files."));
 		else if (!EMPTY(search_text))
 		{
 			GString *opts = get_grep_options();

--- a/src/search.c
+++ b/src/search.c
@@ -1628,8 +1628,10 @@ on_find_in_files_dialog_response(GtkDialog *dialog, gint response,
 			ui_encodings_combo_box_get_active_encoding(GTK_COMBO_BOX(fif_dlg.encoding_combo));
 
 		if (!g_file_test(locale_dir, G_FILE_TEST_IS_DIR))
-			dialogs_show_msgbox(GTK_MESSAGE_ERROR, _("Invalid directory for Find in Files."));
-		else if (!EMPTY(search_text))
+			ui_set_statusbar(FALSE, _("Invalid directory for Find in Files."));
+		else if (EMPTY(search_text))
+			ui_set_statusbar(FALSE, _("No text to find."));
+		else
 		{
 			GString *opts = get_grep_options();
 			const gchar *enc = (enc_idx == GEANY_ENCODING_UTF_8) ? NULL :
@@ -1644,9 +1646,6 @@ on_find_in_files_dialog_response(GtkDialog *dialog, gint response,
 			}
 			g_string_free(opts, TRUE);
 		}
-		else
-			dialogs_show_msgbox(GTK_MESSAGE_ERROR, _("No text to find."));
-
 		g_free(locale_dir);
 	}
 	else
@@ -1927,7 +1926,7 @@ static GRegex *compile_regex(const gchar *str, GeanyFindFlags sflags)
 	regex = g_regex_new(str, rflags, 0, &error);
 	if (!regex)
 	{
-		dialogs_show_msgbox(GTK_MESSAGE_ERROR, _("Bad regex: %s"), error->message);
+		ui_set_statusbar(FALSE, _("Bad regex: %s"), error->message);
 		g_error_free(error);
 	}
 	return regex;

--- a/src/search.c
+++ b/src/search.c
@@ -1623,11 +1623,12 @@ on_find_in_files_dialog_response(GtkDialog *dialog, gint response,
 		GtkWidget *dir_combo = fif_dlg.dir_combo;
 		const gchar *utf8_dir =
 			gtk_entry_get_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(dir_combo))));
+		gchar *locale_dir = utils_get_locale_from_utf8(utf8_dir);
 		GeanyEncodingIndex enc_idx =
 			ui_encodings_combo_box_get_active_encoding(GTK_COMBO_BOX(fif_dlg.encoding_combo));
 
-		if (G_UNLIKELY(EMPTY(utf8_dir)))
-			ui_set_statusbar(FALSE, _("Invalid directory for find in files."));
+		if (!g_file_test(locale_dir, G_FILE_TEST_IS_DIR))
+			dialogs_show_msgbox(GTK_MESSAGE_ERROR, _("Invalid directory for find in files."));
 		else if (!EMPTY(search_text))
 		{
 			GString *opts = get_grep_options();
@@ -1644,7 +1645,9 @@ on_find_in_files_dialog_response(GtkDialog *dialog, gint response,
 			g_string_free(opts, TRUE);
 		}
 		else
-			ui_set_statusbar(FALSE, _("No text to find."));
+			dialogs_show_msgbox(GTK_MESSAGE_ERROR, _("No text to find."));
+
+		g_free(locale_dir);
 	}
 	else
 		gtk_widget_hide(fif_dlg.dialog);
@@ -1924,7 +1927,7 @@ static GRegex *compile_regex(const gchar *str, GeanyFindFlags sflags)
 	regex = g_regex_new(str, rflags, 0, &error);
 	if (!regex)
 	{
-		ui_set_statusbar(FALSE, _("Bad regex: %s"), error->message);
+		dialogs_show_msgbox(GTK_MESSAGE_ERROR, _("Bad regex: %s"), error->message);
 		g_error_free(error);
 	}
 	return regex;

--- a/src/search.c
+++ b/src/search.c
@@ -1123,6 +1123,8 @@ void search_show_find_in_files_dialog_full(const gchar *text, const gchar *dir)
 		g_free(cur_dir);
 	}
 
+	ui_set_search_entry_background(fif_dlg.search_combo, TRUE);
+	ui_set_search_entry_background(fif_dlg.dir_combo, TRUE);
 	update_fif_file_mode_combo();
 	update_file_patterns(fif_dlg.files_mode_combo, fif_dlg.files_combo);
 
@@ -1628,9 +1630,15 @@ on_find_in_files_dialog_response(GtkDialog *dialog, gint response,
 			ui_encodings_combo_box_get_active_encoding(GTK_COMBO_BOX(fif_dlg.encoding_combo));
 
 		if (!g_file_test(locale_dir, G_FILE_TEST_IS_DIR))
+		{
 			ui_set_statusbar(FALSE, _("Invalid directory for Find in Files."));
+			ui_set_search_entry_background(dir_combo, FALSE);
+		}
 		else if (EMPTY(search_text))
+		{
 			ui_set_statusbar(FALSE, _("No text to find."));
+			ui_set_search_entry_background(search_combo, FALSE);
+		}
 		else
 		{
 			GString *opts = get_grep_options();

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1101,8 +1101,13 @@ void ui_document_show_hide(GeanyDocument *doc)
 }
 
 
+/* success = FALSE indicates an error for widget */
 void ui_set_search_entry_background(GtkWidget *widget, gboolean success)
 {
+	// set the entry, not just the button
+	if (GTK_IS_COMBO_BOX(widget))
+		widget = gtk_bin_get_child(GTK_BIN(widget));
+
 	gtk_widget_set_name(widget, success ? NULL : "geany-search-entry-no-match");
 }
 


### PR DESCRIPTION
When the Find in Files path doesn't exist, the *status bar* says "Cannot execute grep tool...: Failed to change the working directory. Check the path setting in Preferences". Which is confusing and hides the real problem in the middle of irrelevant text. Instead, show a dialog with the correct error only.

Fixes #1347.

~~Also show dialogs for no search text & bad search regex errors, rather than status bar messages.~~