### PR TITLE
Fix invalid memory access and Unicode support in utils_get_initials()

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -766,21 +766,37 @@ gchar *utils_get_date_time(const gchar *format, time_t *time_to_use)
 }
 
 
+/* Extracts initials from @p name, with basic Unicode support */
+GEANY_EXPORT_SYMBOL
 gchar *utils_get_initials(const gchar *name)
 {
-	gint i = 1, j = 1;
-	gchar *initials = g_malloc0(5);
+	GString *initials;
+	gchar *composed;
+	gboolean at_bound = TRUE;
 
-	initials[0] = name[0];
-	while (name[i] != '\0' && j < 4)
+	g_return_val_if_fail(name != NULL, NULL);
+
+	composed = g_utf8_normalize(name, -1, G_NORMALIZE_ALL_COMPOSE);
+	g_return_val_if_fail(composed != NULL, NULL);
+
+	initials = g_string_new(NULL);
+	for (const gchar *p = composed; *p; p = g_utf8_next_char(p))
 	{
-		if (name[i] == ' ' && name[i + 1] != ' ')
+		gunichar ch = g_utf8_get_char(p);
+
+		if (g_unichar_isspace(ch))
+			at_bound = TRUE;
+		else if (at_bound)
 		{
-			initials[j++] = name[i + 1];
+			const gchar *end = g_utf8_next_char(p);
+			g_string_append_len(initials, p, end - p);
+			at_bound = FALSE;
 		}
-		i++;
 	}
-	return initials;
+
+	g_free(composed);
+
+	return g_string_free(initials, FALSE);
 }
 
 

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -408,6 +408,28 @@ void test_utils_strv_shorten_file_list(void)
 	g_strfreev(data);
 }
 
+static void test_utils_get_initials(void)
+{
+#define CHECK_INITIALS(buf, initials)		\
+	G_STMT_START {							\
+		gchar *r = utils_get_initials(buf);	\
+		g_assert_cmpstr(r, ==, initials);	\
+		g_free(r);							\
+	} G_STMT_END
+
+	CHECK_INITIALS("John Doe", "JD");
+	CHECK_INITIALS(" John Doe ", "JD");
+	CHECK_INITIALS("John", "J");
+	CHECK_INITIALS("John F. Doe", "JFD");
+	CHECK_INITIALS("Gary Errol Anthony Nicholas Yales", "GEANY");
+	CHECK_INITIALS("", "");
+	CHECK_INITIALS("Åsa Åkesson", "ÅÅ"); /* composed */
+	CHECK_INITIALS("Åsa Åkesson", "ÅÅ"); /* decomposed */
+	CHECK_INITIALS("Œdipe", "Œ");
+
+#undef CHECK_INITIALS
+}
+
 int main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
@@ -416,6 +438,7 @@ int main(int argc, char **argv)
 	UTIL_TEST_ADD("strv_find_common_prefix", test_utils_strv_find_common_prefix);
 	UTIL_TEST_ADD("strv_find_lcs", test_utils_strv_find_lcs);
 	UTIL_TEST_ADD("strv_shorten_file_list", test_utils_strv_shorten_file_list);
+	UTIL_TEST_ADD("get_initals", test_utils_get_initials);
 
 	return g_test_run();
 }


### PR DESCRIPTION
Fix utils_get_initials() reading past the end of the input string if that string was empty.

Also fix support for non-ASCII initials for which the UTF-8 character representation would have been truncated to the first byte only, leading to an invalid value.

Fixes #3844.