### PR TITLE
Erlang: display module node in the symbols tree

### DIFF
--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -344,7 +344,7 @@ static TMParserMapGroup group_DOCBOOK[] = {
 static TMParserMapEntry map_ERLANG[] = {
 	{'d', tm_tag_macro_t},     // macro
 	{'f', tm_tag_function_t},  // function
-	{'m', tm_tag_undef_t},     // module
+	{'m', tm_tag_namespace_t}, // module
 	{'r', tm_tag_struct_t},    // record
 	{'t', tm_tag_typedef_t},   // type
 };
@@ -353,6 +353,7 @@ static TMParserMapGroup group_ERLANG[] = {
 	{N_("Structs"), TM_ICON_STRUCT, tm_tag_struct_t},
 	{N_("Typedefs / Enums"), TM_ICON_STRUCT, tm_tag_typedef_t},
 	{N_("Macros"), TM_ICON_MACRO, tm_tag_macro_t},
+	{N_("Module"), TM_ICON_NAMESPACE, tm_tag_namespace_t},
 };
 
 // no scope information

--- a/tests/ctags/maze.erl.tags
+++ b/tests/ctags/maze.erl.tags
@@ -2,6 +2,8 @@ buildÌ16ÎmazeÖ0
 function:   maze :: build
 generateÌ16ÎmazeÖ0
 function:   maze :: generate
+mazeÌ256Ö0
+namespace:  maze
 pickÌ16ÎmazeÖ0
 function:   maze :: pick
 scrambleÌ16ÎmazeÖ0

--- a/tests/ctags/test.erl.tags
+++ b/tests/ctags/test.erl.tags
@@ -6,5 +6,7 @@ function1Ã16Œtest÷0
 function:   test :: function1
 record1Ã2048÷0
 struct:     record1
+testÃ256÷0
+namespace:  test
 type1Ã4096÷0
 typedef:    type1


### PR DESCRIPTION
Properly display the module node itself in the symbols tree so it can be the module content's parent instead of having each content node showing the module name as prefix.

Fixes #2650.

This is a revamp of the old patch I suggested ages ago in #2650 but failed to PR/commit.

@fbrau can you test this and see if all is good for you?