### PR TITLE
Remove custom WIN32 compiler macro in favor of _WIN32

### DIFF
--- a/ctags/gnu_regex/regex_internal.h
+++ b/ctags/gnu_regex/regex_internal.h
@@ -418,7 +418,7 @@ static unsigned int re_string_context_at (const re_string_t *input, int idx,
 #define re_string_skip_bytes(pstr,idx) ((pstr)->cur_idx += (idx))
 #define re_string_set_index(pstr,idx) ((pstr)->cur_idx = (idx))
 
-#ifdef WIN32
+#ifdef _WIN32
 # include <malloc.h>
 #else
 # include <alloca.h>

--- a/m4/geany-mingw.m4
+++ b/m4/geany-mingw.m4
@@ -6,7 +6,6 @@ AC_DEFUN([GEANY_CHECK_MINGW],
 [
 	case "${host}" in
 		*mingw*)
-			AC_DEFINE([WIN32], [1], [we are cross compiling for WIN32])
 			GEANY_CHECK_VTE([no])
 			GEANY_CHECK_SOCKET([yes])
 			AM_CONDITIONAL([MINGW], true)


### PR DESCRIPTION
Closes #3660.