### PR TITLE
Fix a problem when multiple project opens clear the default session

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -1100,7 +1100,8 @@ static gboolean load_config(const gchar *filename)
 	/* save current (non-project) session (it could have been changed since program startup) */
 	if (!main_status.opening_session_files)
 	{
-		configuration_save_default_session();
+		if (have_session_docs())
+			configuration_save_default_session();
 		/* now close all open files */
 		document_close_all();
 	}

--- a/src/project.c
+++ b/src/project.c
@@ -1100,6 +1100,11 @@ static gboolean load_config(const gchar *filename)
 	/* save current (non-project) session (it could have been changed since program startup) */
 	if (!main_status.opening_session_files)
 	{
+		/* Opening another project while some project is already opene causes
+		 * that upon closing the first project, empty session is saved here.
+		 * The check below prevents that but has a side-effect that when
+		 * save_config_on_file_change=FALSE, the session with all closed files
+		 * isn't saved when opening a project. */
 		if (have_session_docs())
 			configuration_save_default_session();
 		/* now close all open files */


### PR DESCRIPTION
Steps to reproduce:
1. With no project open, open some files
2. Open project A
3. Without closing project A first, open project B
4. Close project B
5. The originally open files from (1) are gone

The problem is that when project A closes and all its files are closed, load_config() gets called which contains

configuration_save_default_session();

This saves the session with all files closed and replaces the original session.

This patch modifies the code to call configuration_save_default_session() only when there are some open tabs so the above problem gets solved.

Even though I was worried that this would break saving default session when all its files get closed and then a project is loaded, it doesn't seem to be the case (I haven't investigated deep enough why).

An alternative to this approach would be to pass a boolean as a parameter of quite many functions and propagate the information whether project close preceded its opening but it introduces a much bigger diff and makes the complicated session opening stuff even wilder.

Fixes #3897.