### PR TITLE
Import Scintilla patch to fix middle-click pasting multiple times

### DIFF
--- a/scintilla/gtk/ScintillaGTK.cxx
+++ b/scintilla/gtk/ScintillaGTK.cxx
@@ -1501,8 +1501,8 @@ void ScintillaGTK::PrimaryClearSelection(GtkClipboard *clip, gpointer pSci) {
 void ScintillaGTK::ClaimSelection() {
 	// X Windows has a 'primary selection' as well as the clipboard.
 	// Whenever the user selects some text, we become the primary selection
-	ClearPrimarySelection();
 	if (!sel.Empty()) {
+		ClearPrimarySelection();
 		if (gtk_clipboard_set_with_data(
 			gtk_clipboard_get(GDK_SELECTION_PRIMARY),
 			clipboardCopyTargets, nClipboardCopyTargets,


### PR DESCRIPTION
> On GTK, allow middle click to insert multiple times within a document.
> https://github.com/geany/geany/issues/2629

Fixes #3658 and #3310.

---

This imports my [patch](https://github.com/geany/geany/issues/2629#issuecomment-2436292499) that [Neil applied](https://sourceforge.net/p/scintilla/code/ci/fac2fb49b0eecc9a628dfe1a720d319bc9cd041a/) so we get back multiple PRIMARY pasting.