### PR TITLE
Add options to control scrollwheel behavior (zoom and scroll lines)

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2681,6 +2681,8 @@ indent_hard_tab_width             The size of a tab character. Don't change    8
 editor_ime_interaction            Input method editor (IME)'s candidate        0           to new
                                   window behaviour. May be 0 (windowed) or                 documents
                                   1 (inline)
+scrollwheel_zoom_disable          Disable zooming the editor view with         false       immediately
+                                  the scroll wheel.
 **``interface`` group**
 show_symbol_list_expanders        Whether to show or hide the small            true        to new
                                   expander icons on the symbol list                        documents

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2681,6 +2681,7 @@ indent_hard_tab_width             The size of a tab character. Don't change    8
 editor_ime_interaction            Input method editor (IME)'s candidate        0           to new
                                   window behaviour. May be 0 (windowed) or                 documents
                                   1 (inline)
+scrollwheel_lines                 Number of lines the scrollwheel scrolls      3           immediately
 scrollwheel_zoom_disable          Disable zooming the editor view with         false       immediately
                                   the scroll wheel.
 **``interface`` group**

--- a/src/editor.c
+++ b/src/editor.c
@@ -4779,7 +4779,8 @@ on_editor_scroll_event(GtkWidget *widget, GdkEventScroll *event, gpointer user_d
 	else if (!event->state || (editor_prefs.scrollwheel_zoom_disable && (event->state & GDK_CONTROL_MASK)))
 	{
 		/* scroll normally */
-		gint amount = (event->direction == GDK_SCROLL_DOWN) ? 3 : -3;
+		gint lines = editor_prefs.scrollwheel_lines;
+		gint amount = (event->direction == GDK_SCROLL_DOWN) ? lines : (-1 * lines);
 		sci_scroll_lines(editor->sci, amount);
 		return TRUE;
 	}

--- a/src/editor.c
+++ b/src/editor.c
@@ -4758,22 +4758,29 @@ on_editor_scroll_event(GtkWidget *widget, GdkEventScroll *event, gpointer user_d
 {
 	GeanyEditor *editor = user_data;
 
-	/* we only handle up and down, leave the rest to Scintilla */
+	/* Scintilla handles direct left/right scrolling */
 	if (event->direction != GDK_SCROLL_UP && event->direction != GDK_SCROLL_DOWN)
 		return FALSE;
 
-	/* Handle scroll events if Alt is pressed and scroll whole pages instead of a
-	 * few lines only, maybe this could/should be done in Scintilla directly */
 	if (event->state & GDK_MOD1_MASK)
 	{
-		sci_send_command(editor->sci, (event->direction == GDK_SCROLL_DOWN) ? SCI_PAGEDOWN : SCI_PAGEUP);
+		/* scroll whole pages when Alt is pressed */
+		gint amount = (event->direction == GDK_SCROLL_DOWN) ? SCI_PAGEDOWN : SCI_PAGEUP;
+		sci_send_command(editor->sci, amount);
 		return TRUE;
 	}
 	else if (event->state & GDK_SHIFT_MASK)
 	{
+		/* translate scrolling to left/right when Shift is pressed */
 		gint amount = (event->direction == GDK_SCROLL_DOWN) ? 8 : -8;
-
 		sci_scroll_columns(editor->sci, amount);
+		return TRUE;
+	}
+	else if (!event->state || (editor_prefs.scrollwheel_zoom_disable && (event->state & GDK_CONTROL_MASK)))
+	{
+		/* scroll normally */
+		gint amount = (event->direction == GDK_SCROLL_DOWN) ? 3 : -3;
+		sci_scroll_lines(editor->sci, amount);
 		return TRUE;
 	}
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -142,6 +142,7 @@ typedef struct GeanyEditorPrefs
 	gboolean	show_line_endings_only_when_differ;
 	gboolean	change_history_markers;
 	gboolean	change_history_indicators;
+	gboolean	scrollwheel_zoom_disable;
 }
 GeanyEditorPrefs;
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -142,6 +142,7 @@ typedef struct GeanyEditorPrefs
 	gboolean	show_line_endings_only_when_differ;
 	gboolean	change_history_markers;
 	gboolean	change_history_indicators;
+	gint		scrollwheel_lines;
 	gboolean	scrollwheel_zoom_disable;
 }
 GeanyEditorPrefs;

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -315,6 +315,8 @@ static void init_pref_groups(void)
 		"indent_hard_tab_width", 8);
 	stash_group_add_integer(group, &editor_prefs.ime_interaction,
 		"editor_ime_interaction", SC_IME_WINDOWED);
+	stash_group_add_integer(group, &editor_prefs.scrollwheel_lines,
+		"scrollwheel_lines", 3);
 	stash_group_add_boolean(group, &editor_prefs.scrollwheel_zoom_disable,
 		"scrollwheel_zoom_disable", FALSE);
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -315,6 +315,8 @@ static void init_pref_groups(void)
 		"indent_hard_tab_width", 8);
 	stash_group_add_integer(group, &editor_prefs.ime_interaction,
 		"editor_ime_interaction", SC_IME_WINDOWED);
+	stash_group_add_boolean(group, &editor_prefs.scrollwheel_zoom_disable,
+		"scrollwheel_zoom_disable", FALSE);
 
 	group = stash_group_new(PACKAGE);
 	configuration_add_various_pref_group(group, "files");

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -1018,6 +1018,12 @@ void sci_scroll_columns(ScintillaObject *sci, gint columns)
 }
 
 
+void sci_scroll_lines(ScintillaObject *sci, gint lines)
+{
+	SSM(sci, SCI_LINESCROLL, 0, (uptr_t) lines);
+}
+
+
 gint sci_search_next(ScintillaObject *sci, gint flags, const gchar *text)
 {
 	/* FIXME: SCI_SEACHNEXT() actually returns long */

--- a/src/sciwrappers.h
+++ b/src/sciwrappers.h
@@ -173,6 +173,7 @@ void				sci_goto_pos				(ScintillaObject *sci, gint pos, gboolean unfold);
 void				sci_set_search_anchor		(ScintillaObject *sci);
 void				sci_set_anchor				(ScintillaObject *sci, gint pos);
 void				sci_scroll_columns			(ScintillaObject *sci, gint columns);
+void				sci_scroll_lines				(ScintillaObject *sci, gint lines);
 gint				sci_search_next				(ScintillaObject *sci, gint flags, const gchar *text);
 gint				sci_search_prev				(ScintillaObject *sci, gint flags, const gchar *text);
 void				sci_marker_delete_all		(ScintillaObject *sci, gint marker);


### PR DESCRIPTION
This PR adds two options to control scrollwheel behavior.

* `scrollwheel_lines`: How many lines to scroll.
* `scrollwheel_zoom_disable`: To disable zooming by control + scrollwheel.

Control of vertical scrolling is taken away from Scintilla to provide consistent behavior when the control key is or is not pressed.  Lines option added because I don't see a way to get or set the value used by Scintilla.

Supersedes #2954 