### PR TITLE
Fix some runtime warnings

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1266,6 +1266,9 @@ void document_apply_indent_settings(GeanyDocument *doc)
 
 void document_show_tab(GeanyDocument *doc)
 {
+	if (!doc)
+		return;
+
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(main_widgets.notebook),
 		document_get_notebook_page(doc));
 

--- a/src/document.c
+++ b/src/document.c
@@ -358,6 +358,9 @@ GeanyDocument *document_get_from_page(guint page_num)
 
 	parent = gtk_notebook_get_nth_page(GTK_NOTEBOOK(main_widgets.notebook), page_num);
 
+	if (!parent)
+		return NULL;
+
 	return document_get_from_notebook_child(parent);
 }
 


### PR DESCRIPTION
For details, check the individual commit messages.

I suspect this is a result of https://github.com/geany/geany/pull/3891 and some different timings of when the affected functions get called. I haven't investigated the exact reasons, the extra added checks are probably just fine.