### PR TITLE
Don't include geanyfunctions.h from geanyplugin.h

### DIFF
--- a/plugins/geanyplugin.h
+++ b/plugins/geanyplugin.h
@@ -40,7 +40,6 @@
 #include "encodings.h"
 #include "filetypes.h"
 #include "geany.h"
-#include "geanyfunctions.h"
 #include "highlighting.h"
 #include "keybindings.h"
 #include "main.h"


### PR DESCRIPTION
Clangd complains with
```
main file cannot be included recursively when building a preamble
```
and I suspect geanyfunctions.h is the old (and now empty) version of geanyplugin.h so there's no need to include it anyway.