### PR TITLE
Tweak toggle additional widgets docs

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -1619,6 +1619,12 @@ translations, e.g.::
     key[de]=Hallo
     key[fr_FR]=Bonjour
 
+Toggle all additional widgets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Hide and show all additional widgets like the notebook tabs, the toolbar,
+the messages window and the status bar.
+
+
 Symbols and tags files
 ----------------------
 
@@ -2068,13 +2074,12 @@ Next to current
     Whether to place file tabs next to the current tab
     rather than at the edges of the notebook.
 
-Double-clicking hides all additional widgets
-    Whether to call the View->Toggle All Additional Widgets command
-    when double-clicking on a notebook tab.
-
 Tab label length
     If filenames are long, set the number of characters that should be
     visible on each tab's label.
+
+See also `document tab tips <#document-notebook>`_.
+
 
 Tab positions
 `````````````
@@ -3852,9 +3857,7 @@ Toggle Messages Window                                    Toggles the message wi
 
 Toggle Sidebar                                            Shows or hides the sidebar.
 
-Toggle all additional widgets                             Hide and show all additional widgets like the
-                                                          notebook tabs, the toolbar, the messages window
-                                                          and the status bar.
+Toggle all additional widgets                             See `here <#toggle-all-additional-widgets>`_.
 
 Zoom In                         Ctrl-+  (C)               Zooms in the text.
 
@@ -5547,8 +5550,8 @@ Document notebook
 * Middle-click on a document's notebook tab to close the document.
 * Hold `Ctrl` and click on any notebook tab to switch to the last used
   document.
-* Double-click on a document's notebook tab to toggle all additional
-  widgets (to show them again use the View menu or the keyboard
+* Double-click on a document's notebook tab to `toggle all additional
+  widgets`_ (to show them again use the View menu or the keyboard
   shortcut). The interface pref must be enabled for this to work.
 
 Editor


### PR DESCRIPTION
Describe under the View menu, add links.
Remove note from notebook interface prefs section - add link to document tab tips instead.