### PR TITLE
Preliminary support of multiple carets

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -324,6 +324,11 @@ static gboolean on_editor_button_press_event(GtkWidget *widget, GdkEventButton *
 				keybindings_send_command(GEANY_KEY_GROUP_GOTO, GEANY_KEYS_GOTO_MATCHINGBRACE);
 			return TRUE;
 		}
+		if (event->type == GDK_BUTTON_PRESS && event->state == GDK_MOD1_MASK)
+		{
+			SSM(doc->editor->sci, SCI_ADDSELECTION, editor_info.click_pos, editor_info.click_pos);
+			return TRUE;
+		}
 		return document_check_disk_status(doc, FALSE);
 	}
 


### PR DESCRIPTION
This is just a quick test of multiple carets for Geany. IMO we don't need a full support of everything working on multiple carets, users typically just need to insert/delete things at multiple places simultaneously for which this is sufficient.

Ideally, this should be mapped to alt+click as this is what vscode does and also we use alt+shift for the block caret. I only did run into a problem on macOS where (currently in a virtual machine) I get `GDK_MODIFIER_RESERVED_25_MASK` instead of  `GDK_MOD1_MASK` but I'm always confused with GDK events so I'm maybe doing something wrong.

(Comparing to the LSP plugin, the ratio of the number of thumbs up for this feature to the amount of time spent on implementing it is quite favorable ;-)

Fixes #1141