### PR TITLE
meson: Use host instead of target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -168,7 +168,7 @@ cdata.set_quoted('REVISION', revision)
 
 python_command = get_option('python-command')
 if python_command == '' or python_command == 'auto'
-	if target_machine.system() == 'windows'
+	if host_machine.system() == 'windows'
 		python_command = 'py'
 	else
 		python_command = 'python'
@@ -213,7 +213,7 @@ endforeach
 geany_cflags = def_cflags
 have_gcc4_visibility = cc.has_argument('-fvisibility=hidden')
 geany_cflags += '-DGEANY_PRIVATE'
-if target_machine.system() == 'windows'
+if host_machine.system() == 'windows'
 	geany_cflags += '-DGEANY_EXPORT_SYMBOL=__declspec(dllexport)'
 elif have_gcc4_visibility
 	geany_cflags += '-fvisibility=hidden'


### PR DESCRIPTION
They are gonna be the same in practice, but it's not how "target" is supposed to be used[^1][^2].

Streamline this to use "host", which also makes things match our Autotools closer.

[^1]: https://mesonbuild.com/Cross-compilation.html
[^2]: https://www.gnu.org/software/autoconf/manual/html_node/Specifying-Target-Triplets.html