### PR TITLE
Explicitly link to libpthread if available

### DIFF
--- a/m4/geany-lib.m4
+++ b/m4/geany-lib.m4
@@ -47,6 +47,10 @@ dnl set these variables accordingly. For now its the same as if not specified (0
 	LIBGEANY_CFLAGS="${LIBGEANY_EXPORT_CFLAGS}"
 	LIBGEANY_LDFLAGS="-version-info ${libgeany_current}:${libgeany_revision}:${libgeany_age}"
 
+	dnl Scintilla requires the C++ threads implementation, which on GCC requires
+	dnl linking to libpthread -- using -pthread via gthread-2.0 is not enough.
+	AC_SEARCH_LIBS([pthread_create], [pthread])
+
 	AC_SUBST([LIBGEANY_CFLAGS])
 	AC_SUBST([LIBGEANY_LDFLAGS])
 


### PR DESCRIPTION
Scintilla requires C++ threads which at least on GCC 8 Linux requires explicitly linking to libpthread.

This fixes building with `-Wl,-z,defs` linker flags on GCC 8.

---

This was under Debian Buster (10, fairly old I agree), it seems to work fine without on my usual machine on Bookworm (12).  Is there a downside of linking pthreads?