### PR TITLE
Fix read past end of string in utils_get_initials()

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -768,17 +768,13 @@ gchar *utils_get_date_time(const gchar *format, time_t *time_to_use)
 
 gchar *utils_get_initials(const gchar *name)
 {
-	gint i = 1, j = 1;
 	gchar *initials = g_malloc0(5);
+	gsize name_len = strlen(name);
 
-	initials[0] = name[0];
-	while (name[i] != '\0' && j < 4)
+	for(gsize i = 0, j = 0; i < name_len && j < 4; i++)
 	{
-		if (name[i] == ' ' && name[i + 1] != ' ')
-		{
-			initials[j++] = name[i + 1];
-		}
-		i++;
+		if ((i == 0 || name[i - 1] == ' ') && name[i] != ' ')
+			initials[j++] = name[i];
 	}
 	return initials;
 }


### PR DESCRIPTION
Hi, this PR fixes this error spotted in Valgrind:

```
Invalid read of size 1
   at 0x49211F3: utils_get_initials (utils.c:775)
   by 0x48EBA56: load_dialog_prefs (keyfile.c:1025)
   by 0x48EBA56: read_config_file (keyfile.c:1258)
   by 0x48ED7C7: configuration_load (keyfile.c:1286)
   by 0x48EFBB7: load_settings (libmain.c:917)
   by 0x48EFBB7: main_lib (libmain.c:1154)
   by 0x5FC7CCF: (below main) (libc_start_call_main.h:58)
 Address 0xd21bfd1 is 0 bytes after a block of size 1 alloc'd
   at 0x4843788: malloc (vg_replace_malloc.c:442)
   by 0x5B26902: g_malloc (gmem.c:100)
   by 0x5B1BC2A: g_key_file_parse_value_as_string (gkeyfile.c:4310)
   by 0x5B1BD71: g_key_file_get_string (gkeyfile.c:1965)
   by 0x49213FF: utils_get_setting_string (utils.c:900)
   by 0x48EBA29: load_dialog_prefs (keyfile.c:1023)
   by 0x48EBA29: read_config_file (keyfile.c:1258)
   by 0x48ED7C7: configuration_load (keyfile.c:1286)
   by 0x48EFBB7: load_settings (libmain.c:917)
   by 0x48EFBB7: main_lib (libmain.c:1154)
   by 0x5FC7CCF: (below main) (libc_start_call_main.h:58)
```

I slightly reshaped `utils_get_initials()` to make it kinda more intuitive. It also got improved a bit, in that it now produces correct results when `name` begins with a space (which AFAICT doesn't really occur, but why not...)