### PR TITLE
 Improve Find/Replace dialog errors 

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -583,8 +583,6 @@ void search_show_find_dialog(void)
 		{
 			/* update the search text from current selection */
 			gtk_entry_set_text(GTK_ENTRY(find_dlg.entry), sel);
-			/* reset the entry widget's background colour */
-			ui_set_search_entry_background(find_dlg.entry, TRUE);
 		}
 		gtk_widget_grab_focus(find_dlg.entry);
 		set_dialog_position(find_dlg.dialog, find_dlg.position);
@@ -761,8 +759,6 @@ void search_show_replace_dialog(void)
 		{
 			/* update the search text from current selection */
 			gtk_entry_set_text(GTK_ENTRY(replace_dlg.find_entry), sel);
-			/* reset the entry widget's background colour */
-			ui_set_search_entry_background(replace_dlg.find_entry, TRUE);
 		}
 		gtk_widget_grab_focus(replace_dlg.find_entry);
 		set_dialog_position(replace_dlg.dialog, replace_dlg.position);
@@ -1301,6 +1297,9 @@ on_find_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 {
 	GtkWidget *combo = GTK_WIDGET(user_data);
 
+	/* reset the entry widget's background colour */
+	ui_set_search_entry_background(find_dlg.entry, TRUE);
+
 	gtk_window_get_position(GTK_WINDOW(find_dlg.dialog),
 		&find_dlg.position[0], &find_dlg.position[1]);
 
@@ -1451,6 +1450,10 @@ on_replace_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 	GeanyFindFlags search_flags_re;
 	gboolean search_backwards_re, search_replace_escape_re;
 	gchar *find, *replace, *original_find = NULL, *original_replace = NULL;
+
+	/* reset the entry widgets' background colour */
+	ui_set_search_entry_background(replace_dlg.find_entry, TRUE);
+	ui_set_search_entry_background(replace_dlg.replace_entry, TRUE);
 
 	gtk_window_get_position(GTK_WINDOW(replace_dlg.dialog),
 		&replace_dlg.position[0], &replace_dlg.position[1]);

--- a/src/search.c
+++ b/src/search.c
@@ -1329,7 +1329,8 @@ on_find_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 		if (EMPTY(search_data.text))
 		{
-			fail:
+			ui_set_statusbar(FALSE, _("No text to find."));
+		fail:
 			utils_beep();
 			gtk_widget_grab_focus(find_dlg.entry);
 			ui_set_search_entry_background(combo, FALSE);
@@ -1478,19 +1479,25 @@ on_replace_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 	search_replace_escape_re = settings.replace_escape_sequences;
 	find = g_strdup(gtk_entry_get_text(GTK_ENTRY(replace_dlg.find_entry)));
 	replace = g_strdup(gtk_entry_get_text(GTK_ENTRY(replace_dlg.replace_entry)));
-
-	search_flags_re = int_search_flags(settings.replace_case_sensitive,
-		settings.replace_match_whole_word, settings.replace_regexp,
-		settings.replace_regexp_multiline, settings.replace_match_word_start);
-
-	if ((response != GEANY_RESPONSE_FIND) && (search_flags_re & GEANY_FIND_MATCHCASE)
-		&& (strcmp(find, replace) == 0))
+	if (EMPTY(find))
 	{
+		ui_set_statusbar(FALSE, _("No text to find."));
 	fail:
 		utils_beep();
 		gtk_widget_grab_focus(replace_dlg.find_entry);
 		ui_set_search_entry_background(replace_dlg.find_entry, FALSE);
 		goto done;
+	}
+	search_flags_re = int_search_flags(settings.replace_case_sensitive,
+		settings.replace_match_whole_word, settings.replace_regexp,
+		settings.replace_regexp_multiline, settings.replace_match_word_start);
+
+	if ((response != GEANY_RESPONSE_FIND) &&
+		(search_flags_re & GEANY_FIND_MATCHCASE & ~GEANY_FIND_REGEXP) &&
+		(strcmp(find, replace) == 0))
+	{
+		ui_set_search_entry_background(replace_dlg.replace_entry, FALSE);
+		goto fail;
 	}
 	original_find = g_strdup(find);
 	original_replace = g_strdup(replace);

--- a/src/search.c
+++ b/src/search.c
@@ -1299,6 +1299,8 @@ static GeanyFindFlags int_search_flags(gint match_case, gint whole_word, gint re
 static void
 on_find_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 {
+	GtkWidget *combo = GTK_WIDGET(user_data);
+
 	gtk_window_get_position(GTK_WINDOW(find_dlg.dialog),
 		&find_dlg.position[0], &find_dlg.position[1]);
 
@@ -1319,7 +1321,8 @@ on_find_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 
 		g_free(search_data.text);
 		g_free(search_data.original_text);
-		search_data.text = g_strdup(gtk_entry_get_text(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(user_data)))));
+		search_data.text = g_strdup(gtk_entry_get_text(GTK_ENTRY(
+			gtk_bin_get_child(GTK_BIN(combo)))));
 		search_data.original_text = g_strdup(search_data.text);
 		search_data.flags = int_search_flags(settings.find_case_sensitive,
 			settings.find_match_whole_word, settings.find_regexp, settings.find_regexp_multiline,
@@ -1330,6 +1333,7 @@ on_find_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 			fail:
 			utils_beep();
 			gtk_widget_grab_focus(find_dlg.entry);
+			ui_set_search_entry_background(combo, FALSE);
 			return;
 		}
 		if (search_data.flags & GEANY_FIND_REGEXP)
@@ -1345,7 +1349,7 @@ on_find_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 			if (! utils_str_replace_escape(search_data.text, FALSE))
 				goto fail;
 		}
-		ui_combo_box_add_to_history(GTK_COMBO_BOX_TEXT(user_data), search_data.original_text, 0);
+		ui_combo_box_add_to_history(GTK_COMBO_BOX_TEXT(combo), search_data.original_text, 0);
 
 		switch (response)
 		{

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1101,8 +1101,13 @@ void ui_document_show_hide(GeanyDocument *doc)
 }
 
 
+/* success = FALSE indicates an error for widget */
 void ui_set_search_entry_background(GtkWidget *widget, gboolean success)
 {
+	// set the entry, not just the button
+	if (GTK_IS_COMBO_BOX(widget))
+		widget = gtk_bin_get_child(GTK_BIN(widget));
+
 	gtk_widget_set_name(widget, success ? NULL : "geany-search-entry-no-match");
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1046,9 +1046,11 @@ GIOChannel *utils_set_up_io_channel(
 }
 
 
-/* Contributed by Stefan Oltmanns, thanks.
+/* Replace escapes in place.
+ * Contributed by Stefan Oltmanns, thanks.
  * Replaces \\, \r, \n, \t and \uXXX by their real counterparts.
  * keep_backslash is used for regex strings to leave '\\' and '\?' in place */
+// See also g_strcompress which allocates.
 gboolean utils_str_replace_escape(gchar *string, gboolean keep_backslash)
 {
 	gsize i, j, len;


### PR DESCRIPTION
**Depends on #3828, merge that first.**

Show status message when there's no search text - like Find in Files does.
Don't error when find & replace text are the same and regex is enabled. E.g. when using `\1` in replace text, the result is not the same.
Also set replace background when find & replace text are the same.