### PR TITLE
Support for Fortran module procedures

### DIFF
--- a/scintilla/lexilla/lexers/LexFortran.cxx
+++ b/scintilla/lexilla/lexers/LexFortran.cxx
@@ -421,40 +421,40 @@ static int classifyFoldPointFortran(const char* s, const char* prevWord, const c
 	int lev = 0;
 
 	if ((strcmp(prevWord, "module") == 0 && strcmp(s, "subroutine") == 0)
-		|| (strcmp(prevWord, "module") == 0 && strcmp(s, "function") == 0)) {
+		|| (strcmp(prevWord, "module") == 0 && strcmp(s, "function") == 0)
+		|| (strcmp(prevWord, "module") == 0 && strcmp(s, "procedure") == 0)) { // Take care of the "module procedure" statement
 		lev = 0;
 	} else if (strcmp(s, "associate") == 0 || strcmp(s, "block") == 0
-	        || strcmp(s, "blockdata") == 0 || strcmp(s, "select") == 0
-	        || strcmp(s, "selecttype") == 0 || strcmp(s, "selectcase") == 0
-	        || strcmp(s, "do") == 0 || strcmp(s, "enum") ==0
-	        || strcmp(s, "function") == 0 || strcmp(s, "interface") == 0
-	        || strcmp(s, "module") == 0 || strcmp(s, "program") == 0
-	        || strcmp(s, "subroutine") == 0 || strcmp(s, "then") == 0
-	        || (strcmp(s, "type") == 0 && chNextNonBlank != '(')
-		|| strcmp(s, "critical") == 0 || strcmp(s, "submodule") == 0){
+			|| strcmp(s, "blockdata") == 0 || strcmp(s, "select") == 0
+			|| strcmp(s, "selecttype") == 0 || strcmp(s, "selectcase") == 0
+			|| strcmp(s, "do") == 0 || strcmp(s, "enum") ==0
+			|| strcmp(s, "function") == 0 || strcmp(s, "interface") == 0
+			|| strcmp(s, "module") == 0 || strcmp(s, "program") == 0
+			|| strcmp(s, "subroutine") == 0 || strcmp(s, "then") == 0
+			|| (strcmp(s, "type") == 0 && chNextNonBlank != '(')
+			|| strcmp(s, "critical") == 0 || strcmp(s, "submodule") == 0) {
 		if (strcmp(prevWord, "end") == 0)
 			lev = 0;
 		else
 			lev = 1;
 	} else if ((strcmp(s, "end") == 0 && chNextNonBlank != '=')
-	        || strcmp(s, "endassociate") == 0 || strcmp(s, "endblock") == 0
-	        || strcmp(s, "endblockdata") == 0 || strcmp(s, "endselect") == 0
-	        || strcmp(s, "enddo") == 0 || strcmp(s, "endenum") ==0
-	        || strcmp(s, "endif") == 0 || strcmp(s, "endforall") == 0
-	        || strcmp(s, "endfunction") == 0 || strcmp(s, "endinterface") == 0
-	        || strcmp(s, "endmodule") == 0 || strcmp(s, "endprogram") == 0
-	        || strcmp(s, "endsubroutine") == 0 || strcmp(s, "endtype") == 0
-	        || strcmp(s, "endwhere") == 0 || strcmp(s, "endcritical") == 0
-		|| (strcmp(prevWord, "module") == 0 && strcmp(s, "procedure") == 0)  // Take care of the "module procedure" statement
-		|| strcmp(s, "endsubmodule") == 0 || strcmp(s, "endteam") == 0) {
+			|| strcmp(s, "endassociate") == 0 || strcmp(s, "endblock") == 0
+			|| strcmp(s, "endblockdata") == 0 || strcmp(s, "endselect") == 0
+			|| strcmp(s, "enddo") == 0 || strcmp(s, "endenum") ==0
+			|| strcmp(s, "endif") == 0 || strcmp(s, "endforall") == 0
+			|| strcmp(s, "endfunction") == 0 || strcmp(s, "endinterface") == 0
+			|| strcmp(s, "endmodule") == 0 || strcmp(s, "endprogram") == 0
+			|| strcmp(s, "endsubroutine") == 0 || strcmp(s, "endtype") == 0
+			|| strcmp(s, "endwhere") == 0 || strcmp(s, "endcritical") == 0
+			|| strcmp(s, "endsubmodule") == 0 || strcmp(s, "endteam") == 0
+			|| strcmp(s, "endprocedure") == 0) {
 		lev = -1;
 	} else if (strcmp(prevWord, "end") == 0 && strcmp(s, "if") == 0){ // end if
 		lev = 0;
 	} else if (strcmp(prevWord, "type") == 0 && strcmp(s, "is") == 0){ // type is
 		lev = -1;
-	} else if ((strcmp(prevWord, "end") == 0 && strcmp(s, "procedure") == 0)
-			   || strcmp(s, "endprocedure") == 0) {
-			lev = 1; // level back to 0, because no folding support for "module procedure" in submodule
+	} else if ((strcmp(prevWord, "end") == 0 && strcmp(s, "procedure") == 0)) {
+		lev = 0; 
 	} else if (strcmp(prevWord, "change") == 0 && strcmp(s, "team") == 0){ // change team
 		lev = 1;
 	}

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -650,13 +650,14 @@ static TMParserMapEntry map_FORTRAN[] = {
 	{'N', tm_tag_enumerator_t},  // enumerator
 	{'p', tm_tag_struct_t},      // program
 	{'P', tm_tag_undef_t},       // prototype
+	{'r', tm_tag_method_t},      // module procedure
 	{'s', tm_tag_method_t},      // subroutine
+	{'S', tm_tag_namespace_t},   // submodule
 	{'t', tm_tag_class_t},       // type
 	{'v', tm_tag_variable_t},    // variable
-	{'S', tm_tag_undef_t},       // submodule
 };
 static TMParserMapGroup group_FORTRAN[] = {
-	{N_("Module"), TM_ICON_CLASS, tm_tag_namespace_t},
+	{N_("Modules / Submodules"), TM_ICON_CLASS, tm_tag_namespace_t},
 	{N_("Programs"), TM_ICON_CLASS, tm_tag_struct_t},
 	{N_("Interfaces"), TM_ICON_STRUCT, tm_tag_interface_t},
 	{N_("Functions / Subroutines"), TM_ICON_METHOD, tm_tag_function_t | tm_tag_method_t},


### PR DESCRIPTION
Hello. This PR implements/fixes a couple of things related to module procedures and submodules in modern Fortran.

1. Module procedures in submodules are correctly recognized and treated like regular subroutines/functions.
2. Folding of a module procedure block in submodules is enabled.
3. Definitions of module procedures within interfaces in modules are also correctly recognized.
4. Submodules are shown in the symbol list.