### PR TITLE
Don't call plugin extension functions when quitting or closing all files

### DIFF
--- a/src/pluginextension.c
+++ b/src/pluginextension.c
@@ -21,6 +21,7 @@
 #include "pluginextension.h"
 
 #include "editor.h"
+#include "main.h"
 
 
 typedef struct
@@ -143,6 +144,8 @@ void plugin_extension_unregister(PluginExtension *extension)
  */
 #define CALL_PROVIDED(f, doc, ext)												\
 	G_STMT_START {																\
+		if (main_status.quitting || main_status.closing_all)					\
+			return FALSE;														\
 		for (GList *node = all_extensions; node; node = node->next)				\
 		{																		\
 			PluginExtensionEntry *entry = node->data;							\
@@ -167,6 +170,8 @@ void plugin_extension_unregister(PluginExtension *extension)
  */
 #define CALL_PERFORM(f_provided, doc, f_perform, args, defret)					\
 	G_STMT_START {																\
+		if (main_status.quitting || main_status.closing_all)					\
+			return defret;														\
 		for (GList *node = all_extensions; node; node = node->next)				\
 		{																		\
 			PluginExtensionEntry *entry = node->data;							\


### PR DESCRIPTION
Plugins may need to call the _provided() function e.g. inside Scintilla event handler which can get called for every file when batch-closing a session. For the LSP plugin, the _provided() call then keeps starting the server even though it should be terminated when closing project or quitting Geany.