### PR TITLE
Add various pref replace in session

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2754,6 +2754,9 @@ gio_unsafe_save_backup            Make a backup when using GIO unsafe file     f
 keep_edit_history_on_reload       Whether to maintain the edit history when    true        immediately
                                   reloading a file, and allow the operation
                                   to be reverted.
+show_keep_edit_history_on_reload_msg Whether to show a confirmation dialog to  true        immediately
+                                  drop the edit history on reloading a file,
+                                  see also `keep_edit_history_on_reload` above.
 reload_clean_doc_on_file_change   Whether to automatically reload documents    false       immediately
                                   that have no changes but which have changed
                                   on disk.

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2657,148 +2657,149 @@ Rarely used preferences, explained in the table below. A few of them require
 restart to take effect, and a few other will only affect newly opened or created
 documents before restart.
 
-================================  ===========================================  ==========  ===========
-Key                               Description                                  Default     Applies
-================================  ===========================================  ==========  ===========
+======================================== ============================================ ============ ===========
+Key                                      Description                                  Default      Applies
+======================================== ============================================ ============ ===========
 **``editor`` group**
-use_gtk_word_boundaries           Whether to look for the end of a word        true        to new
-                                  when using word-boundary related                         documents
-                                  Scintilla commands (see `Scintilla
-                                  keyboard commands`_).
-brace_match_ltgt                  Whether to highlight <, > angle brackets.    false       immediately
-complete_snippets_whilst_editing  Whether to allow completion of snippets      false       immediately
-                                  when editing an existing line (i.e. there
-                                  is some text after the current cursor
-                                  position on the line). Only used when the
-                                  keybinding `Complete snippet` is set to
-                                  ``Space``.
-show_editor_scrollbars            Whether to display scrollbars. If set to     true        immediately
-                                  false, the horizontal and vertical
-                                  scrollbars are hidden completely.
-indent_hard_tab_width             The size of a tab character. Don't change    8           immediately
-                                  it unless you really need to; use the
-                                  indentation settings instead.
-editor_ime_interaction            Input method editor (IME)'s candidate        0           to new
-                                  window behaviour. May be 0 (windowed) or                 documents
-                                  1 (inline)
+use_gtk_word_boundaries                  Whether to look for the end of a word        true         to new
+                                         when using word-boundary related                          documents
+                                         Scintilla commands (see `Scintilla
+                                         keyboard commands`_).
+brace_match_ltgt                         Whether to highlight <, > angle brackets.    false        immediately
+complete_snippets_whilst_editing         Whether to allow completion of snippets      false        immediately
+                                         when editing an existing line (i.e. there
+                                         is some text after the current cursor
+                                         position on the line). Only used when the
+                                         keybinding `Complete snippet` is set to
+                                         ``Space``.
+show_editor_scrollbars                   Whether to display scrollbars. If set to     true         immediately
+                                         false, the horizontal and vertical
+                                         scrollbars are hidden completely.
+indent_hard_tab_width                    The size of a tab character. Don't change    8            immediately
+                                         it unless you really need to; use the
+                                         indentation settings instead.
+editor_ime_interaction                   Input method editor (IME)'s candidate        0            to new
+                                         window behaviour. May be 0 (windowed) or                  documents
+                                         1 (inline)
 **``interface`` group**
-show_symbol_list_expanders        Whether to show or hide the small            true        to new
-                                  expander icons on the symbol list                        documents
-                                  treeview.
-compiler_tab_autoscroll           Whether to automatically scroll to the       true        immediately
-                                  last line of the output in the Compiler
-                                  tab.
-statusbar_template                The status bar statistics line format.       See below.  immediately
-                                  (See `Statusbar Templates`_ for details).
-new_document_after_close          Whether to open a new document after all     false       immediately
-                                  documents have been closed.
-msgwin_status_visible             Whether to show the Status tab in the        true        immediately
-                                  Messages Window
-msgwin_compiler_visible           Whether to show the Compiler tab in the      true        immediately
-                                  Messages Window
-msgwin_messages_visible           Whether to show the Messages tab in the      true        immediately
-                                  Messages Window
-msgwin_scribble_visible           Whether to show the Scribble tab in the      true        immediately
-                                  Messages Window
-warn_on_project_close             Whether to show a warning when opening       true        immediately
-                                  a project while one is already open.
+show_symbol_list_expanders               Whether to show or hide the small            true         to new
+                                         expander icons on the symbol list                         documents
+                                         treeview.
+compiler_tab_autoscroll                  Whether to automatically scroll to the       true         immediately
+                                         last line of the output in the Compiler
+                                         tab.
+statusbar_template                       The status bar statistics line format.       See below.   immediately
+                                         (See `Statusbar Templates`_ for details).
+new_document_after_close                 Whether to open a new document after all     false        immediately
+                                         documents have been closed.
+msgwin_status_visible                    Whether to show the Status tab in the        true         immediately
+                                         Messages Window
+msgwin_compiler_visible                  Whether to show the Compiler tab in the      true         immediately
+                                         Messages Window
+msgwin_messages_visible                  Whether to show the Messages tab in the      true         immediately
+                                         Messages Window
+msgwin_scribble_visible                  Whether to show the Scribble tab in the      true         immediately
+                                         Messages Window
+warn_on_project_close                    Whether to show a warning when opening       true         immediately
+                                         a project while one is already open.
 **``terminal`` group**
-send_selection_unsafe             By default, Geany strips any trailing        false       immediately
-                                  newline characters from the current
-                                  selection before sending it to the terminal
-                                  to not execute arbitrary code. This is
-                                  mainly a security feature.
-                                  If, for whatever reasons, you really want
-                                  it to be executed directly, set this option
-                                  to true.
-send_cmd_prefix                   String with which prefix the commands sent   Empty       immediately
-                                  to the shell.  This may be used to tell
-                                  some shells (BASH with ``HISTCONTROL`` set
-                                  to ``ignorespace``, ZSH with
-                                  ``HIST_IGNORE_SPACE`` enabled, etc.) from
-                                  putting these commands in their history by
-                                  setting this to a space.  Note that leading
-                                  spaces must be escaped using `\s` in the
-                                  configuration file.
+send_selection_unsafe                    By default, Geany strips any trailing        false        immediately
+                                         newline characters from the current
+                                         selection before sending it to the terminal
+                                         to not execute arbitrary code. This is
+                                         mainly a security feature.
+                                         If, for whatever reasons, you really want
+                                         it to be executed directly, set this option
+                                         to true.
+send_cmd_prefix                          String with which prefix the commands sent   Empty        immediately
+                                         to the shell.  This may be used to tell
+                                         some shells (BASH with ``HISTCONTROL`` set
+                                         to ``ignorespace``, ZSH with
+                                         ``HIST_IGNORE_SPACE`` enabled, etc.) from
+                                         putting these commands in their history by
+                                         setting this to a space.  Note that leading
+                                         spaces must be escaped using `\s` in the
+                                         configuration file.
 **``files`` group**
-allow_always_save                 Whether files can be saved always, even      false       immediately
-                                  if they don't have any changes.
-                                  By default, the Save button and menu
-                                  item are disabled when a file is
-                                  unchanged. When setting this option to
-                                  true, the Save button and menu item are
-                                  always active and files can be saved.
-use_atomic_file_saving            Defines the mode how Geany saves files to    false       immediately
-                                  disk. If disabled, Geany directly writes
-                                  the content of the document to disk. This
-                                  might cause loss of data when there is
-                                  no more free space on disk to save the
-                                  file. When set to true, Geany first saves
-                                  the contents into a temporary file and if
-                                  this succeeded, the temporary file is
-                                  moved to the real file to save.
-                                  This gives better error checking in case of
-                                  no more free disk space. But it also
-                                  destroys hard links of the original file
-                                  and its permissions (e.g. executable flags
-                                  are reset). Use this with care as it can
-                                  break things seriously.
-                                  The better approach would be to ensure your
-                                  disk won't run out of free space.
-use_gio_unsafe_file_saving        Whether to use GIO as the unsafe file        true        immediately
-                                  saving backend. It is better on most
-                                  situations but is known not to work
-                                  correctly on some complex setups.
-gio_unsafe_save_backup            Make a backup when using GIO unsafe file     false       immediately
-                                  saving. Backup is named `filename~`.
-keep_edit_history_on_reload       Whether to maintain the edit history when    true        immediately
-                                  reloading a file, and allow the operation
-                                  to be reverted.
-show_keep_edit_history_on_reload_msg Whether to show a confirmation dialog to  true        immediately
-                                  drop the edit history on reloading a file,
-                                  see also `keep_edit_history_on_reload` above.
-reload_clean_doc_on_file_change   Whether to automatically reload documents    false       immediately
-                                  that have no changes but which have changed
-                                  on disk.
-                                  If unsaved changes exist then the user is
-                                  prompted to reload manually.
-save_config_on_file_change        Automatically save Geany's configuration     true        immediately
-                                  to disk once the document list changes
-                                  (i.e. new documents are opened, saved or
-                                  closed). This helps to prevent accidentally
-                                  losing the session file list or other
-                                  changed settings when Geany is not shut
-                                  down cleanly. Disable this option if your
-                                  configuration directory is on a slow drive,
-                                  network share or similar and you experience
-                                  problems.
-extract_filetype_regex            Regex to extract filetype name from file     See link    immediately
-                                  via capture group one.
-                                  See `ft_regex`_ for default.
+allow_always_save                        Whether files can be saved always, even      false        immediately
+                                         if they don't have any changes.
+                                         By default, the Save button and menu
+                                         item are disabled when a file is
+                                         unchanged. When setting this option to
+                                         true, the Save button and menu item are
+                                         always active and files can be saved.
+use_atomic_file_saving                   Defines the mode how Geany saves files to    false        immediately
+                                         disk. If disabled, Geany directly writes
+                                         the content of the document to disk. This
+                                         might cause loss of data when there is
+                                         no more free space on disk to save the
+                                         file. When set to true, Geany first saves
+                                         the contents into a temporary file and if
+                                         this succeeded, the temporary file is
+                                         moved to the real file to save.
+                                         This gives better error checking in case of
+                                         no more free disk space. But it also
+                                         destroys hard links of the original file
+                                         and its permissions (e.g. executable flags
+                                         are reset). Use this with care as it can
+                                         break things seriously.
+                                         The better approach would be to ensure your
+                                         disk won't run out of free space.
+use_gio_unsafe_file_saving               Whether to use GIO as the unsafe file        true         immediately
+                                         saving backend. It is better on most
+                                         situations but is known not to work
+                                         correctly on some complex setups.
+gio_unsafe_save_backup                   Make a backup when using GIO unsafe file     false        immediately
+                                         saving. Backup is named `filename~`.
+keep_edit_history_on_reload              Whether to maintain the edit history when    true         immediately
+                                         reloading a file, and allow the operation
+                                         to be reverted.
+show_keep_edit_history_on_reload_msg     Whether to show a confirmation dialog to     true         immediately
+                                         drop the edit history on reloading a file,
+                                         see also `keep_edit_history_on_reload`
+                                         above.
+reload_clean_doc_on_file_change          Whether to automatically reload documents    false        immediately
+                                         that have no changes but which have changed
+                                         on disk.
+                                         If unsaved changes exist then the user is
+                                         prompted to reload manually.
+save_config_on_file_change               Automatically save Geany's configuration     true         immediately
+                                         to disk once the document list changes
+                                         (i.e. new documents are opened, saved or
+                                         closed). This helps to prevent accidentally
+                                         losing the session file list or other
+                                         changed settings when Geany is not shut
+                                         down cleanly. Disable this option if your
+                                         configuration directory is on a slow drive,
+                                         network share or similar and you experience
+                                         problems.
+extract_filetype_regex                   Regex to extract filetype name from file     See link     immediately
+                                         via capture group one.
+                                         See `ft_regex`_ for default.
 **``search`` group**
-find_selection_type               See `Find selection`_.                       0           immediately
-replace_and_find_by_default       Set ``Replace & Find`` button as default so  true        immediately
-                                  it will be activated when the Enter key is
-                                  pressed while one of the text fields has
-                                  focus.
-skip_confirmation_for_replace_in_session If set, do *not* show the             false       immediately
-                                  confirmation dialog before replacing text
-                                  in the whole session, i.e. in all open
-                                  files.
+find_selection_type                      See `Find selection`_.                       0            immediately
+replace_and_find_by_default              Set ``Replace & Find`` button as default so  true         immediately
+                                         it will be activated when the Enter key is
+                                         pressed while one of the text fields has
+                                         focus.
+skip_confirmation_for_replace_in_session If set, do *not* show the                    false        immediately
+                                         confirmation dialog before replacing text
+                                         in the whole session, i.e. in all open
+                                         files.
 **``build`` group**
-number_ft_menu_items              The maximum number of menu items in the      2           on restart
-                                  filetype build section of the Build menu.
-number_non_ft_menu_items          The maximum number of menu items in the      3           on restart
-                                  independent build section.
-number_exec_menu_items            The maximum number of menu items in the      2           on restart
-                                  execute section of the Build menu.
+number_ft_menu_items                     The maximum number of menu items in the      2            on restart
+                                         filetype build section of the Build menu.
+number_non_ft_menu_items                 The maximum number of menu items in the      3            on restart
+                                         independent build section.
+number_exec_menu_items                   The maximum number of menu items in the      2            on restart
+                                         execute section of the Build menu.
 **``socket`` group**
-socket_remote_cmd_port            TCP port number to be used for inter         2           on restart
-                                  process communication (i.e. with other
-                                  Geany instances, e.g. "Open with Geany").
-                                  Only available on Windows, valid port
-                                  range: 1024 to 65535.
-================================  ===========================================  ==========  ===========
+socket_remote_cmd_port                   TCP port number to be used for inter         2            on restart
+                                         process communication (i.e. with other
+                                         Geany instances, e.g. "Open with Geany").
+                                         Only available on Windows, valid port
+                                         range: 1024 to 65535.
+======================================== ============================================ ============ ===========
 
 Statusbar Templates
 ```````````````````

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2778,6 +2778,10 @@ replace_and_find_by_default       Set ``Replace & Find`` button as default so  t
                                   it will be activated when the Enter key is
                                   pressed while one of the text fields has
                                   focus.
+skip_confirmation_for_replace_in_session If set, do *not* show the             false       immediately
+                                  confirmation dialog before replacing text
+                                  in the whole session, i.e. in all open
+                                  files.
 **``build`` group**
 number_ft_menu_items              The maximum number of menu items in the      2           on restart
                                   filetype build section of the Build menu.

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -345,6 +345,8 @@ static void init_pref_groups(void)
 		"find_selection_type", GEANY_FIND_SEL_CURRENT_WORD);
 	stash_group_add_boolean(group, &search_prefs.replace_and_find_by_default,
 		"replace_and_find_by_default", TRUE);
+	stash_group_add_boolean(group, &search_prefs.skip_confirmation_for_replace_in_session,
+		"skip_confirmation_for_replace_in_session", FALSE);
 
 	group = stash_group_new(PACKAGE);
 	configuration_add_various_pref_group(group, "socket");

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -57,7 +57,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 247
+#define GEANY_API_VERSION 248
 
 /* hack to have a different ABI when built with different GTK major versions
  * because loading plugins linked to a different one leads to crashes.

--- a/src/search.c
+++ b/src/search.c
@@ -1462,7 +1462,8 @@ on_replace_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 	}
 
 	if (response == GEANY_RESPONSE_REPLACE_IN_SESSION) {
-		if (! dialogs_show_question_full(replace_dlg.dialog, NULL, NULL,
+		if (!search_prefs.skip_confirmation_for_replace_in_session &&
+			! dialogs_show_question_full(replace_dlg.dialog, NULL, NULL,
 			_("This operation will modify all open files which contain the text to replace."),
 			_("Are you sure to replace in the whole session?"))) {
 			return;

--- a/src/search.h
+++ b/src/search.h
@@ -60,6 +60,8 @@ typedef struct GeanySearchPrefs
 	gboolean	use_current_file_dir;	/* find in files directory to use on showing dialog */
 	gboolean	hide_find_dialog;		/* hide the find dialog on next or previous */
 	gboolean	replace_and_find_by_default;	/* enter in replace window performs Replace & Find instead of Replace */
+	gboolean	skip_confirmation_for_replace_in_session;	/* do *not* ask for confirmation
+															   before using "replace in session */
 	GeanyFindSelOptions find_selection_type;
 }
 GeanySearchPrefs;


### PR DESCRIPTION
Allow brave users to disable the confirmation dialog when replacing text in the whole session.

While modifying the docs, I noticed a missing various pref in the table and added it.
Because of the long names of the other and the new setting, the table grew and needed reformatting. I put this into a separate commit for easier review but we can probably squash them together afterwards.

Closes #3702.