### PR TITLE
Fix elevated CPU usage after ui_progress_bar_start/stop() is used

### DIFF
--- a/src/printing.c
+++ b/src/printing.c
@@ -292,6 +292,8 @@ static void end_print(GtkPrintOperation *operation, GtkPrintContext *context, gp
 	if (dinfo == NULL)
 		return;
 
+	/* see ui_progress_bar_stop() for more details on why this is called */
+	gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(main_widgets.progressbar), 0.0);
 	gtk_widget_hide(main_widgets.progressbar);
 	g_object_unref(dinfo->sci);
 	g_object_unref(dinfo->layout);

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2871,6 +2871,10 @@ void ui_progress_bar_stop(void)
 		g_source_remove(progress_bar_timer_id);
 		progress_bar_timer_id = 0;
 	}
+
+	/* hack to remove tick callback which is created for "activity mode" progress
+	 * bars - without this it is called forever and causes elevated CPU usage */
+	gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(main_widgets.progressbar), 0.0);
 }
 
 


### PR DESCRIPTION
After calling
```
ui_progress_bar_start("foo");
...
ui_progress_bar_stop();
```

which should theoretically completely stop the progress bar, I get elevated CPU usage of the whole Geany process ~1% CPU on idle (and around 4% on macOS) compared to 0% after Geany launch before the status bar progress bar is used (e.g. by compiling). GTK seems to keep the widget connected to "tick callback" which causes the higher CPU (in fact, there's no gtk_progress_bar_stop() so it can't do it).

The workaround to fix this problem is to call
```
gtk_progress_bar_set_fraction()
```
which switches the progress bar to the mode where it shows the user-provided progress and this removes the "tick callback".

Am I crazy or can others reproduce this too? It was quite a bug hunt - first I suspected the LSP plugin (clangd indexes files on start which creates the progress bar which made it confusing), then jsonrpc-glib, then the blinking caret or Scintilla notifications, then Geany, and finally I got to GTK (3.24.38 to be precise).

