### PR TITLE
Fix crash by protecting tm_ctags_*() functions against TM_PARSER_NONE

### DIFF
--- a/src/tagmanager/tm_ctags.c
+++ b/src/tagmanager/tm_ctags.c
@@ -444,6 +444,9 @@ void tm_ctags_parse(guchar *buffer, gsize buffer_size,
 {
 	g_return_if_fail(buffer != NULL || file_name != NULL);
 
+	if (language == TM_PARSER_NONE)
+		return;
+
 	parseRawBuffer(file_name, buffer, buffer_size, language, source_file);
 
 	rename_anon_tags(source_file);
@@ -452,6 +455,9 @@ void tm_ctags_parse(guchar *buffer, gsize buffer_size,
 
 const gchar *tm_ctags_get_lang_name(TMParserType lang)
 {
+	if (lang == TM_PARSER_NONE)
+		return "unknown";
+
 	return getLanguageName(lang);
 }
 
@@ -464,9 +470,14 @@ TMParserType tm_ctags_get_named_lang(const gchar *name)
 
 const gchar *tm_ctags_get_lang_kinds(TMParserType lang)
 {
-	guint kind_num = countLanguageKinds(lang);
 	static gchar kinds[257];
+	guint kind_num;
 	guint i;
+
+	if (lang == TM_PARSER_NONE)
+		return "";
+
+	kind_num = countLanguageKinds(lang);
 
 	for (i = 0; i < kind_num; i++)
 		kinds[i] = getLanguageKind(lang, i)->letter;
@@ -478,14 +489,22 @@ const gchar *tm_ctags_get_lang_kinds(TMParserType lang)
 
 const gchar *tm_ctags_get_kind_name(gchar kind, TMParserType lang)
 {
-	kindDefinition *def = getLanguageKindForLetter(lang, kind);
+	kindDefinition *def = NULL;
+
+	if (lang != TM_PARSER_NONE)
+		def = getLanguageKindForLetter(lang, kind);
+
 	return def ? def->name : "unknown";
 }
 
 
 gchar tm_ctags_get_kind_from_name(const gchar *name, TMParserType lang)
 {
-	kindDefinition *def = getLanguageKindForName(lang, name);
+	kindDefinition *def = NULL;
+
+	if (lang != TM_PARSER_NONE)
+		def = getLanguageKindForName(lang, name);
+
 	return def ? def->letter : '-';
 }
 


### PR DESCRIPTION
This can happen when in the filetype configuration we set
```ini
[settings]
tag_parser=
```
This then leads to this crash in the ctags code:
```
#0  countKinds (kcb=0x0) at main/kind.c:230
#1  0x0000fffff7e802c8 in countLanguageKinds (language=language@entry=-2)
    at main/parse.c:300
#2  0x0000fffff7e15f88 in tm_ctags_get_lang_kinds (lang=lang@entry=-2)
    at tm_ctags.c:467
#3  0x0000fffff7e173e8 in read_ctags_file
    (file_tags=0xaaaaaad7e260, lang=-2, tags_file=0xaaaaaaf86de0 "/usr/local/share/geany/tags/std.py.tags") at tm_source_file.c:313
#4  tm_source_file_read_tags_file
    (tags_file=tags_file@entry=0xaaaaaaf86de0 "/usr/local/share/geany/tags/std.py.tags", mode=-2) at tm_source_file.c:552
#5  0x0000fffff7e1a4dc in tm_workspace_load_global_tags
    (tags_file=tags_file@entry=0xaaaaaaf86de0 "/usr/local/share/geany/tags/std.py.tags", mode=<optimized out>) at tm_workspace.c:379
#6  0x0000fffff7c9937c in symbols_load_global_tags
    (tags_file=0xaaaaaaf86de0 "/usr/local/share/geany/tags/std.py.tags", ft=ft@entry=0xaaaaab4cdf40) at symbols.c:166
#7  0x0000fffff7c997bc in load_user_tags (ft_id=GEANY_FILETYPES_PYTHON)
    at symbols.c:1377
#8  symbols_global_tags_loaded (file_type_idx=<optimized out>) at symbols.c:193
#9  0x0000fffff7c53bdc in document_load_config
    (doc=0xaaaaac1c90d0, type=0xaaaaab4cdf40, filetype_changed=<optimized out>)
    at document.c:2820
#10 0x0000fffff7c53cc8 in document_set_filetype
    (doc=0xaaaaac1c90d0, type=0xaaaaab4cdf40) at document.c:2859
#11 0x0000fffff7c55ac4 in document_open_file_full (doc=<optimized out>, 
    doc@entry=0x0, filename=<optimized out>, pos=pos@entry=0, readonly=readonly@entry=0, ft=ft@entry=0x0, forced_enc=forced_enc@entry=0x0) at document.c:1490
#12 0x0000fffff7c55b00 in document_open_file
    (locale_filename=<optimized out>, readonly=readonly@entry=0, ft=ft@entry=0x0, forced_enc=forced_enc@entry=0x0) at document.c:904
```

Until there's some LSP support in Geany, setting `tag_parser` to the empty value is necessary to disable ctags parsing so it doesn't clash with the LSP implementation.