### PR TITLE
Windows: Add glib-compile-schemas.exe to GTK bundle

### DIFF
--- a/geany.nsi.in
+++ b/geany.nsi.in
@@ -274,6 +274,8 @@ Section -AdditionalIcons
 SectionEnd
 
 Section -Post
+	Exec '"$INSTDIR\bin\glib-compile-schemas.exe" "$INSTDIR\share\glib-2.0\schemas"'
+
 	WriteUninstaller "$INSTDIR\uninst.exe"
 	WriteRegStr SHCTX "${PRODUCT_DIR_REGKEY}" Path "$INSTDIR"
 	WriteRegStr SHCTX "${PRODUCT_UNINST_KEY}" "StartMenu" "$SMPROGRAMS\$StartmenuFolder"

--- a/scripts/gtk-bundle-from-msys2.sh
+++ b/scripts/gtk-bundle-from-msys2.sh
@@ -247,8 +247,8 @@ cleanup_unnecessary_files() {
 	rm -rf share/vala
 	rm -rf share/xml
 	rm -rf usr/share/libalpm
-	# cleanup binaries and libs (delete anything except *.dll and GSpawn helper binaries)
-	find bin ! -name '*.dll' ! -name 'grep.exe' ! -name 'gspawn-win32-helper*.exe' -type f -delete
+	# cleanup binaries and libs (delete anything except *.dll, glib-compile-schemas and GSpawn helper binaries)
+	find bin ! -name '*.dll' ! -name 'grep.exe' ! -name 'gspawn-win32-helper*.exe' ! -name 'glib-compile-schemas.exe' -type f -delete
 	# cleanup empty directories
 	find . -type d -empty -delete
 }


### PR DESCRIPTION
This is necessary to compile GLib schemas, e.g. when installing plugins     with their dependencies.

It is not strictly necessary to compile the schemas again on installation as they are already compiled during the bundle creation but it probably won't hurt and might be useful if installing Geany over an existing installation.

When the command is executed by the installer a little black console window pops up for a very small fraction of a second. I guess we can live with this.