### PR TITLE
Improve sidebar and message window resizing behavior

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8329,11 +8329,13 @@
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="position">400</property>
+            <signal name="notify::position" handler="on_vpaned1_position_notify" swapped="no"/>
             <child>
               <object class="GtkHPaned" id="hpaned1">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="position">167</property>
+                <signal name="notify::position" handler="on_hpaned1_position_notify" swapped="no"/>
                 <child>
                   <object class="GtkNotebook" id="notebook3">
                     <property name="visible">True</property>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -2066,6 +2066,43 @@ static void builder_connect_func(GtkBuilder *builder, GObject *object,
 }
 
 
+static void on_hpaned1_position_notify(GObject *object, GParamSpec *pspec, gpointer data)
+{
+	GtkPaned *hpaned = GTK_PANED(ui_lookup_widget(main_widgets.window, "hpaned1"));
+	GtkAllocation allocation;
+
+	gtk_widget_get_allocation(GTK_WIDGET(hpaned), &allocation);
+
+	if (interface_prefs.sidebar_pos == GTK_POS_LEFT && gtk_paned_get_position(hpaned) < 10)
+	{
+		ui_prefs.sidebar_visible = FALSE;
+		ui_sidebar_show_hide();
+	}
+	else if (interface_prefs.sidebar_pos == GTK_POS_RIGHT &&
+		allocation.width - gtk_paned_get_position(hpaned) < 10)
+	{
+		ui_prefs.sidebar_visible = FALSE;
+		ui_sidebar_show_hide();
+	}
+}
+
+
+static void on_vpaned1_position_notify(GObject *object, GParamSpec *pspec, gpointer data)
+{
+	GtkPaned *vpaned = GTK_PANED(ui_lookup_widget(main_widgets.window, "vpaned1"));
+	GtkAllocation allocation;
+
+	gtk_widget_get_allocation(GTK_WIDGET(vpaned), &allocation);
+
+	if (interface_prefs.msgwin_orientation == GTK_ORIENTATION_VERTICAL &&
+			allocation.height - gtk_paned_get_position(vpaned) < 10)
+		msgwin_show_hide(FALSE);
+	else if (interface_prefs.msgwin_orientation == GTK_ORIENTATION_HORIZONTAL &&
+			allocation.width - gtk_paned_get_position(vpaned) < 10)
+		msgwin_show_hide(FALSE);
+}
+
+
 void callbacks_connect(GtkBuilder *builder)
 {
 	GHashTable *hash;

--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -378,6 +378,21 @@ void msgwin_show_hide(gboolean show)
 		show);
 	ignore_callback = FALSE;
 	ui_widget_show_hide(main_widgets.message_window_notebook, show);
+	if (show)
+	{
+		GtkPaned *vpaned = GTK_PANED(ui_lookup_widget(main_widgets.window, "vpaned1"));
+		GtkAllocation allocation;
+
+		gtk_widget_get_allocation(GTK_WIDGET(vpaned), &allocation);
+
+		if (interface_prefs.msgwin_orientation == GTK_ORIENTATION_VERTICAL &&
+				allocation.height - gtk_paned_get_position(vpaned) < 10)
+			gtk_paned_set_position(vpaned, allocation.height - 200);
+		else if (interface_prefs.msgwin_orientation == GTK_ORIENTATION_HORIZONTAL &&
+				allocation.width - gtk_paned_get_position(vpaned) < 10)
+			gtk_paned_set_position(vpaned, allocation.width - 300);
+	}
+
 	/* set the input focus back to the editor */
 	keybindings_send_command(GEANY_KEY_GROUP_FOCUS, GEANY_KEYS_FOCUS_EDITOR);
 }

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1015,6 +1015,19 @@ void ui_sidebar_show_hide(void)
 	}
 
 	ui_widget_show_hide(main_widgets.sidebar_notebook, ui_prefs.sidebar_visible);
+	if (ui_prefs.sidebar_visible)
+	{
+		GtkPaned *hpaned = GTK_PANED(ui_lookup_widget(main_widgets.window, "hpaned1"));
+		GtkAllocation allocation;
+
+		gtk_widget_get_allocation(GTK_WIDGET(hpaned), &allocation);
+
+		if (interface_prefs.sidebar_pos == GTK_POS_LEFT && gtk_paned_get_position(hpaned) < 10)
+			gtk_paned_set_position(hpaned, 300);
+		else if (interface_prefs.sidebar_pos == GTK_POS_RIGHT &&
+				allocation.width - gtk_paned_get_position(hpaned) < 10)
+			gtk_paned_set_position(hpaned, allocation.width - 300);
+	}
 
 	ui_widget_show_hide(gtk_notebook_get_nth_page(
 		GTK_NOTEBOOK(main_widgets.sidebar_notebook), 0), interface_prefs.sidebar_symbol_visible);


### PR DESCRIPTION
When the user drags the message window or the sidebar window too much towards the edge of the main window, it may become too hard or even impossible to drag them back as towards the edge of the main window the cursor resizes the main window and doesn't allow dragging the sidebar separator. The only workaround in this case is to manually edit the Geany config file which is annoying.

This patch does two things:
1. When the sidebar/msgwindow divider is dragged to the edge of the window, at the 10px distance from the window border it "snaps" completely to the edge and toggles sidebar/msgwindow visibility.
2. When sidebar/msgwindow is toggled to be shown again, if its previous distance from the edge of the window is less than 10px, its size is restored to some reasonable size (300px for the sidebar, 200px for the message window)

This patch has been tested with all the sidebar/msgwindow location settings and should work correctly in all the configurations.

Fixes #4017.
Fixes #1753.
Fixes #3329.