### PR TITLE
Add themes from geany-themes

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,6 +1,51 @@
 
 colorschemes = \
-	colorschemes/alt.conf
+	colorschemes/lgpl-2.0.txt \
+	colorschemes/lgpl-2.1.txt \
+	colorschemes/abc-dark.conf \
+	colorschemes/abc-light.conf \
+	colorschemes/alt.conf \
+	colorschemes/bespin.conf \
+	colorschemes/black.conf \
+	colorschemes/carbonfox.conf \
+	colorschemes/cyber-sugar.conf \
+	colorschemes/darcula.conf \
+	colorschemes/dark-colors.conf \
+	colorschemes/dark.conf \
+	colorschemes/delt-dark.conf \
+	colorschemes/dark-fruit-salad.conf \
+	colorschemes/earthsong.conf \
+	colorschemes/epsilon.conf \
+	colorschemes/evg-ega-dark.conf \
+	colorschemes/gedit.conf \
+	colorschemes/github.conf \
+	colorschemes/grey8.conf \
+	colorschemes/hacker.conf \
+	colorschemes/himbeere.conf \
+	colorschemes/inkpot.conf \
+	colorschemes/kugel.conf \
+	colorschemes/kurayami.conf \
+	colorschemes/matcha.conf \
+	colorschemes/mc.conf \
+	colorschemes/metallic-bottle.conf \
+	colorschemes/notepad-plus-plus.conf \
+	colorschemes/oblivion2.conf \
+	colorschemes/octagon.conf \
+	colorschemes/one-dark.conf \
+	colorschemes/pygments.conf \
+	colorschemes/retro.conf \
+	colorschemes/sleepy-pastel.conf \
+	colorschemes/slushpoppies.conf \
+	colorschemes/solarized-dark.conf \
+	colorschemes/solarized-light.conf \
+	colorschemes/spyder-dark.conf \
+	colorschemes/steampunk.conf \
+	colorschemes/tango-dark.conf \
+	colorschemes/tango-light.conf \
+	colorschemes/tinge.conf \
+	colorschemes/ubuntu.conf \
+	colorschemes/underthesea.conf \
+	colorschemes/vibrant-ink.conf
 
 filetypes_dist = \
 	filedefs/filetypes.abaqus \

--- a/data/colorschemes/abc-dark.conf
+++ b/data/colorschemes/abc-dark.conf
@@ -1,0 +1,120 @@
+#
+# Author <irvirty(at)gmail(dot)com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Other:
+# GNU General Public License v2.0
+#https://github.com/geany/geany/blob/master/COPYING
+#https://github.com/geany/geany/blob/d9f8cdbad58d09f0c18ca8acccb49209263018f0/data/filedefs/filetypes.common#L2
+# Inspired by GitHub, Sublime Text, Geany
+
+[theme_info]
+name=Abc Dark
+description=Dark flat theme.
+version=4.3.1
+author=irvirty
+# list of each compatible Geany release version
+compat=1.38;2.0;
+
+[named_styles]
+
+default=#dbdbdb;#1C1C1C;false;false
+error=#e37170;#292929;false;italic
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#000000;#E7A96B;true;true
+current_line=#FFFFFF;#262626;true
+brace_good=#000000;#7FEC75;true;false
+brace_bad=#000000;#FF5656;true;false
+margin_line_number=#6E6E6E;#1C1C1C
+margin_folding=#5C5C5C;#1C1C1C
+fold_symbol_highlight=#1C1C1C
+indent_guide=#595959
+caret=#fff;#fff;false;
+marker_line=#000000;#E7A96B
+marker_search=marker_line
+marker_mark=#545454;#95BFD7
+call_tips=#939393;#262626;false;false
+white_space=#595959;#000000;true;false
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#ADADAD
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#8AD1FF
+number_1=number
+number_2=number_1
+
+type=#50AAB3;;true;false
+class=type
+function=#cc8ad4
+parameter=#23B0E6
+
+keyword=#BF6069;;true;false
+keyword_1=keyword
+keyword_2=keyword_1
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#6BB37C
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1;#6E006E;false;false
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+label=default,bold
+preprocessor=#45BDE6
+regex=number_1
+operator=default
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#80B8FF
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=#85C6CC
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#75C075;#ffffff;false;false
+line_removed=#FF7E7E;#ffffff;false;false
+line_changed=#A46FA4;#ffffff;false;false

--- a/data/colorschemes/abc-light.conf
+++ b/data/colorschemes/abc-light.conf
@@ -1,0 +1,120 @@
+#
+# Author <irvirty(at)gmail(dot)com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Other:
+# GNU General Public License v2.0
+#https://github.com/geany/geany/blob/master/COPYING
+#https://github.com/geany/geany/blob/d9f8cdbad58d09f0c18ca8acccb49209263018f0/data/filedefs/filetypes.common#L2
+# Inspired by GitHub, Sublime Text, Geany
+
+[theme_info]
+name=Abc Light
+description=Light flat theme.
+version=4.2.1
+author=irvirty
+# list of each compatible Geany release version
+compat=1.38;2.0;
+
+[named_styles]
+
+default=#2B2B2B;#F7F7F7;false;false
+error=#D44747;#EBEBEB;false;italic
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#000000;#FFB565;true;true
+current_line=#4D4D4D;#FFFFFF;true
+brace_good=#FFFFFF;#5BAB53;true;false
+brace_bad=#FFFFFF;#D44747;true;false
+margin_line_number=#7D7D7D;#F7F7F7
+margin_folding=#969696;#F7F7F7
+fold_symbol_highlight=#F7F7F7
+indent_guide=#ADADAD
+caret=#000000;#000000;false;
+marker_line=#000000;#FFB565
+marker_search=marker_line
+marker_mark=#4F4F4F;#80C8F3
+call_tips=#565656;#FFFFFF;false;false
+white_space=#ADADAD;#F7F7F7;true;false
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#454545
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#46a1db
+number_1=number
+number_2=number_1
+
+type=#2C8E99;;true;false
+class=type
+function=#9e00b0
+parameter=#2DA4B2
+
+keyword=#BF4D58;;true;false
+keyword_1=keyword
+keyword_2=keyword_1
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#166E2E
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1;#E0C0E0;false;false
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+label=default,bold
+preprocessor=#007299
+regex=number_1
+operator=default
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#0065BF
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=#116269
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#75C075;#ffffff;false;false
+line_removed=#FF7E7E;#ffffff;false;false
+line_changed=#A46FA4;#ffffff;false;false

--- a/data/colorschemes/bespin.conf
+++ b/data/colorschemes/bespin.conf
@@ -1,0 +1,121 @@
+#
+# This file was generated from a textmate theme named Bespin
+# with tm2gtksw2 tool. (Alexandre da Silva)
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Ported to Geany by Matthew Brush <matt(at)geany(dot)org>
+#
+
+[theme_info]
+name=Bespin
+description=A port of the Bespin theme.
+# incremented automatically, do not change manually
+version=1225
+author=Alexandre da Silva (tm2gtksw2)
+url=https://github.com/gmate/gmate/blob/master/styles/Bespin.xml
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#baae9e;#28211c;false;false
+error=#f8f8f8;#4a2947
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#baae9e;#4c4a49;true;true
+current_line=#000;#2e2723;true
+brace_good=#00f;#2e2723;true;false
+brace_bad=#df4545;#2e2723;true;false
+margin_line_number=#baae9e;#2e2723
+margin_folding=#baae9e;#2e2723
+fold_symbol_highlight=#2e2723
+indent_guide=#40342c
+white_space=#40342c;#fff;true;false
+caret=#a7a7a7;#000;false
+marker_line=#000;#ff0;
+marker_search=#000;#0000f0;
+marker_mark=#000;#b8f4b8;
+call_tips=#c0c0c0;#fff;false;false
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#666;;;true
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#cf6a4c
+number_1=number
+number_2=number_1
+
+type=#9b859d;;true
+class=type
+function=#937121
+parameter=function
+
+keyword=#5ea6ea;;true
+keyword_1=keyword
+keyword_2=type
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#54be0d
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#cf6a4c
+regex=#e9c062
+operator=#5ea6ea
+decorator=string_1,bold
+other=#ddf2a4
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#ac885b
+tag_unknown=#ac885b
+tag_end=#ac885b
+attribute=#937121
+attribute_unknown=#937121
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#f8f8f8;#253b22
+line_removed=#f8f8f8;#420e09
+line_changed=#f8f8f8;#4a410d

--- a/data/colorschemes/black.conf
+++ b/data/colorschemes/black.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright 2013 Paul Lenton (EckoZero) <lentonp(at)gmail(dot)com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,59 +16,69 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 #
+# This is a remix of vibrant-ink, originally by Jason Wilson
+# <jason.wilson(at)gmail(dot)com>
+# Thanks Jason! My remix is licensed under the exact same terms as
+# Jason's original (GNU GPLv2)
+#
+
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Black Scheme
+description=Black background, other colours
+# incremented automatically, do not change manually
+version=1237
+author=Paul Lenton <lentonp(at)gmail(dot)com>
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#fff;#000;false;false
+error=#ff80c0;#000;false;false
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#f00;#404040;false;true
+current_line=#8dc63f;#330;true;false
+brace_good=#ff0;#000;true;false
+brace_bad=#c5360f;#000;true;false
+margin_line_number=#b2aeab;#404040;false;false
+margin_folding=#222;#111;false;false
+fold_symbol_highlight=#fff
+indent_guide=#066;;false;false
+caret=#fff;#066;false;false
+marker_line=#ff208c;#80d4b2;false;false
+marker_search=#ff0;#f00;false;false
+marker_mark=#810000;#000;false;false
+call_tips=#ccc;#fff;false;false
+white_space=#ccc;;true
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+
+comment=#f00
+comment_doc=#f00;#070707;false;false
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#28a8b4
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#fff;;true;false
 class=type
-function=0x000080
+function=default
 parameter=function
 
-keyword=0x003030;;true
+keyword=#f39;;true;false
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=#6f0;;true;false
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,37 +88,38 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#8dc63f
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=#8dc63f;#000;false;false
 character=string_1
 backticks=string_2
 here_doc=string_2
 
+scalar=string_2
 label=default,bold
-preprocessor=0x808000
+preprocessor=#fff
 regex=number_1
-operator=0x300080
+operator=#fc0
 decorator=string_1,bold
-other=0x404080
+other=default
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
 
-tag=type
-tag_unknown=tag,bold
-tag_end=tag,bold
-attribute=keyword_1
-attribute_unknown=attribute,bold
-value=string_1
-entity=default
+tag=#6f0;#000;false;false
+tag_unknown=#ccc;#000;false;false
+tag_end=#fff;#000;false;false
+attribute=#bd96bd;#000;false;false
+attribute_unknown=#fff;#000;false;false
+value=#6f0;#000;false;false
+entity=#fff;#000;false;false
 
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
-line_changed=preprocessor
+line_added=#00f5ff;#000;false;false
+line_removed=#ff0;#000;false;false
+line_changed=#399;#000;false;false

--- a/data/colorschemes/carbonfox.conf
+++ b/data/colorschemes/carbonfox.conf
@@ -1,6 +1,3 @@
-#
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
-#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -16,59 +13,62 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 #
+# Colors selected by jag(at)justaguylinux(dot)com
+# Colors adapted from the Carbonfox theme (Nightfox for Ghostty)
+# Author: Drew Griffin
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Carbonfox
+description=Dark theme inspired by Carbonfox.
+version=0.2.0
+author=Drew Griffin
+compat=1.38;2.0;
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#f2f4f8;#1c2736;false;false
+error=#ee5396;#282828;false;italic
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#f2f4f8;#484848;true;true
+current_line=#f2f4f8;#282828;true
+brace_good=#161616;#25be6a;true;false
+brace_bad=#161616;#ee5396;true;false
+margin_line_number=#4B5263;#161616
+margin_folding=#484848;#282828
+fold_symbol_highlight=#939393
+indent_guide=#484848
+caret=#dbc704;#f2f4f8;false;
+marker_line=#161616;#ee5396
+marker_search=marker_line
+marker_mark=#545454;#78a9ff
+call_tips=#939393;#262626;false;false
+white_space=#595959;#161616;true;false
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#a7adba;;;true
+comment_doc=comment
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#dbc704
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#25be6a;;true;false
 class=type
-function=0x000080
-parameter=function
+function=#be95ff
+parameter=#33b1ff
 
-keyword=0x003030;;true
+keyword=#be95ff;;true;false
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=keyword_1
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,30 +78,30 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#25be6a
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=#25be6a;#000;false;false
 character=string_1
 backticks=string_2
 here_doc=string_2
 
 label=default,bold
-preprocessor=0x808000
+preprocessor=#78a9ff
 regex=number_1
-operator=0x300080
+operator=default
 decorator=string_1,bold
-other=0x404080
+other=default
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
 
-tag=type
+tag=#78a9ff
 tag_unknown=tag,bold
 tag_end=tag,bold
-attribute=keyword_1
+attribute=#25be6a
 attribute_unknown=attribute,bold
 value=string_1
 entity=default
@@ -109,6 +109,6 @@ entity=default
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
-line_changed=preprocessor
+line_added=#46c880;#ffffff;false;false
+line_removed=#f16da6;#ffffff;false;false
+line_changed=#c8a5ff;#ffffff;false;false

--- a/data/colorschemes/cyber-sugar.conf
+++ b/data/colorschemes/cyber-sugar.conf
@@ -1,0 +1,135 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+
+[theme_info]
+name=Cyber Sugar
+description=A dark cyber theme with sugar colors.
+# incremented automatically, do not change manually
+version=1.0
+author=pingu
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_colors]
+base0=#80bfff
+base1=#000
+base2=#fff
+base3=#a6a
+base4=#000
+barbie=#e64d7d
+orange=#ea7d10
+frostwhite=#fff
+attentionred=#ff1f47
+pastelgreen=#6cf982
+softpink=#f9b8b8
+red=#f00
+redbg=#751212
+green=#859900
+blue=#268bd2
+oxfordblue=#002147
+
+[named_styles]
+default=base0;base1
+error=red
+
+
+# Editor styles
+#-------------------------------------------------------------------------------
+selection=;oxfordblue;;true
+current_line=;#1a1a1a;true
+brace_good=#000;pastelgreen;true
+brace_bad=red;frostwhite;true
+margin_line_number=#a6a;base4
+margin_folding=base3;#000
+fold_symbol_highlight=base2
+indent_guide=base2;;true
+caret=orange
+marker_line=#fff;#00f;
+marker_search=;frostwhite;
+marker_mark=;
+call_tips=base0;#fff
+white_space=base2;;true
+
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=softpink
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=attentionred
+number_1=number
+number_2=number_1
+
+type=barbie;;true
+class=orange
+function=#00FFFA
+parameter=function
+
+keyword=barbie;;true
+keyword_1=keyword
+keyword_2=orange;;true
+keyword_3=frostwhite
+keyword_4=keyword_3
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=pastelgreen
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=red
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=keyword,bold
+preprocessor=orange
+regex=number_1
+operator=#fff
+decorator=string_1,bold
+other=orange
+
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=barbie
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=orange
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=green
+line_removed=red
+line_changed=blue

--- a/data/colorschemes/darcula.conf
+++ b/data/colorschemes/darcula.conf
@@ -1,0 +1,149 @@
+#
+# Copyright 2015 Jiri Techet <techet(at)gmail(dot)com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+# Ported from the IntelliJ Darcula theme by Jiri Techet
+#
+
+[theme_info]
+name=Darcula
+description=A soft dark theme based on the IntelliJ Darcula theme.
+# incremented automatically, do not change manually
+version=1
+author=Jiri Techet <techet(at)gmail(dot)com>
+url=https://github.com/codebrainz/geany-themes
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_colors]
+fg=#b6c3cf
+bg=#3b3b3b
+
+caret_grey=#c6c6c6
+margin_fg_grey=#989898
+comment_grey=#919191
+fold_fg_grey=#888
+whitespace_grey=#505050
+calltip_fg_grey=#555
+calltip_bg_grey=#ddd
+fold_bg_grey=#4c4c4c
+current_line_grey=#434343
+margin_bg_grey=#424446
+
+type_violet=#a88ab6
+keyword_blue=#9196bf
+number_blue=#7aa6c4
+selection_blue=#2f5692
+brace_bg_green=#4d6360
+diff_added_green=#558266
+docstring_green=#73a46a
+string_green=#b2ca78
+alert_yellow=#ffef4c
+tag_yellow=#edc881
+keyword_orange=#d58a4a
+error_red=#c85550
+diff_removed_red=#a0665b
+
+[named_styles]
+
+default=fg;bg;false;false 
+error=error_red;;;true
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=;selection_blue;;true
+current_line=;current_line_grey;true
+brace_good=alert_yellow;brace_bg_green;true
+brace_bad=error_red;current_line_grey;true
+margin_line_number=margin_fg_grey;margin_bg_grey
+margin_folding=fold_fg_grey;fold_bg_grey
+fold_symbol_highlight=fold_bg_grey
+indent_guide=whitespace_grey
+caret=caret_grey
+marker_line=margin_bg_grey;alert_yellow
+marker_search=;alert_yellow
+marker_mark=margin_bg_grey;alert_yellow
+call_tips=calltip_fg_grey;calltip_bg_grey;true;true
+white_space=whitespace_grey;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=comment_grey
+comment_doc=docstring_green
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=number_blue
+number_1=number
+number_2=number_1
+
+type=type_violet
+class=type
+function=tag_yellow
+parameter=function
+
+keyword=keyword_orange
+keyword_1=keyword
+keyword_2=keyword_blue
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=string_green
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=tag_yellow
+regex=number_1
+operator=default
+decorator=tag_yellow
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=tag_yellow
+tag_unknown=tag
+tag_end=tag
+attribute=keyword_orange
+attribute_unknown=attribute
+value=string_green
+entity=number_blue
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=diff_added_green
+line_removed=diff_removed_red
+line_changed=preprocessor

--- a/data/colorschemes/dark-colors.conf
+++ b/data/colorschemes/dark-colors.conf
@@ -1,0 +1,136 @@
+#
+# Copyright (C) 2016 - Yannis Kontochristopoulos <ikontochris(at)gmail(dot)com>
+#
+# Dark Colors is a theme inspired by Tinge:
+#   Copyright (C) 2008 - Harsh J <harshj(at)gmail(dot)com>
+#   See: http://www.harshj.com/2008/01/27/tinge-theme-for-gedit/
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+[theme_info]
+name=Dark Colors
+description=A dark theme utilising warm colors 
+# incremented automatically, do not change manually
+version=1225
+
+[named_colors]
+text=#e6e6e6
+soft_text=#a69996
+softer_text=#4c4645
+background=#0c0807
+selection_brown=#422e21
+marker_search_turquoise=#286659
+current_line_red=#281816
+black=#000
+white=#fff
+light_blue=#5191cc
+soft_blue=#596f80
+red=#b31111
+yellow=#b3a123
+orange=#e66917
+orange2=#ff9400
+green=#00df13
+purple=#b6f
+
+[named_styles]
+default=text;background;false;false
+error=green;background;false;false
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=background;selection_brown;false;true
+current_line=background;current_line_red;true;false
+brace_good=light_blue;background;true;false
+brace_bad=white;background;true;false
+margin_line_number=soft_text;#2b2826;false;false
+margin_folding=#574a22;#141312;false;false
+fold_symbol_highlight=soft_text
+indent_guide=softer_text
+caret=white;white;false
+marker_line=soft_text;yellow
+marker_search=marker_search_turquoise;marker_search_turquoise;false;false
+marker_mark=red;background;false;false
+call_tips=#c0c0c0;white;false;false
+white_space=softer_text;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=soft_blue
+comment_doc=soft_blue;background;false;false
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=green
+number_1=number
+number_2=number_1
+
+type=purple;;true;false
+class=type
+function=type
+parameter=function
+
+keyword=orange;;true;false
+keyword_1=keyword
+keyword_2=yellow;;true;false
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=red
+string_1=string
+string_2=string_1
+string_3=string_1
+string_4=string_1
+string_eol=text;background;false;false
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=text
+regex=number_1
+operator=orange2
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=yellow;background;false;false
+tag_unknown=green;background;false;false
+tag_end=text;background;false;false
+attribute=orange;background;false;false
+attribute_unknown=green;background;false;false
+value=text;background;false;false
+entity=text;background;false;false
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=green;background;false;false
+line_removed=red;background;false;false
+line_changed=light_blue;background;false;false

--- a/data/colorschemes/dark-fruit-salad.conf
+++ b/data/colorschemes/dark-fruit-salad.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright 2011 John Gabriele <jmg3000(at)gmail(dot)com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,92 +16,99 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 #
+# Ported from old theme by Matthew Brush <matt(at)geany(dot)org>
+# Note: was part of `set_geany_colors` utility
+#
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Dark Fruit Salad
+description=Low contrast theme ported from the set_geany_colors utility
+# incremented automatically, do not change manually
+version=1226
+author=John Gabriele <jmg3000(at)gmail(dot)com>
+url=https://github.com/codebrainz/geany-themes
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#f0f0f0;#5f5f5f;false;false
+error=#ebbf71;#e1e17a
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#000;#202020;false;true
+current_line=#000;#565656;true
+brace_good=#f0f0f0;#587941;false;false
+brace_bad=#f00;#fff;false;false
+margin_line_number=#5f5f5f;#f0f0f0
+margin_folding=#d69cd6;#202020
+fold_symbol_highlight=#202020
+indent_guide=#d69cd6
+caret=#000;#000;false
+marker_line=#000;#ff0
+marker_search=#000;#0000f0
+marker_mark=#000;#b8f4b8
+call_tips=#c0c0c0;#fff;false;false
+white_space=#a7a7a7;;true
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#a3d97d
+comment_doc=#99e4de;;true
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#ff939c
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#e1e17a;;true
 class=type
-function=0x000080
+function=#92bde8;;true
 parameter=function
 
-keyword=0x003030;;true
+keyword=#92bde8;;true
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=#d69cd6;;true
 keyword_3=keyword_1
 keyword_4=keyword_1
 
-identifier=default
+identifier=#f0f0f0
 identifier_1=identifier
-identifier_2=identifier_1
-identifier_3=identifier_1
+identifier_2=#99e4de;;true
+identifier_3=#ff939c;;true
 identifier_4=identifier_1
 
-string=0x008000
+string=#ebbf71
 string_1=string
-string_2=string_1
+string_2=#e1e17a
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
-character=string_1
+string_eol=string_1,italic
+character=#e1e17a;;true
 backticks=string_2
 here_doc=string_2
 
+scalar=string_2
 label=default,bold
-preprocessor=0x808000
+preprocessor=#ff939c
 regex=number_1
-operator=0x300080
+operator=default
 decorator=string_1,bold
-other=0x404080
+other=default
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
 
-tag=type
+tag=keyword
 tag_unknown=tag,bold
 tag_end=tag,bold
-attribute=keyword_1
+attribute=#99e4de
 attribute_unknown=attribute,bold
 value=string_1
 entity=default
@@ -109,6 +116,6 @@ entity=default
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
+line_added=#8ae234
+line_removed=#e1e17a
 line_changed=preprocessor

--- a/data/colorschemes/dark.conf
+++ b/data/colorschemes/dark.conf
@@ -1,0 +1,120 @@
+#
+# Copyright 2011 Duncan Lock <duncan.lock(at)gmail(dot)com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+# Ported from old theme by Matthew Brush <matt(at)geany(dot)org>
+#
+
+[theme_info]
+name=Dark
+description=Dark syntax colouring theme
+# incremented automatically, do not change manually
+version=1225
+author=Duncan Lock <duncan.lock(at)gmail(dot)com>
+url=http://code.google.com/p/geany-dark-scheme/
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#fff;#1e1e1e;false;false
+error=#f00;#1e1e1e;false;false
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#fff;#333964;false;true
+current_line=#000;#2f2f2f;true;false
+brace_good=#fff;#50aa15;true;false
+brace_bad=#fff;#aa1515;true;false
+margin_line_number=#000;#d0d0d0;false;false
+margin_folding=#000;#dfdfdf;false;false
+fold_symbol_highlight=#fff
+indent_guide=#393939;#1e1e1e;false;false
+caret=#fff;#000;true;false
+marker_line=#000;#ff0;false;false
+marker_search=#000;#b8f4b8;false;false
+marker_mark=#000;#b8f4b8;
+call_tips=#c0c0c0;#fff;false;false
+white_space=#424242;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#747474;#1e1e1e;false;false
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#aaff57;#1e1e1e;false;false
+number_1=number
+number_2=number_1
+
+type=#2e8b57;;true
+class=type
+function=default
+parameter=function
+
+keyword=#ffcb4f;#1e1e1e;true;false
+keyword_1=keyword
+keyword_2=#aaff57;#1e1e1e;false;true
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=#fff;#1e1e1e;false;false
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#aaff57;#1e1e1e;false;false
+string_1=string
+string_2=#a18651;#1e1e1e;false;false
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#5abefd;#1e1e1e;false;false
+regex=number_1
+operator=#98bac5;#1e1e1e;true;false
+decorator=#808000;#1e1e1e;false;false
+other=#fff;#1e1e1e;false;false
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#7392cf;#1e1e1e;false;false
+tag_unknown=#fff;#8c0101;true;false
+tag_end=#7392cf;#1e1e1e;true;false
+attribute=#cda0d5;#1e1e1e;false;false
+attribute_unknown=#fff;#8c0101;false;false
+value=#4575b6;#1e1e1e;false;false
+entity=#ffa95c;#2c2821;false;false
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#008b8b
+line_removed=#6a5acd
+line_changed=preprocessor

--- a/data/colorschemes/delt-dark.conf
+++ b/data/colorschemes/delt-dark.conf
@@ -1,0 +1,106 @@
+#
+# Copyright Éric "delt" Tremblay
+#
+# Ported from a previous theme i made for kate/kwrite.
+# Licensed under GPL version 2, same as geany itself.
+#
+
+[theme_info]
+name=Delt Dark
+description=A dark-blueish theme, good for many programming languages
+# incremented automatically, do not change manually
+version=1
+author=Éric Tremblay
+url=https://github.com/geany/geany-themes/
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#c1c1c1;#010a15;false;false
+error=#fff;#f00
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#000;#424d71;false;true
+current_line=#fff;#121d30;true
+brace_good=#fff;#848;true;false
+brace_bad=#fff;#f00;true;false
+margin_line_number=#55a;#000
+margin_folding=#338;#113
+fold_symbol_highlight=#113
+indent_guide=#121d20
+caret=#fbff00;#fbff00;false
+marker_line=#000;#ff0
+marker_search=#000;#0000f0
+marker_mark=#000;#b8f4b8
+call_tips=#c0c0c0;#fff;false;false
+white_space=#111a25;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#638aff;;false;false
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#ff54ff;;false;false
+number_1=number
+number_2=number_1
+
+type=#75ffd6;;true;false
+class=#00ff5c;;false;false
+function=default
+parameter=default
+
+keyword=#fff;;true;false
+keyword_1=#fff;;true;false;
+keyword_2=#0ff;;true;false;
+keyword_3=#0f0
+keyword_4=keyword_1
+
+identifier=#fff
+identifier_1=default
+identifier_2=#f0f
+identifier_3=#ff0
+identifier_4=#f00
+
+string=#d04eff;;true;false
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#00ff5c;;true;false
+regex=number_1
+operator=#b0c1ff;;true;false
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#fff;;true;false
+tag_unknown=#ff4
+tag_end=#ff0;;true;false
+attribute=#0ff;;false;false
+attribute_unknown=attribute
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#008b8b
+line_removed=#6a5acd
+line_changed=preprocessor

--- a/data/colorschemes/earthsong.conf
+++ b/data/colorschemes/earthsong.conf
@@ -1,0 +1,120 @@
+#
+# MIT License
+#
+# Copyright (c) 2019-2020 Daniel Plakhotich <daniel(dot)plakhotich(at)gmail(dot)com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Colour schemes by Dayle Rees:
+#   https://github.com/daylerees/colour-schemes
+
+[theme_info]
+name=Earthsong
+description=Warm theme based on the scheme of the same name by Dayle Rees.
+version=1.1
+author=Daniel Plakhotich <daniel(dot)plakhotich(at)gmail(dot)com>
+url=
+
+[named_styles]
+
+default=#ccb69f;#26221f;false;false
+error=#ffffff;#ff0000
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#ffffff;#c47958;true;true
+current_line=#000000;#45403b;true
+brace_good=#26221f;#ccb69f;false;false
+brace_bad=#ff0000;#ffffff;false;false
+margin_line_number=#756d63;#26221f
+margin_folding=#756d63;#302828
+fold_symbol_highlight=#333333
+indent_guide=#574f45
+caret=#f8f8f0;#000000;false
+marker_line=#ccb69f;#605000
+marker_search=#000000;#00ff00
+marker_mark=#ccb69f;#506000
+call_tips=#26221f;#ccb69f;true;true
+white_space=#574f45;#ffffff;true;false
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#756d63
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc
+
+number=#eeb437
+number_1=number
+number_2=number_1
+
+type=#d2734a
+class=type
+function=#5c9c61
+parameter=function
+
+keyword=type
+keyword_1=keyword
+keyword_2=keyword_1
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#dbab44
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+label=default,bold
+preprocessor=keyword
+regex=number_1
+operator=default
+decorator=default
+other=operator
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#8fc45a
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=type
+attribute_unknown=attribute
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#9fd92c
+line_removed=#00a1be
+line_changed=#ddd26f

--- a/data/colorschemes/epsilon.conf
+++ b/data/colorschemes/epsilon.conf
@@ -1,0 +1,119 @@
+#
+# Copyright (c) 2016 Adrien Jacquet <adrienjacquet at openmailbox dot org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+[theme_info]
+name=Epsilon
+description=A simple light theme for Geany.
+# incremented automatically, do not change manually
+version=1
+author=N3mesis98
+url=https://github.com/geany/geany-themes/pull/7
+# list of each compatible Geany release version
+compat=1.32
+
+[named_styles]
+default=#2e3436;#fff;false;false
+error=#2e3436;#ef2929
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=;#add8e6;;true
+brace_good=#52a800;;true
+brace_bad=#f00;;true
+margin_line_number=#2e3436;#e1e1e1
+margin_folding=#2e3436;#d3d7cf
+fold_symbol_highlight=#d3d7cf
+indent_guide=#babdb6
+caret=#000;#000;false
+marker_line=;#000
+marker_search=;#000;true;true
+marker_mark=;#000
+call_tips=#ededed;#fff
+white_space=#babdb6;;true
+current_line=;
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#a52a2a
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc_keyword,italic
+
+number=#52a800
+number_1=number
+number_2=number_1
+
+type=#399
+class=type
+function=default
+parameter=default
+
+keyword=#204a87;;true
+keyword_1=keyword
+keyword_2=#204a87
+keyword_3=keyword_2
+keyword_4=keyword_2
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#ff7800
+string_1=string
+string_2=string
+string_3=string
+string_4=string
+string_eol=string
+character=string
+backticks=string
+here_doc=string
+verbatim=string
+
+scalar=string_2
+label=default,bold
+preprocessor=type
+regex=number_1
+operator=#a6832b
+decorator=number_1,bold
+other=default
+extra=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#204a87;;true
+tag_unknown=tag
+tag_end=tag
+attribute=keyword
+attribute_unknown=attribute,italic
+value=string_1
+entity=preprocessor
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#4e9a06
+line_removed=#dc0000
+line_changed=#ffa700

--- a/data/colorschemes/evg-ega-dark.conf
+++ b/data/colorschemes/evg-ega-dark.conf
@@ -1,0 +1,148 @@
+# Geany color theme
+# 2023 by Evgueni Antonov <Evgueni(dot)Antonov(at)gmail(dot)com>
+#
+# Created on Geany 1.38 (on lubuntu).
+# I created this theme specifically for Python, so this is how it was tested.
+# I can't guarantee how it will work and appear on previous Geany versions.
+#
+# PUBLIC DOMAIN
+#
+# Inspired by vim and the DOS era (the EGA color palette). Initially I wanted to use
+# 100% the EGA color palette, but then decided to darken some of the colors. Then
+# noticed how I like my vim theme, so I made a mix of them all.
+#
+
+
+[theme_info]
+name=Evg-EGA-Dark
+description=A dark theme inspired by vim, DOS and EGA 
+# incremented automatically, do not change manually
+version=1225
+author=Evgueni Antonov <Evgueni(dot)Antonov(at)gmail(dot)com>
+url=https://github.com/StrayFeral/geany_tools/
+
+
+[named_colors]
+# DOS colors
+dos_grey=#9c9c9c
+
+# EGA palette
+white=#ffffff
+black=#000000
+ega_blue=#0000aa
+ega_green=#00aa00
+ega_cyan=#00aaaa
+ega_red=#aa0000
+ega_magenta=#aa00aa
+ega_brown=#aa5500
+ega_light_grey=#aaaaaa
+ega_dark_grey=#555555
+ega_bright_blue=#5555ff
+ega_bright_green=#55ff55
+ega_bright_cyan=#55ffff
+ega_bright_red=#ff5555
+ega_bright_magenta=#ff55ff
+ega_bright_yellow=#ffff55
+
+darker_blue=#000088
+darker_white=#e0e0e0
+darker_yellow=#cccc55
+darker_cyan=#005050
+fruity_dark_red=#aa88aa
+
+# Misc
+background_color=#000000
+text_color=#00aaaa
+current_line_background_color=#202020
+selection_background_color=#383838
+margin_line_number_background_color=#202020
+
+
+[named_styles]
+default=dos_grey;background_color;false;false
+error=ega_bright_red;background_color;false;false
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=dos_grey;selection_background_color;false;true
+current_line=dos_grey;current_line_background_color;true;false
+brace_good=white;ega_cyan;true;true
+brace_bad=ega_bright_yellow;ega_red;true;true
+margin_line_number=dos_grey;margin_line_number_background_color;false;false
+margin_folding=dos_grey
+fold_symbol_highlight=ega_blue
+indent_guide=ega_blue
+caret=white;white;false
+marker_line=ega_blue;ega_brown
+marker_search=ega_bright_yellow;ega_bright_green
+marker_mark=ega_bright_magenta
+call_tips=dos_grey;white;false;false
+white_space=ega_bright_blue;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=ega_dark_grey;background_color;true;true
+comment_doc=ega_dark_grey;background_color;false;false
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc
+comment_doc_keyword_error=comment_doc
+
+number=ega_bright_magenta
+number_1=number
+number_2=number_1
+
+type=ega_bright_cyan;;true;false
+class=type
+function=type
+parameter=function
+
+keyword=darker_yellow
+keyword_1=keyword
+keyword_2=ega_bright_cyan
+keyword_3=keyword
+keyword_4=keyword
+
+identifier=default
+identifier_1=dos_grey
+identifier_2=identifier
+identifier_3=identifier
+identifier_4=identifier
+
+string=ega_green
+string_1=string
+string_2=string_1
+string_3=string_1
+string_4=string_1
+string_eol=text_color
+character=string_1
+backticks=string_2
+here_doc=ega_dark_grey
+
+scalar=string_2
+label=white
+preprocessor=text_color
+regex=number_1
+operator=white
+decorator=ega_brown
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=ega_dark_grey
+tag_unknown=ega_bright_red
+tag_end=ega_dark_grey
+attribute=ega_cyan
+attribute_unknown=ega_bright_red
+value=ega_bright_cyan
+entity=white
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=ega_bright_green
+line_removed=ega_red
+line_changed=ega_bright_blue

--- a/data/colorschemes/gedit.conf
+++ b/data/colorschemes/gedit.conf
@@ -1,0 +1,120 @@
+#
+# Copyright 2006-2007 GtkSourceView team
+#
+# GtkSourceView is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# GtkSourceView is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# Ported to Geany by Matthew Brush <matt(at)geany(dot)org>
+#
+
+[theme_info]
+name=Gedit
+description=A port of Gedit's default theme.
+# incremented automatically, do not change manually
+version=1225
+author=Yevgen Muntyan <muntyan(at)tamu(dot)edu>
+url=http://git.gnome.org/browse/gtksourceview/tree/data/styles/classic.xml
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#000;#fff;false;false
+error=#000;#f00;true;false
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#fff;#86abd9;true;true
+current_line=#000;#edeceb;true
+brace_good=#fff;#bebebe;true;false
+brace_bad=#fff;#f00;true;false
+margin_line_number=current_line,bold
+margin_folding=margin_line_number
+fold_symbol_highlight=#fff
+indent_guide=#bbbebb
+caret=#000;#000;false
+marker_line=#000;#ff0
+marker_search=marker_line
+marker_mark=#000;#6c8ea2
+call_tips=#bbbebb;#fff;false;false
+white_space=call_tips,bold
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#00f
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#f0f
+number_1=number
+number_2=#a52a2a;;true
+
+type=#2e8b57;;true
+class=number
+function=default
+parameter=function
+
+keyword=number_2
+keyword_1=keyword
+keyword_2=keyword_1
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=#008a8c
+
+string=number
+string_1=string
+string_2=string_1
+string_3=;;true;false
+string_4=;;false;true
+string_eol=string_1,italic
+character=string_1
+backticks=#a020f0
+here_doc=string_2
+
+scalar=identifier_4
+label=default,bold
+preprocessor=backticks
+regex=identifier_4
+operator=default
+decorator=string_1,bold
+other=default
+extra=keyword
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=identifier_4
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=#6a5acd
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#008b8b
+line_removed=attribute
+line_changed=preprocessor

--- a/data/colorschemes/github.conf
+++ b/data/colorschemes/github.conf
@@ -1,0 +1,122 @@
+#
+# Copyright 2009 Felipe Mesquita <fmesquitacunha(at)gmail(dot)com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Ported to Geany by Matthew Brush <matt(at)geany(dot)org>
+#
+# Note: This one is my favourite! -Matt (geany-themes maintainer)
+#
+
+[theme_info]
+name=GitHub
+description=Similar to GitHub.com's highlighting colors.
+# incremented automatically, do not change manually
+version=1227
+author=Felipe Mesquita <fmesquitacunha(at)gmail(dot)com>
+url=https://github.com/mig/gedit-themes/blob/master/github.xml
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#000;#f8f8ff;false;false
+error=#f00;#bfbfbf;false;italic
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=;#f0ec0f;false;true
+current_line=#000;#b7deee;true
+brace_good=#000;#32b953;bold
+brace_bad=#000;#ee5959
+margin_line_number=#7f7f7f;#ececec
+margin_folding=#7f7f7f;#d9d7d7
+fold_symbol_highlight=#ececec
+indent_guide=#c0c0c0;#fff;true;false
+caret=#000;#c0c0c0;false;false
+marker_line=#7f7f7f;#ececec
+marker_search=;#c0c0c0
+marker_mark=#7f7f7f;#ececec
+call_tips=default
+white_space=#c0c0c0;#fff;true;false
+
+# Generic programming languages
+#-------------------------------------------------------------------------------
+
+comment=#998
+comment_doc=#998
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#099
+number_1=number
+number_2=number_1
+
+type=#458;;true
+class=type
+function=#900
+parameter=function
+
+keyword=#0086b3;;true
+keyword_1=keyword
+keyword_2=#aa2c8c;;true
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#d14
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#0f8787
+regex=number_1
+operator=default
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=type
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=keyword_1
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#000;#dfd
+line_removed=#000;#fdd
+line_changed=#000;#ffc

--- a/data/colorschemes/grey8.conf
+++ b/data/colorschemes/grey8.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright 2023 Collins Mutugi <monsieurcollmut@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,57 +18,57 @@
 #
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=grey8
+description=A simple gray theme.
+# incremented automatically, do not change manually
+version=6
+author=Collins Mutugi
+url=
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#FDFDFD;#888888;false;false
+error=#c00
 
-# Editor styles
-#-------------------------------------------------------------------------------
-
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#000000;#E2E2E2;true;true
+current_line=#000;;false
+brace_good=default
+brace_bad=default,bold
+margin_line_number=#C7C7C7
+margin_folding=default
+fold_symbol_highlight=#000
+indent_guide=default
+caret=#ccc;#000;true;true
+marker_line=default,italic
+marker_search=;#000
+marker_mark=#000;#000
+call_tips=#000;#000;true;true
+white_space=#104e10;;true
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#C1C1C1
+comment_doc=comment
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#FFCC25
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#FFCC25;;true
 class=type
-function=0x000080
-parameter=function
+function=default
+parameter=default
 
-keyword=0x003030;;true
+keyword=#404040;;true
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=keyword_1
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,30 +78,31 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#FFCC25;;true
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=string_1,italic
 character=string_1
 backticks=string_2
 here_doc=string_2
 
+scalar=string_2
 label=default,bold
-preprocessor=0x808000
+preprocessor=default
 regex=number_1
-operator=0x300080
+operator=default
 decorator=string_1,bold
-other=0x404080
+other=default
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
 
-tag=type
+tag=#FFF
 tag_unknown=tag,bold
 tag_end=tag,bold
-attribute=keyword_1
+attribute=#FFF;;true
 attribute_unknown=attribute,bold
 value=string_1
 entity=default
@@ -109,6 +110,7 @@ entity=default
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
-line_changed=preprocessor
+line_added=#000
+line_removed=#c00
+line_changed=#00c
+

--- a/data/colorschemes/hacker.conf
+++ b/data/colorschemes/hacker.conf
@@ -1,0 +1,116 @@
+#~ Copyright (C) 2022 Pau Chen You (cycool29) <cycool29(at)gmail(dot)com>
+
+#~ This program is free software; you can redistribute it and/or
+#~ modify it under the terms of the GNU General Public License
+#~ as published by the Free Software Foundation; either version 2
+#~ of the License, or (at your option) any later version.
+
+#~ This program is distributed in the hope that it will be useful,
+#~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+#~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#~ GNU General Public License for more details.
+
+#~ You should have received a copy of the GNU General Public License
+#~ along with this program; if not, write to the Free Software
+#~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+[theme_info]
+name=Hacker 
+description= A colorscheme inspired by the Retro theme, but with more colours.
+# incremented automatically, do not change manually
+version=0
+author=Pau Chen You
+url=https://github.com/cycool29/hacker-theme-geany
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#0f0;#000;false;false
+error=#a52a2a;#000;true;true
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#;#aaa;true;true
+current_line=#000;#030;true;false
+brace_good=#0f0;#4e9a06;true;false
+brace_bad=#0f0;#a52a2a;true;false
+margin_line_number=#eee;#282828;false;false
+margin_folding=#888a85;#282828;false;false
+fold_symbol_highlight=#000
+indent_guide=#474545;#000;false;false
+caret=#0f0;#000;false;false
+marker_line=#000;#ff0;false;false
+marker_search=#000;#b8f4b8;false;false
+marker_mark=#000;#b8f4b8;
+call_tips=#c0c0c0;#0f0;false;false
+white_space=#506369;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#808080;#000;false;false
+comment_doc=#0a0;#000;false;true
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#c80000;#000;false;false
+number_1=number
+number_2=number_1
+
+type=#0f0;#000;true;false
+class=#be5f00;#000;true;true
+function=type
+parameter=#ffa500;#000;true;false
+
+keyword=#8ae234;#0f0;true;false
+keyword_1=#558eff;#000;true;false
+keyword_2=#a0a;#000;true;false
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#0099ff;#000;false;false
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=#0f0;#ad7fa8;false;false
+character=string
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#ad7fa8;#000;true;false
+regex=#4e9a06;#000;false;false
+operator=#0f0;#000;false;false
+decorator=#be5f00;#000;false;false
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#729fcf;#000;true;false
+tag_unknown=#0f0;#8c0101;true;false
+tag_end=#7392cf;#000;true;false
+attribute=#be5f00;#000;false;false
+attribute_unknown=#0f0;#8c0101;false;false
+value=#0f0;#000;false;false
+entity=#ad7fa8;#000;false;false
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_removed=#f00;#000;true;false
+line_added=#85ff85;#000;true;false
+line_changed=#ff0;#0f0;true;false
+

--- a/data/colorschemes/himbeere.conf
+++ b/data/colorschemes/himbeere.conf
@@ -1,0 +1,135 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+
+[theme_info]
+name=Himbeere
+description=A dark theme with raspberry colors.
+# incremented automatically, do not change manually
+version=1226
+author=commenthol
+url=https://github.com/codebrainz/geany-themes
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_colors]
+base0=#ccc
+base1=#1a1c1e
+base2=#3f3f3f
+base3=#808080
+base4=#303030
+berry=#e12d66
+cyan=#25d0f0
+bluegrey=#747e9e
+orange=#ff8000
+lime=#65ff00
+grey=#777
+red=#f00
+redbg=#751212
+green=#859900
+blue=#268bd2
+
+[named_styles]
+default=base0;base1
+error=red
+
+
+# Editor styles
+#-------------------------------------------------------------------------------
+selection=;#083840;;true
+current_line=;#000;true
+brace_good=cyan;berry;true
+brace_bad=red;;true
+margin_line_number=base3;base4
+margin_folding=base3;#212121
+fold_symbol_highlight=base2
+indent_guide=base2;;true
+caret=cyan
+marker_line=#fff;#00f;
+marker_search=#fff;#d791a8;
+marker_mark=;
+call_tips=base0;base1
+white_space=base2;;true
+
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=grey
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=orange
+number_1=number
+number_2=number_1
+
+type=berry;;true
+class=cyan
+function=berry
+parameter=function
+
+keyword=berry;;true
+keyword_1=keyword
+keyword_2=cyan;;true
+keyword_3=bluegrey
+keyword_4=keyword_3
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=lime
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=red
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=keyword,bold
+preprocessor=cyan
+regex=number_1
+operator=bluegrey
+decorator=string_1,bold
+other=cyan
+
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=berry
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=cyan
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=green
+line_removed=red
+line_changed=blue

--- a/data/colorschemes/inkpot.conf
+++ b/data/colorschemes/inkpot.conf
@@ -1,0 +1,118 @@
+#
+# Copyright 2012 Campbell Barton <ideasman42(at)gmail(dot)com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+
+[theme_info]
+name=InkPot
+description=Based on the vim theme of the same name.
+# incremented automatically, do not change manually
+version=1226
+author=Campbell Barton <ideasman42(at)gmail(dot)com>
+url=https://github.com/codebrainz/geany-themes
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#cfbfad;#1e1e27;false;false
+error=#1e1e1e;#f00;false;false
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=;#4e4e8f;false;true
+current_line=#000;#2d2d32;true
+brace_good=#cfbfad;#4e4e8f
+brace_bad=#cfbfad;#f00
+margin_line_number=#8b8bcd;#2e2e2e
+margin_folding=#000;#3e3e3e;false;false
+fold_symbol_highlight=#6e6e6e
+indent_guide=#3b3b4d;;true;false
+caret=#8b8bff;#fff;false;false
+marker_line=#000;#ff0;false;false
+marker_search=#000;#b8f4b8;false;false
+marker_mark=#000;#b8f4b8;
+call_tips=default
+white_space=indent_guide
+
+# Generic programming languages
+#-------------------------------------------------------------------------------
+
+comment=#cd8b00
+comment_doc=#737dd5
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=#4e5ab3;;true
+comment_doc_keyword_error=comment_doc
+
+number=#f0ad6d
+number_1=number
+number_2=number_1
+
+type=#ff8bff;;true
+class=#ff8bff
+function=#ff8bff
+parameter=function
+
+keyword=#808bed
+keyword_1=keyword
+keyword_2=#afc2ff;;true
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#ffcd8b;#404040
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1
+character=string
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=#e76000;;bold
+preprocessor=#409090
+regex=number_1
+operator=#eee8d5
+decorator=#e76000;;true
+other=#808bed
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=type
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=#ff8bff
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#0a0
+line_removed=#f00
+line_changed=#e7b937

--- a/data/colorschemes/kugel.conf
+++ b/data/colorschemes/kugel.conf
@@ -1,0 +1,132 @@
+#
+# Copyright 2011 Thomas Martitz <thomas.martitz(at)student.htw-berlin(dot)de>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+#
+
+[theme_info]
+name=Kugel
+description=A dark, but not too dark with focus to be comfortable to the eyes.
+# incremented automatically, do not change manually
+version=1226
+author=Thomas Martitz <thomas.martitz@student.htw-berlin.de>
+url=https://github.com/codebrainz/geany-themes
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#ececec;#2d3335;false;false
+error=#f00;;true;false
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#fff;#333964;false;true
+current_line=#000;#282d2e;true;false
+brace_good=#fff;#50aa15;true;false
+brace_bad=#fff;#aa1515;true;false
+margin_line_number=#ececec
+margin_folding=#888a85;#3a4145
+fold_symbol_highlight=#fff
+indent_guide=#606c70
+caret=#ddd;#000;false
+marker_line=#000;#ff0;
+marker_search=#000;#0000f0;
+marker_mark=#000;#b8f4b8;
+call_tips=#555753;#eeeeec
+white_space=#606c70;#fff;true;false
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#888a85
+comment_doc=#3f5fbf
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc_keyword,italic
+
+number=#06a7a7
+number_1=number
+number_2=number_1
+
+type=#1e90ff
+class=type
+function=default
+parameter=#bbf647
+
+keyword=#729fcf
+keyword_1=keyword
+keyword_2=type
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#dd4040
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=#000;#e0c0e0
+character=#8ae234
+backticks=#30ff00
+# here_doc ???
+here_doc=#ff84cd
+
+scalar=#bcf360
+# label ???
+label=default,bold
+preprocessor=#acac00
+regex=#aaff57
+operator=#fcaf3e
+decorator=preprocessor
+other=default
+extra=#404080
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=type
+tag_unknown=tag,italic
+tag_end=tag
+attribute=keyword
+attribute_unknown=attribute,italic
+value=string_1
+entity=preprocessor
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#34b034
+line_removed=#ff2727
+line_changed=#7f007f

--- a/data/colorschemes/kurayami.conf
+++ b/data/colorschemes/kurayami.conf
@@ -1,0 +1,153 @@
+#
+# Copyright 2023 Kevin Manca
+# Copyright 2024 Thomas Herrle <therrle(at)gmail(dot)com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Kurayami Theme for Geany
+# Derived from Kevin M's Kurayami kitty theme (github.com/kevinm6)
+# Original license: MIT
+# Upstream: https://github.com/kevinm6/kitty-themes/blob/master/themes/kurayami.conf
+# Ported to Geany by Thomas Herrle 
+
+[theme_info]
+name=Kurayami
+description=A dark theme emphasizing readability with muted colors
+version=1
+author=Kevin M (Kitty theme) - Ported to Geany
+url=https://github.com/kevinm6/kitty-themes/blob/master/themes/kurayami.conf
+compat=1.22;1.23;1.23.1;1.24
+
+[named_colors]
+# Basic colors
+fg=#cccccc
+bg=#1c1c1c
+selection_fg=#cccccc
+selection_bg=#264f78
+
+# Base colors
+black=#2c2c2c
+bright_black=#626262
+red=#bf616a
+bright_red=#b2201f
+green=#00af87
+bright_green=#36F57A
+yellow=#cecb00
+bright_yellow=#fffd00
+blue=#158C8A
+bright_blue=#1a8fff
+purple=#B48EAD
+bright_purple=#cb1ed1
+cyan=#1a8fff
+bright_cyan=#14ffff
+white=#dcdcdc
+bright_white=#ffffff
+
+# Additional UI colors
+cursor=#ffffff
+cursor_bg=#3c3c3c
+tab_active_fg=#DCDCDC
+tab_active_bg=#015A60
+tab_inactive_fg=#808080
+tab_inactive_bg=#3c3c3c
+url_color=#0087bd
+
+[named_styles]
+default=fg;bg;false;false
+error=bright_red;bg;false;true
+
+# Editor styles
+selection=selection_fg;selection_bg;false;true
+current_line=;black;true
+brace_good=bright_blue;black;true
+brace_bad=bright_red;black;true
+margin_line_number=bright_black;black
+margin_folding=bright_black;black
+fold_symbol_highlight=white
+indent_guide=bright_black
+caret=cursor;;false
+marker_line=yellow;black
+marker_search=black;blue
+marker_mark=green;black
+call_tips=bright_black;black;false;false
+white_space=bright_black;;true
+
+# Programming languages
+comment=bright_black
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment,bold
+comment_doc_keyword_error=comment,italic
+
+number=purple
+number_1=number
+number_2=number_1
+
+type=green
+class=type
+function=type
+parameter=cyan
+
+keyword=blue
+keyword_1=keyword
+keyword_2=cyan
+keyword_3=keyword_1
+keyword_4=keyword_2
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=red
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=green
+regex=number_1
+operator=default
+decorator=string_1,bold
+other=default
+extra=keyword
+
+# Markup languages
+tag=keyword
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=type
+attribute_unknown=attribute,bold
+value=number
+entity=number
+
+# Diff
+line_added=bright_green
+line_removed=bright_red
+line_changed=bright_blue

--- a/data/colorschemes/lgpl-2.0.txt
+++ b/data/colorschemes/lgpl-2.0.txt
@@ -1,0 +1,480 @@
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1991 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is
+ numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Library General Public License, applies to some
+specially designated Free Software Foundation software, and to any
+other libraries whose authors decide to use it.  You can use it for
+your libraries, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the library, or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link a program with the library, you must provide
+complete object files to the recipients so that they can relink them
+with the library, after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  Our method of protecting your rights has two steps: (1) copyright
+the library, and (2) offer you this license which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  Also, for each distributor's protection, we want to make certain
+that everyone understands that there is no warranty for this free
+library.  If the library is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original
+version, so that any problems introduced by others will not reflect on
+the original authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that companies distributing free
+software will individually obtain patent licenses, thus in effect
+transforming the program into proprietary software.  To prevent this,
+we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+  Most GNU software, including some libraries, is covered by the ordinary
+GNU General Public License, which was designed for utility programs.  This
+license, the GNU Library General Public License, applies to certain
+designated libraries.  This license is quite different from the ordinary
+one; be sure to read it in full, and don't assume that anything in it is
+the same as in the ordinary license.
+
+  The reason we have a separate public license for some libraries is that
+they blur the distinction we usually make between modifying or adding to a
+program and simply using it.  Linking a program with a library, without
+changing the library, is in some sense simply using the library, and is
+analogous to running a utility program or application program.  However, in
+a textual and legal sense, the linked executable is a combined work, a
+derivative of the original library, and the ordinary General Public License
+treats it as such.
+
+  Because of this blurred distinction, using the ordinary General
+Public License for libraries did not effectively promote software
+sharing, because most developers did not use the libraries.  We
+concluded that weaker conditions might promote sharing better.
+
+  However, unrestricted linking of non-free programs would deprive the
+users of those programs of all benefit from the free status of the
+libraries themselves.  This Library General Public License is intended to
+permit developers of non-free programs to use free libraries, while
+preserving your freedom as a user of such programs to change the free
+libraries that are incorporated in them.  (We have not seen how to achieve
+this as regards changes in header files, but we have achieved it as regards
+changes in the actual functions of the Library.)  The hope is that this
+will lead to faster development of free libraries.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, while the latter only
+works together with the library.
+
+  Note that it is possible for a library to be covered by the ordinary
+General Public License rather than by this special one.
+
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library which
+contains a notice placed by the copyright holder or other authorized
+party saying it may be distributed under the terms of this Library
+General Public License (also called "this License").  Each licensee is
+addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also compile or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    c) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    d) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the source code distributed need not include anything that is normally
+distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Library General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/data/colorschemes/lgpl-2.1.txt
+++ b/data/colorschemes/lgpl-2.1.txt
@@ -1,0 +1,501 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/data/colorschemes/matcha.conf
+++ b/data/colorschemes/matcha.conf
@@ -1,0 +1,130 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+
+[theme_info]
+name=Matcha
+description=A dark theme with Matcha colors, based on Himbeere.
+# incremented automatically, do not change manually
+author=xelser
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24;1.37.1
+
+[named_colors]
+base0=#CCCCCC
+base1=#222222
+base2=#808080
+aliz=#F0544C
+azul=#3498DB
+sea=#2EB398
+grey=#777777
+yellow=#FFFF55
+cyan=#00AAAA
+red=#FF5555
+green=#55FF55
+blue=#0000AA
+
+[named_styles]
+default=base0;base1
+error=red
+
+
+# Editor styles
+#-------------------------------------------------------------------------------
+selection=;#333;;true
+current_line=;#111;true
+brace_good=cyan;aliz;true
+brace_bad=red;;true
+margin_line_number=grey;base1
+margin_folding=base2;base1
+fold_symbol_highlight=base1
+indent_guide=grey;;true
+caret=cyan
+marker_line=#fff;#00f;
+marker_search=#fff;#d791a8;
+marker_mark=;
+call_tips=base0;base1
+white_space=grey;;true
+
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=grey;;;true
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=yellow
+number_1=number
+number_2=number_1
+
+type=aliz;;true
+class=cyan
+function=aliz
+parameter=function
+
+keyword=aliz;;true
+keyword_1=keyword
+keyword_2=cyan;;true
+keyword_3=azul
+keyword_4=keyword_3
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=sea
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=red
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=keyword,bold
+preprocessor=cyan
+regex=number_1
+operator=azul
+decorator=string_1,bold
+other=cyan
+
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=aliz
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=cyan
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=green
+line_removed=red
+line_changed=blue

--- a/data/colorschemes/mc.conf
+++ b/data/colorschemes/mc.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright 2012 Henrik Pauli <ralesk@drangolin.net>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,82 +18,85 @@
 #
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Ralesk's MC
+description=Midnight Commander-like scheme
+# incremented automatically, do not change manually
+version=1225
+author=Henrik Pauli <ralesk@drangolin.net>
+url=http://share.drangolin.net/mc.conf
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#c0c0c0;#114;false;false
+error=#fff;#f00
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#000;#369;true;true
+current_line=#000;#12126d;false
+brace_good=#c0c0c0;#369;true;false
+brace_bad=#fff;#f00;true;false
+margin_line_number=#114;#393
+margin_folding=#f4d432;#7f3f00
+fold_symbol_highlight=#7f3f00
+indent_guide=#242490
+caret=#c3f;#000;true
+marker_line=#000;#ff0
+marker_search=#000;#0000f0
+marker_mark=#000;#b8f4b8
+call_tips=#c0c0c0;#fff;false;false
+white_space=#3636a3;#fff;true;false
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#960;;;true
+comment_doc=#c60;;;true
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#3fcfcf
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#fff;;true
 class=type
-function=0x000080
-parameter=function
+function=#d3d7cf
+parameter=#f99
 
-keyword=0x003030;;true
+keyword=#f4d432;;true
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=#9f0200;;true
 keyword_3=keyword_1
 keyword_4=keyword_1
 
 identifier=default
-identifier_1=identifier
-identifier_2=identifier_1
-identifier_3=identifier_1
-identifier_4=identifier_1
+identifier_1=#0f0
+identifier_2=#fff
+identifier_3=#0ff
+identifier_4=#7f0000
 
-string=0x008000
+string=#3a3
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
-character=string_1
-backticks=string_2
+string_eol=#000;#e0c0e0
+character=#5c5
+backticks=#fff;#000
 here_doc=string_2
 
 label=default,bold
-preprocessor=0x808000
-regex=number_1
-operator=0x300080
+preprocessor=#808000
+regex=#2f7f7f
+operator=#ff0
 decorator=string_1,bold
-other=0x404080
+other=#404080
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
@@ -109,6 +112,6 @@ entity=default
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
+line_added=#008b8b
+line_removed=#6a5acd
 line_changed=preprocessor

--- a/data/colorschemes/metallic-bottle.conf
+++ b/data/colorschemes/metallic-bottle.conf
@@ -1,6 +1,6 @@
-#
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
-#
+###
+# Copyright 2013 Tomasz Wyderka <wyderkat(at)cofoh(dot)com>
+##
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -18,57 +18,57 @@
 #
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Metallic Bottle
+description=Bright color scheme matching GTK "Radiance" theme.
+version=1.22.0
+author=Tomasz Wyderka
+url=http://www.cofoh.com/mettalic_bottle
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#000;#fbfaf9;false;false
+error=#fff;#843121;false;true
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#000;#c48c65;false;true
+current_line=#000;#fff;true
+brace_good=#757c75;;true;false
+brace_bad=#843121;;true;false
+margin_line_number=#000;#dfd7cf
+margin_folding=#000;#f6f4f2
+fold_symbol_highlight=#fff
+indent_guide=#3d291c
+caret=#843121
+marker_line=#000;#1d1613
+marker_search=#000;#843121
+marker_mark=#000;#757c75
+call_tips=#a1654b;#fff;false;false
+white_space=#a1654b;#fff;true;false
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#757c75;;false;true
+comment_doc=#4b4a3a;;false;true
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#644129
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#843121;;true
 class=type
-function=0x000080
+function=#843121
 parameter=function
 
-keyword=0x003030;;true
+keyword=#1d1613;;true
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=#3d291c;;true;true
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,22 +78,23 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#4b4a3a
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=#000;#e0c0e0
 character=string_1
 backticks=string_2
 here_doc=string_2
 
+scalar=string_2
 label=default,bold
-preprocessor=0x808000
+preprocessor=#c48c65
 regex=number_1
-operator=0x300080
+operator=#d0c096
 decorator=string_1,bold
-other=0x404080
+other=#c48c65
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
@@ -109,6 +110,6 @@ entity=default
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
-line_changed=preprocessor
+line_added=#c48c65
+line_removed=#843121
+line_changed=#fbfaf9

--- a/data/colorschemes/notepad-plus-plus.conf
+++ b/data/colorschemes/notepad-plus-plus.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright 2013 Paul <phpbased.net@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,59 +16,65 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 #
+# Note: Notepad++ port
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Notepad-plus-plus
+description=Default theme port from Notepad++
+version=122
+author=Paul <phpbased.net@gmail.com>
+url=
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#000080;#fefcf5
+error=#f00;#bfbfbf
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=;#c0c0c0;false;true
+current_line=#e8e8ff;#e8e8ff;true;true
+brace_good=#f00;;true
+brace_bad=#f00
+margin_line_number=#808080;#e4e4e4
+margin_folding=#808080;#f3f3f3
+fold_symbol_highlight=#fff
+indent_guide=#c0c0c0;#fff;true;true
+caret=#8000ff;#fefcf5
 
-# Programming languages
+marker_line=#7f7f7f;#ececec
+marker_search=;#0f0
+marker_mark=#7f7f7f;#ececec
+
+call_tips=default
+white_space=#c0c0c0;#fff;true;false
+
+# Generic programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#008000
+comment_doc=comment
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#ff8000
 number_1=number
-number_2=number_1
+number_2=#f00
 
-type=0x2E8B57;;true
+type=#00f;#fff
 class=type
-function=0x000080
+function=#900
 parameter=function
 
-keyword=0x003030;;true
+keyword=#00f;#fefcf5;true
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=#aa2c8c;;true
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,22 +84,24 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#808080;#fefcf5
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=string_1,italic
 character=string_1
 backticks=string_2
 here_doc=string_2
 
+scalar=string_2
 label=default,bold
-preprocessor=0x808000
+preprocessor=#000080;#fefcf5
 regex=number_1
-operator=0x300080
+operator=#8000ff;#fefcf5
 decorator=string_1,bold
-other=0x404080
+other=default
+
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
@@ -101,14 +109,14 @@ other=0x404080
 tag=type
 tag_unknown=tag,bold
 tag_end=tag,bold
-attribute=keyword_1
+attribute=#f00
 attribute_unknown=attribute,bold
-value=string_1
+value=#8000ff;#fff
 entity=default
 
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
-line_changed=preprocessor
+line_added=#3de737
+line_removed=#e74837
+line_changed=#e7b937

--- a/data/colorschemes/oblivion2.conf
+++ b/data/colorschemes/oblivion2.conf
@@ -1,0 +1,120 @@
+#
+# Copyright Bernhard Posselt <bernhard.posselt(at)gmx(dot)at>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+# Ported from old theme by Matthew Brush <matt(at)geany(dot)org>
+#
+
+[theme_info]
+name=Oblivion 2
+description=Based on the Gedit color scheme Oblivion and the Dark Color Scheme with rearranged colors.
+# incremented automatically, do not change manually
+version=1225
+author=Bernhard Posselt <bernhard.posselt(at)gmx(dot)at>
+url=http://download.geany.org/contrib/oblivion2.tar.gz
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#fff;#2e3436;false;false
+error=#fff;#f00
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#000;#a52a2a;false;true
+current_line=#000;#292929;true;false
+brace_good=#fff;#4e9a06;true;false
+brace_bad=#fff;#a52a2a;true;false
+margin_line_number=#eee;#000;false;false
+margin_folding=#888a85;#000;false;false
+fold_symbol_highlight=#000
+indent_guide=#474545;#2e3436;false;false
+caret=#fff;#000;false;false
+marker_line=#000;#ff0;false;false
+marker_search=#000;#b8f4b8;false;false
+marker_mark=#000;#b8f4b8;
+call_tips=#c0c0c0;#fff;false;false
+white_space=#506369;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#888a85;#2e3436;false;false
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#ef2929;#2e3436;false;false
+number_1=number
+number_2=number_1
+
+type=#729fcf;#2e3436;true;false
+class=type
+function=default
+parameter=function
+
+keyword=#8ae234;#2e3436;true;false
+keyword_1=keyword
+keyword_2=#729fcf;#2e3436;true;false
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#edd400;#2e3436;false;false
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=#fff;#ad7fa8;false;false
+character=#a18651;#2e3436;false;false
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#ad7fa8;#2e3436;true;false
+regex=#4e9a06;#2e3436;false;false
+operator=#ad7fa8;#2e3436;true;false
+decorator=#729fcf;#2e3436;false;false
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#729fcf;#2e3436;true;false
+tag_unknown=#fff;#8c0101;true;false
+tag_end=#7392cf;#2e3436;true;false
+attribute=#fff;#2e3436;true;false
+attribute_unknown=#fff;#8c0101;false;false
+value=#4575b6;#2e3436;false;false
+entity=#ad7fa8;#2e3436;false;false
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#729fcf;#2e3436;true;false
+line_removed=#8ae234;#2e3436;true;false
+line_changed=#fff;#fff;true;false

--- a/data/colorschemes/octagon.conf
+++ b/data/colorschemes/octagon.conf
@@ -1,0 +1,136 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+# Colors selected by jag(at)justaguylinux(dot)com
+# Colors adapted from the Monokia Pro theme (https://github.com/loctvl842/monokai-pro.nvim)
+# Author: Drew Griffin
+
+[theme_info]
+name=Octagon
+description=A dark theme using Monokai Pro Octagon color palette
+# incremented automatically, do not change manually
+version=0.1.0
+author=Drew Griffin
+compat=1.38;2.0;
+# Octagon is a theme inspired by https://github.com/loctvl842/monokai-pro.nvim:
+# Colors selected by DrewG @ justaguylinux(dot)com
+
+[named_colors]
+bg=#282a3a
+bg+1=#3a3d4b
+bg+2=#535763
+fg-4=#696d77
+fg-3=#888d94
+fg-2=#a0a5ae
+fg-1=#eaf2f1
+fg=#f5f9f8
+
+white=#ffffff
+red=#ff657a
+orange=#ff9b5e
+yellow=#ffd76d
+green=#bad761
+blue=#9cd1bb
+purple=#c39ac9
+pink=#ff657a
+
+[named_styles]
+default=fg;bg;false;false
+error=red;bg+1;false;false
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=bg+2;fg-4;false;true
+current_line=bg+1;;true;false
+brace_good=blue;;true;false
+brace_bad=red;bg;true;false
+margin_line_number=fg-3;bg+1;false;false
+margin_folding=fg-4;bg+2;false;false
+fold_symbol_highlight=fg-3
+indent_guide=fg-4
+caret=fg;bg;false
+marker_line=fg-2;yellow
+marker_search=blue;bg+1;false;false
+marker_mark=orange;bg;false;false
+call_tips=fg-1;bg+2;false;false
+white_space=fg-4;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=fg-3;;;true
+comment_doc=fg-3;bg+1;false;false
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=green
+number_1=number
+number_2=number_1
+
+type=purple;;true;false
+class=type
+function=type
+parameter=function
+
+keyword=orange;;true;false
+keyword_1=keyword
+keyword_2=yellow;;true;false
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=red
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=red;#000;false;false
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=fg-2
+regex=number_1
+operator=orange
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=yellow;bg+1;false;false
+tag_unknown=green;bg;false;false
+tag_end=fg-2;bg;false;false
+attribute=orange;bg+1;false;false
+attribute_unknown=green;bg;false;false
+value=fg;bg;false;false
+entity=fg;bg;false;false
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=green;bg+1;false;false
+line_removed=red;bg;false;false
+line_changed=blue;bg+2;false;false

--- a/data/colorschemes/one-dark.conf
+++ b/data/colorschemes/one-dark.conf
@@ -1,0 +1,148 @@
+# Copyright (c) 2016 GitHub Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR #
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Ported to Geany and tweaked by Jefferson González <jgmdev(at)gmail(dot)com>
+#
+
+[theme_info]
+name=One Dark
+description=Port of atom one dark theme.
+# incremented automatically, do not change manually
+version=1
+author=GitHub Inc.
+url=https://github.com/atom/atom/tree/master/packages/one-dark-syntax
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_colors]
+
+# Monochrome -----------------------------------
+mono_1=#abb2bf
+mono_2=#828997
+mono_3=#5c6370
+mono_4=#282c34
+mono_5=#2C313C
+mono_6=#21252B
+
+# Colors -----------------------------------
+cyan=#56b6c2
+blue=#61afef
+purple=#c678dd
+green=#98c379
+red_light=#e06c75
+red_dark=#be5046
+orange_dark=#d19a66
+orange_light=#e5c07b
+
+# Base colors -----------------------------------
+syntax_fg=#abb2bf
+syntax_bg=#282c34
+syntax_gutter=#89909f
+syntax_guide=#b7bfcd
+syntax_accent=#528cff
+
+[named_styles]
+default=syntax_fg;mono_4;false;false
+error=syntax_fg;red_dark;false;false
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=;#404859;false;true
+current_line=;mono_5;true
+brace_good=mono_1;mono_3;false
+brace_bad=error
+margin_line_number=syntax_gutter;syntax_bg
+margin_folding=mono_3;syntax_bg
+fold_symbol_highlight=mono_1
+indent_guide=mono_3
+caret=syntax_accent;;true
+marker_line=syntax_guide;syntax_bg
+marker_search=mono_2;cyan
+marker_mark=mono_2;syntax_bg
+call_tips=mono_1;mono_6
+white_space=mono_3;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=mono_2
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=purple;;true;false
+comment_doc_keyword_error=red_light;;false;true
+
+number=orange_dark
+number_1=number
+number_2=number_1
+
+type=purple
+class=orange_light
+function=blue;;true;false
+parameter=red_light
+
+keyword=blue;;true;false
+keyword_1=purple;;false;false
+keyword_2=blue;;false;false
+keyword_3=green
+keyword_4=keyword_1
+
+identifier=orange_light
+identifier_1=default
+identifier_2=purple
+identifier_3=red_dark
+identifier_4=red_light
+
+string=green
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=cyan;;false;true
+character=string_1
+backticks=string_2
+here_doc=orange_dark
+
+scalar=orange_light
+label=default,bold
+preprocessor=red_light
+regex=number_1
+operator=cyan
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=red_light
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=orange_dark
+attribute_unknown=attribute,bold
+value=string
+entity=orange_dark
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=green
+line_removed=red_light
+line_changed=orange_light

--- a/data/colorschemes/pygments.conf
+++ b/data/colorschemes/pygments.conf
@@ -1,0 +1,131 @@
+#
+# Copyright (c) 2006-2012 by the respective authors.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Ported to Geany by Nicolas Holvoët <contact(at)nhrx(dot)org>
+#
+
+[theme_info]
+name=Pygments
+description=Default Pygments theme for Geany
+# incremented automatically, do not change manually
+version=1226
+author=Pocoo
+url=http://pygments.org
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#161616;#f8f8f8;false;false
+error=#f00;#bfbfbf
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#2e3436;#cacaca;false;true
+current_line=#2e3436;#e7e7e7;true
+brace_good=#9433ad;#dcd4e0;true
+brace_bad=#ddd;#e0754a;true
+margin_line_number=#3a4346;#d6d6d6
+margin_folding=#747474;#e1e1e1
+fold_symbol_highlight=#d6d6d6
+indent_guide=#b5b5b5
+caret=#000;#000;false
+marker_line=#2e3436;#729fcf
+marker_search=#2e3436;#fcaf3e
+marker_mark=#565656;#d4d4d4
+call_tips=default
+white_space=#b5b5b5;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#408080;;;true
+comment_doc=#3465a4;;;true
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc_keyword,italic
+
+number=#666
+number_1=number
+number_2=number_1
+
+type=#0032ff;;true
+class=type
+function=#0026bc
+parameter=function
+
+keyword=#008000;;true
+keyword_1=keyword
+keyword_2=#008000
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#ba2121;;false;false
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+verbatim=string
+
+scalar=string_2
+label=default,bold
+preprocessor=#af7100
+regex=number_1
+operator=default
+decorator=#a2f
+other=default
+extra=#204a87
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#008000;;true
+tag_unknown=tag
+tag_end=tag
+attribute=#0032ff;;true
+attribute_unknown=attribute,italic
+value=string_1
+entity=preprocessor
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#256a1b
+line_removed=#a40000
+line_changed=#ce5c00

--- a/data/colorschemes/retro.conf
+++ b/data/colorschemes/retro.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright 2011 Matthew Brush <mbrush(at)codebrainz(dot)ca>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,57 +18,57 @@
 #
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Retro
+description=Inspired by old green screen terminals.
+# incremented automatically, do not change manually
+version=6
+author=Matthew Brush
+url=
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#008500;#000;false;false
+error=#c00
 
-# Editor styles
-#-------------------------------------------------------------------------------
-
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#000;#0c0;true;true
+current_line=;;false
+brace_good=default
+brace_bad=default,bold
+margin_line_number=default
+margin_folding=default
+fold_symbol_highlight=#000
+indent_guide=default
+caret=#0c0;#000;true;true
+marker_line=default,italic
+marker_search=;#000
+marker_mark=#0c0;#000
+call_tips=#000;#0c0;true;true
+white_space=#104e10;;true
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#67e667
+comment_doc=comment
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#39e639
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#0c0;;true
 class=type
-function=0x000080
+function=default
 parameter=function
 
-keyword=0x003030;;true
+keyword=#008500;;true
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=keyword_1
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,30 +78,31 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#269926;;true
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=string_1,italic
 character=string_1
 backticks=string_2
 here_doc=string_2
 
+scalar=string_2
 label=default,bold
-preprocessor=0x808000
+preprocessor=default
 regex=number_1
-operator=0x300080
+operator=default
 decorator=string_1,bold
-other=0x404080
+other=default
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
 
-tag=type
+tag=#0c0
 tag_unknown=tag,bold
 tag_end=tag,bold
-attribute=keyword_1
+attribute=#0c0;;true
 attribute_unknown=attribute,bold
 value=string_1
 entity=default
@@ -109,6 +110,6 @@ entity=default
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
-line_changed=preprocessor
+line_added=#0c0
+line_removed=#c00
+line_changed=#00c

--- a/data/colorschemes/sleepy-pastel.conf
+++ b/data/colorschemes/sleepy-pastel.conf
@@ -1,0 +1,102 @@
+#
+# Public Domain
+#
+# Inspired by the tango theme: https://github.com/codebrainz/geany-themes/blob/master/colorschemes/tango-dark.conf
+# 
+
+[theme_info]
+name=Sleepy Pastel
+description=Dark theme inspired by Tango 
+version=1.0.0
+author=randomekek on github
+url=https://github.com/codebrainz/geany-themes/blob/master/sleepy-pastel.conf
+
+[named_styles]
+
+default=#dfdee0;#2e3436;false;false
+error=#fff;#f00
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#000;#626d71;false;true
+current_line=#000;#363f41;true
+brace_good=#cb956d;#4c5153;false;false
+brace_bad=#d7616d;#4c5153;true;false
+margin_line_number=#b2cba3;#4c5153
+margin_folding=#b2cba3;#4c5153
+fold_symbol_highlight=#4c5153
+indent_guide=#666
+caret=#ddd;#000;false
+marker_line=#000;#49473f
+marker_search=#000;#f0f0f0
+marker_mark=#000;#49473f
+call_tips=#b2cba3;#4c5153;true;true
+white_space=#666;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#888a85;#2e3436;false;false
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#8ae234;#2e3436;false;false
+number_1=number
+number_2=number_1
+
+type=#eeeeec;#2e3436;false;false
+class=type
+function=default
+parameter=function
+
+keyword=#729fcf;#2e3436;false;false
+keyword_1=keyword
+keyword_2=keyword_1
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#93cf55;#2e3436;false;false
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backtick=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#5db895;#2e3436;false;false
+regex=number_1
+operator=#cb956d;#2e3436;false;false
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#729fcf;#2e3436;false;false
+tag_unknown=tag
+tag_end=tag,bold
+attribute=#729fcf;#2e3436;false;false
+attribute_unknown=attribute
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#79c580
+line_removed=#dc8383
+line_changed=#c0afd3

--- a/data/colorschemes/slushpoppies.conf
+++ b/data/colorschemes/slushpoppies.conf
@@ -1,0 +1,120 @@
+#
+# Copyright 2006-2007 Will Farrington <wcfarrington(at)gmail(dot)com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Ported to Geany by Matthew Brush <matt(at)geany(dot)org>
+#
+
+[theme_info]
+name=Slush and Poppies
+description=A port of Slush and Poppies from gedit-themes.
+# incremented automatically, do not change manually
+version=1225
+author=Will Farrington <wcfarrington(at)gmail(dot)com>
+url=https://github.com/mig/gedit-themes/blob/master/slush_and_poppies.xml
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#000;#f8f8ff;false;false
+error=#f8f8ff;#800000
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#000;#c0c0c0;false;true
+current_line=#000;#d9d9d9;true
+brace_good=;#4f94cd
+brace_bad=;#002f29;true
+margin_line_number=#000;#d0d0d0
+margin_folding=#000;#dfdfdf
+fold_symbol_highlight=#fff
+indent_guide=#c0c0c0
+caret=#000;#000;false
+marker_line=#000;#ff0
+marker_search=#000;#0000f0
+marker_mark=#000;#b8f4b8
+call_tips=#c0c0c0;#fff;false;false
+white_space=#c0c0c0;#fff;true;false
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#406040
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#2060a0
+number_1=number
+number_2=number_1
+
+type=#800000;;true
+class=type
+function=default
+parameter=function
+
+keyword=#0080a0;;true
+keyword_1=keyword
+keyword_2=keyword_1
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#c03030
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#800000
+regex=number_1
+operator=default
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#0080a0
+tag_unknown=tag
+tag_end=tag
+attribute=#8000c0
+attribute_unknown=attribute
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#008b8b
+line_removed=#6a5acd
+line_changed=preprocessor

--- a/data/colorschemes/solarized-dark.conf
+++ b/data/colorschemes/solarized-dark.conf
@@ -1,0 +1,147 @@
+#
+# Copyright 2011 Ethan Schoonover <es(at)ethanschoonover(dot)com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Ported to Geany by Joshua Hoff <https://github.com/joshuarh> and
+# Matthew Brush <matt(at)geany(dot)org>
+#
+
+[theme_info]
+name=Solarized (dark)
+description=Dark Solarized theme for Geany
+# incremented automatically, do not change manually
+version=1225
+author=Ethan Schoonover
+url=http://ethanschoonover.com/solarized
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_colors]
+# See: http://ethanschoonover.com/solarized#the-values
+base03=#002b36
+base02=#073642
+base01=#586e75
+base00=#657b83
+base0=#839496
+base1=#93a1a1
+base2=#eee8d5
+base3=#fdf6e3
+yellow=#b58900
+orange=#cb4b16
+red=#dc322f
+magenta=#d33682
+violet=#6c71c4
+blue=#268bd2
+cyan=#2aa198
+green=#859900
+
+[named_styles]
+
+default=base0;base03
+error=red
+
+
+# Editor styles
+#-------------------------------------------------------------------------------
+selection=;#0f4d5c;;true
+current_line=;base02;true
+brace_good=base1;;true
+brace_bad=red;;true
+margin_line_number=base00;base03
+margin_folding=base00;base02
+fold_symbol_highlight=base02
+indent_guide=base01
+caret=base3
+marker_line=;
+marker_search=;base2
+marker_mark=;
+call_tips=base0;base03
+white_space=indent_guide
+
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=base01
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=cyan
+number_1=number
+number_2=number_1
+
+type=yellow;;true
+class=type
+function=blue
+parameter=function
+
+keyword=green;;true
+keyword_1=keyword
+keyword_2=blue;;true
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=magenta
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=red
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=orange
+regex=violet
+operator=default
+decorator=string_1,bold
+other=default
+
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=type
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=keyword_1
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=green
+line_removed=red
+line_changed=blue

--- a/data/colorschemes/solarized-light.conf
+++ b/data/colorschemes/solarized-light.conf
@@ -1,0 +1,147 @@
+#
+# Copyright 2011 Ethan Schoonover <es(at)ethanschoonover(dot)com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Ported to Geany by Joshua Hoff <https://github.com/joshuarh> and
+# Matthew Brush <matt(at)geany(dot)org>
+#
+
+[theme_info]
+name=Solarized (light)
+description=Light Solarized theme for Geany
+# incremented automatically, do not change manually
+version=1225
+author=Ethan Schoonover
+url=http://ethanschoonover.com/solarized
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_colors]
+# See: http://ethanschoonover.com/solarized#the-values
+base03=#002b36
+base02=#073642
+base01=#586e75
+base00=#657b83
+base0=#839496
+base1=#93a1a1
+base2=#eee8d5
+base3=#fdf6e3
+yellow=#b58900
+orange=#cb4b16
+red=#dc322f
+magenta=#d33682
+violet=#6c71c4
+blue=#268bd2
+cyan=#2aa198
+green=#859900
+
+[named_styles]
+
+default=base00;base3
+error=red
+
+
+# Editor styles
+#-------------------------------------------------------------------------------
+selection=;#dbd4be;;true
+current_line=;base2;true
+brace_good=base01;;true
+brace_bad=red;;true
+margin_line_number=base0;base3
+margin_folding=base0;base2
+fold_symbol_highlight=base2
+indent_guide=base1
+caret=base03
+marker_line=;
+marker_search=;
+marker_mark=;
+call_tips=base00;base3
+white_space=indent_guide
+
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=base1
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=cyan
+number_1=number
+number_2=number_1
+
+type=yellow;;true
+class=type
+function=blue
+parameter=function
+
+keyword=green;;true
+keyword_1=keyword
+keyword_2=blue;;true
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=magenta
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=red
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=orange
+regex=violet
+operator=default
+decorator=string_1,bold
+other=default
+
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=type
+tag_unknown=tag,bold
+tag_end=tag,bold
+attribute=keyword_1
+attribute_unknown=attribute,bold
+value=string_1
+entity=default
+
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=green
+line_removed=red
+line_changed=blue

--- a/data/colorschemes/spyder-dark.conf
+++ b/data/colorschemes/spyder-dark.conf
@@ -1,0 +1,118 @@
+#
+# Copyright 2013 Paul Thompson <redoubts(at)gmail(dot)com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301, USA.
+#
+
+[theme_info]
+name=Spyder Dark
+description= A colorscheme inspired by Xubuntu 12.04, and the Spyder IDE.
+# incremented automatically, do not change manually
+version=0
+author=Paul Thompson
+url=https://github.com/Redoubts/SpyderDark
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#fff;#131926;false;false
+error=#a52a2a;#131926;true;true
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#000;#a52a2a;false;true
+current_line=#000;#2b2b43;true;false
+brace_good=#fff;#4e9a06;true;false
+brace_bad=#fff;#a52a2a;true;false
+margin_line_number=#eee;#282828;false;false
+margin_folding=#888a85;#282828;false;false
+fold_symbol_highlight=#000
+indent_guide=#474545;#131926;false;false
+caret=#fff;#000;false;false
+marker_line=#000;#550;false;false
+marker_search=#000;#b8f4b8;false;false
+marker_mark=#000;#b8f4b8;
+call_tips=#c0c0c0;#fff;false;false
+white_space=#506369;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#7f7f7f;#131926;false;false
+comment_doc=#11a642;#131926;false;true
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#c80000;#131926;false;false
+number_1=number
+number_2=number_1
+
+type=#fff;#131926;true;false
+class=#be5f00;#131926;true;true
+function=type
+parameter=#ffa500;#131926;true;false
+
+keyword=#8ae234;#0f0;true;false
+keyword_1=#558eff;#131926;true;false
+keyword_2=#a0a;#131926;true;false
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#11a642;#131926;false;false
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=#fff;#ad7fa8;false;false
+character=string
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#ad7fa8;#131926;true;false
+regex=#4e9a06;#131926;false;false
+operator=#fff;#131926;false;false
+decorator=#be5f00;#131926;false;false
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#729fcf;#131926;true;false
+tag_unknown=#fff;#8c0101;true;false
+tag_end=#7392cf;#131926;true;false
+attribute=#be5f00;#131926;false;false
+attribute_unknown=#fff;#8c0101;false;false
+value=#fff;#131926;false;false
+entity=#ad7fa8;#131926;false;false
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_removed=#729fcf;#131926;true;false
+line_added=#8ae234;#131926;true;false
+line_changed=#000;#fff;true;false

--- a/data/colorschemes/steampunk.conf
+++ b/data/colorschemes/steampunk.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright 2013 Baptiste Darthenay <geany(dot)batisteo(at)recursor(dot)net>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,59 +16,65 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 #
+#
+# Best folding style with this theme, in filedefs/filetypes.common:
+# folding_style=2,2
+#
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Steampunk
+description=A dark brown and shiny brass theme for the 19th century developer.
+version=3
+author=Baptiste Darthenay
+url=https://github.com/batisteo/geany-themes/blob/master/steampunk.conf
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#fea;#252016;false;false
+error=#faecbd;#a22
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#000;#605339;false;true
+current_line=#000;#342d1f;true
+brace_good=#8ab634;#514630;true
+brace_bad=#ce5c00;#484333;true
+margin_line_number=#caa223
+margin_folding=#651;#362a1d
+fold_symbol_highlight=#b79024;#252016
+indent_guide=#b79024
+caret=#d3d7cf;#000
+marker_line=#c4a000;#edd400
+marker_search=#000;#0000f0
+marker_mark=#8c5200;#cf7900
+call_tips=#ccc;#fff;false
+white_space=#650;;true
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#786442
+comment_doc=comment
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#fce94f
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#cf7900;;true
 class=type
-function=0x000080
+function=#cf7900
 parameter=function
 
-keyword=0x003030;;true
+keyword=#cc9d22;;true
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=#729f9c
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,37 +84,40 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#ebc95d
 string_1=string
-string_2=string_1
+string_2=comment,italic
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=string_1,italic
 character=string_1
 backticks=string_2
 here_doc=string_2
+verbatim=string
 
+scalar=string_2
 label=default,bold
-preprocessor=0x808000
+preprocessor=#729f9c
 regex=number_1
-operator=0x300080
-decorator=string_1,bold
-other=0x404080
+operator=#fa5;;true
+decorator=#978;;;true
+other=default
+extra=#359
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
 
-tag=type
-tag_unknown=tag,bold
+tag=#729f9c
+tag_unknown=tag
 tag_end=tag,bold
-attribute=keyword_1
-attribute_unknown=attribute,bold
+attribute=#729f9c
+attribute_unknown=attribute
 value=string_1
 entity=default
 
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
+line_added=#595
+line_removed=#a66
 line_changed=preprocessor

--- a/data/colorschemes/tango-dark.conf
+++ b/data/colorschemes/tango-dark.conf
@@ -1,0 +1,130 @@
+#
+# Created by Barry van Oudtshoorn
+# 
+# This is free and unencumbered software released into the public domain.
+# 
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+# 
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+# 
+# For more information, please refer to <https://unlicense.org>
+# 
+# Ported to Geany by Matthew Brush <matt(at)geany(dot)org>
+#
+
+[theme_info]
+name=Tango
+description=Loosely based on the Dark theme, but Tangofied.
+# incremented automatically, do not change manually
+version=1226
+author=Barry van Oudtshoorn
+url=https://github.com/codebrainz/geany-themes/blob/master/tango-dark.conf
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#eeeeec;#2e3436;false;false
+error=#fff;#f00
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#000;#626d71;false;true
+current_line=#000;#475458;true
+brace_good=#fff;#647175;true;false
+brace_bad=#eea1a8;#647175;true;false
+margin_line_number=#000;#d0d0d0
+margin_folding=#000;#dfdfdf
+fold_symbol_highlight=#fff
+indent_guide=#c0c0c0
+caret=#fbff00;#fbff00;false
+marker_line=#000;#ff0
+marker_search=#000;#0000f0
+marker_mark=#000;#b8f4b8
+call_tips=#c0c0c0;#fff;false;false
+white_space=#505050;;true
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#888a85;#2e3436;false;false
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#8ae234;#2e3436;false;false
+number_1=number
+number_2=number_1
+
+type=#eeeeec;#2e3436;false;false
+class=type
+function=default
+parameter=function
+
+keyword=#729fcf;#2e3436;true;false
+keyword_1=keyword
+keyword_2=keyword_1
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#8ae234;#2e3436;true;false
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=string_1
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#007f7f;#2e3436;true;false
+regex=number_1
+operator=default
+decorator=string_1,bold
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#729fcf;#2e3436;false;false
+tag_unknown=tag
+tag_end=tag,bold
+attribute=#729fcf;#2e3436;false;false
+attribute_unknown=attribute
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#008b8b
+line_removed=#6a5acd
+line_changed=preprocessor

--- a/data/colorschemes/tango-light.conf
+++ b/data/colorschemes/tango-light.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright 2011 Colomban Wendling <lists.ban@herbesfolles.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,57 +18,60 @@
 #
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Tango Light
+description=A light theme using Tango colors.
+# incremented automatically, do not change manually
+version=1225
+author=Colomban Wendling <lists.ban@herbesfolles.org>
+url=https://github.com/codebrainz/geany-themes/blob/master/tango-light.conf
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#2e3436;#eeeeec;false;false
+error=#2e3436;#ef2929
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#2e3436;#babdb6;false;true
+current_line=#2e3436;#d3d7cf;true
+brace_good=#5c3566;;true
+brace_bad=#2e3436;#ef2929;true
+margin_line_number=#2e3436;#babdb6
+margin_folding=#2e3436;#d3d7cf
+fold_symbol_highlight=#d3d7cf
+indent_guide=#babdb6
+caret=#000;#000;false
+marker_line=#2e3436;#729fcf
+marker_search=#2e3436;#fcaf3e
+marker_mark=#2e3436;#8ae234
+call_tips=#555753;#eeeeec
+white_space=#babdb6;;true
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#c00;;;true
+comment_doc=#3465a4;;;true
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
-comment_doc_keyword_error=comment_doc,italic
+comment_doc_keyword_error=comment_doc_keyword,italic
 
-number=0x400080
+number=#4e9a06
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#4e9a06;;true
 class=type
-function=0x000080
+function=default
 parameter=function
 
-keyword=0x003030;;true
+keyword=#204a87;;true
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=#a40000;;true
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,37 +81,40 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#ce5c00;;false;false
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=string_1,italic
 character=string_1
 backticks=string_2
 here_doc=string_2
+verbatim=string
 
+scalar=string_2
 label=default,bold
-preprocessor=0x808000
+preprocessor=#75507b
 regex=number_1
-operator=0x300080
+operator=default
 decorator=string_1,bold
-other=0x404080
+other=default
+extra=#204a87
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
 
-tag=type
-tag_unknown=tag,bold
-tag_end=tag,bold
-attribute=keyword_1
-attribute_unknown=attribute,bold
+tag=#204a87;;true
+tag_unknown=tag
+tag_end=tag
+attribute=#4e9a06;;true
+attribute_unknown=attribute,italic
 value=string_1
-entity=default
+entity=preprocessor
 
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
-line_changed=preprocessor
+line_added=#4e9a06
+line_removed=#a40000
+line_changed=#ce5c00

--- a/data/colorschemes/tinge.conf
+++ b/data/colorschemes/tinge.conf
@@ -1,0 +1,128 @@
+#
+# Copyright (C) 2008 - Harsh J <harshj(at)gmail(dot)com>
+#   See: http://www.harshj.com/2008/01/27/tinge-theme-for-gedit/
+#
+# Tinge is a theme inspired by Monokai and improved upon Darkmate:
+#   Copyright (C) 2006-2008 GtkSourceView team
+#   Original author: Luigi Maselli <luigix(at)gmail(dot)com>
+#   See: http://www.monokai.nl/blog/2006/07/15/textmate-color-theme/
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Ported to Geany by Matthew Brush <matt(at)geany(dot)org>
+#
+
+[theme_info]
+name=Tinge
+description=A tinge more tanginess
+# incremented automatically, do not change manually
+version=1225
+author=Harsh J <harshj(at)gmail(dot)com>
+# alt url:
+# http://www.harshj.com/2008/01/27/tinge-theme-for-gedit/
+url=https://github.com/mig/gedit-themes/blob/master/Tinge.xml
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
+
+[named_styles]
+
+default=#eee;#232323;false;false
+error=;#ff2f6a;true
+
+# Editor styles
+#-------------------------------------------------------------------------------
+
+selection=#000;#555753;false;true
+current_line=#000;#6f6f6f;true
+brace_good=#b6f;#232323;true;false
+brace_bad=#eee;#232323;true;false
+margin_line_number=#bbb;#555753
+margin_folding=#000;#dfdfdf
+fold_symbol_highlight=#fff
+indent_guide=#3d3d3d
+white_space=#3d3d3d;#fff;true;false
+caret=#009cff;#000;false
+marker_line=#bbb;#555753
+marker_search=#bbb;#555753
+marker_mark=#bbb;#555753
+call_tips=#c0c0c0;#fff;false;false
+
+# Programming languages
+#-------------------------------------------------------------------------------
+
+comment=#b6f
+comment_doc=comment
+comment_line=comment
+comment_line_doc=comment_doc
+comment_doc_keyword=comment_doc,bold
+comment_doc_keyword_error=comment_doc,italic
+
+number=#ff2f6a
+number_1=number
+number_2=number_1
+
+type=#009cff;;true
+class=type
+function=#9e91ff
+parameter=function
+
+keyword=#f90;;true
+keyword_1=keyword
+keyword_2=#00c900;;true
+keyword_3=keyword_1
+keyword_4=keyword_1
+
+identifier=default
+identifier_1=identifier
+identifier_2=identifier_1
+identifier_3=identifier_1
+identifier_4=identifier_1
+
+string=#ff3a35
+string_1=string
+string_2=string_1
+string_3=default
+string_4=default
+string_eol=string_1,italic
+character=#f90
+backticks=string_2
+here_doc=string_2
+
+scalar=string_2
+label=default,bold
+preprocessor=#009cff;;true
+regex=#adb2ff
+operator=default
+decorator=#009cff
+other=default
+
+# Markup-type languages
+#-------------------------------------------------------------------------------
+
+tag=#f90
+tag_unknown=#f90
+tag_end=#f90
+attribute=#9e91ff
+attribute_unknown=#9e91ff
+value=string_1
+entity=default
+
+# Diff
+#-------------------------------------------------------------------------------
+
+line_added=#ff3a35
+line_removed=#ff79d9
+line_changed=#f90

--- a/data/colorschemes/ubuntu.conf
+++ b/data/colorschemes/ubuntu.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright 2013 James Brierley <jmb8710(at)gmail(dot)com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,82 +18,84 @@
 #
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Ubuntu
+description=A theme for Ubuntu fanboys and fangirls.
+version=1
+author=James Brierley
+url=
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#000;#fff;false;false
+error=#fff;#f00
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#000;#c0c0c0;false;true
+current_line=#000;#f0f0f0;true
+brace_good=#333;#fff;true;false
+brace_bad=#fff;#333;true;false
+margin_line_number=#000;#d0d0d0
+margin_folding=#000;#dfdfdf
+fold_symbol_highlight=#fff
+indent_guide=#c0c0c0
+caret=#000;#000;false
+marker_line=#000;#ff0
+marker_search=#000;#0000f0
+marker_mark=#000;#b8f4b8
+call_tips=#c0c0c0;#fff;false;false
+white_space=#c0c0c0;#fff;true;false
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#808080
+comment_doc=#595959
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#dd4814
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#5e2750;;true
 class=type
-function=0x000080
+function=#000080
 parameter=function
 
-keyword=0x003030;;true
+keyword=#2c001e;;true
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=#9f0200;;true
 keyword_3=keyword_1
 keyword_4=keyword_1
 
-identifier=default
+identifier=#151515
 identifier_1=identifier
 identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#dd4814
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=#000;#e0c0e0
 character=string_1
 backticks=string_2
 here_doc=string_2
 
 label=default,bold
-preprocessor=0x808000
+preprocessor=comment_doc,bold
 regex=number_1
-operator=0x300080
+operator=#5e2750
 decorator=string_1,bold
-other=0x404080
+other=#404080
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
@@ -109,6 +111,6 @@ entity=default
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
+line_added=#008b8b
+line_removed=#6a5acd
 line_changed=preprocessor

--- a/data/colorschemes/underthesea.conf
+++ b/data/colorschemes/underthesea.conf
@@ -1,6 +1,3 @@
-#
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
-#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -16,59 +13,62 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 #
+# Colors selected by jag(at)justaguylinux(dot)com
+# UndertheSea is a theme inspired by the UnderTheSea iterm2colorscheme
+
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=UndertheSea
+description=Dark flat theme.
+version=0.1.0
+author=Drew Griffin
+compat=1.38;2.0;
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#D8DEE9;#1B2B34;false;false
+error=#EC5F67;#343D46;false;italic
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#000000;#A3BE8C;true;true
+current_line=#FFFFFF;#343D46;true
+brace_good=#000000;#7FEC75;true;false
+brace_bad=#000000;#FF5656;true;false
+margin_line_number=#C0C5CE;#17252c
+margin_folding=#5C5C5C;#17252C
+fold_symbol_highlight=#17252C
+indent_guide=#4F5B66
+caret=#fff;#fff;false;
+marker_line=#000000;#EC5F67
+marker_search=marker_line
+marker_mark=#545454;#95BFD7
+call_tips=#939393;#262626;false;false
+white_space=#595959;#000000;true;false
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#a7adba;;;true
+comment_doc=comment
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#F99157
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#A3BE8C;;true;false
 class=type
-function=0x000080
-parameter=function
+function=#c594c5
+parameter=#23B0E6
 
-keyword=0x003030;;true
+keyword=#C594C5;;true;false
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=keyword_1
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,30 +78,30 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#A3BE8C
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=#A3BE8C;#6E006E;false;false
 character=string_1
 backticks=string_2
 here_doc=string_2
 
 label=default,bold
-preprocessor=0x808000
+preprocessor=#45BDE6
 regex=number_1
-operator=0x300080
+operator=default
 decorator=string_1,bold
-other=0x404080
+other=default
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
 
-tag=type
+tag=#80B8FF
 tag_unknown=tag,bold
 tag_end=tag,bold
-attribute=keyword_1
+attribute=#A3BE8C
 attribute_unknown=attribute,bold
 value=string_1
 entity=default
@@ -109,6 +109,6 @@ entity=default
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
-line_changed=preprocessor
+line_added=#75C075;#ffffff;false;false
+line_removed=#FF7E7E;#ffffff;false;false
+line_changed=#A46FA4;#ffffff;false;false

--- a/data/colorschemes/vibrant-ink.conf
+++ b/data/colorschemes/vibrant-ink.conf
@@ -1,5 +1,5 @@
 #
-# Copyright 2010 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
+# Copyright Jason Wilson <jason.willson(at)gmail(dot)com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,59 +16,67 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 #
+# License linked from Google Projects page:
+#   http://dev.perl.org/licenses/
+#
+# Ported to Geany by Matthew Brush <matt(at)geany(dot)org>
+#
 
 [theme_info]
-name=Alternate
-description=Alternate Geany color scheme with styles like the Geany <= 0.19 Python/script defaults with gray comments.
-version=0.01
-author=Nick Treleaven
-url=https://github.com/geany/geany-themes
+name=Vibrant
+description=Vibrant Ink Theme for Geany
+# incremented automatically, do not change manually
+version=1225
+author=Jason Wilson <jason.willson(at)gmail(dot)com>
+url=http://code.google.com/p/geany-vibrant-ink-theme
+# list of each compatible Geany release version
+compat=1.22;1.23;1.23.1;1.24
 
 [named_styles]
 
-default=0x000000;0xffffff;false;false
-error=0xffffff;0xff0000
+default=#fff;#000;false;false
+error=#ff80c0;#000;false;false
 
 # Editor styles
 #-------------------------------------------------------------------------------
 
-selection=0x000000;0xc0c0c0;false;true
-current_line=0x000000;0xf0f0f0;true
-brace_good=0x0000ff;0xFFFFFF;true;false
-brace_bad=0xff0000;0xFFFFFF;true;false
-margin_line_number=0x000000;0xd0d0d0
-margin_folding=0x000000;0xdfdfdf
-fold_symbol_highlight=0xffffff
-indent_guide=0xc0c0c0
-caret=0x000000;0x000000;false
-marker_line=0x000000;0xffff00
-marker_search=0x000000;0x0000f0
-marker_mark=0x000000;0xb8f4b8
-call_tips=0xc0c0c0;0xffffff;false;false
-white_space=0xc0c0c0;0xffffff;true;false
+selection=#8000ff;#404040;false;true
+current_line=#0080c0;#330;true;false
+brace_good=#9c9;#000;true;false
+brace_bad=#cf3;#000;true;false
+margin_line_number=#e4e4e4;#404040;false;false
+margin_folding=#222;#111;false;false
+fold_symbol_highlight=#fff
+indent_guide=#c0c0c0;;false;false
+caret=#fff;#112435;false;false
+marker_line=#0ff;#80d4b2;false;false
+marker_search=#ff0;#f00;false;false
+marker_mark=#c00000;#000;false;false
+call_tips=#c0c0c0;#fff;false;false
+white_space=#424242;;true
 
 # Programming languages
 #-------------------------------------------------------------------------------
 
-comment=0x808080
-comment_doc=0x404000
+comment=#93c
+comment_doc=#772cb7;#070707;false;false
 comment_line=comment
 comment_line_doc=comment_doc
 comment_doc_keyword=comment_doc,bold
 comment_doc_keyword_error=comment_doc,italic
 
-number=0x400080
+number=#cf3
 number_1=number
 number_2=number_1
 
-type=0x2E8B57;;true
+type=#fff;;true;false
 class=type
-function=0x000080
+function=default
 parameter=function
 
-keyword=0x003030;;true
+keyword=#f60;;true;false
 keyword_1=keyword
-keyword_2=0x9f0200;;true
+keyword_2=#dde93d;;true;false
 keyword_3=keyword_1
 keyword_4=keyword_1
 
@@ -78,37 +86,38 @@ identifier_2=identifier_1
 identifier_3=identifier_1
 identifier_4=identifier_1
 
-string=0x008000
+string=#6f0
 string_1=string
 string_2=string_1
 string_3=default
 string_4=default
-string_eol=0x000000;0xe0c0e0
+string_eol=#ccc;#000;false;false
 character=string_1
 backticks=string_2
 here_doc=string_2
 
+scalar=string_2
 label=default,bold
-preprocessor=0x808000
+preprocessor=#edf8f9
 regex=number_1
-operator=0x300080
+operator=#fc0
 decorator=string_1,bold
-other=0x404080
+other=default
 
 # Markup-type languages
 #-------------------------------------------------------------------------------
 
-tag=type
-tag_unknown=tag,bold
-tag_end=tag,bold
-attribute=keyword_1
-attribute_unknown=attribute,bold
-value=string_1
-entity=default
+tag=#f60;#000;false;false
+tag_unknown=#fff;#000;false;false
+tag_end=#fff;#000;false;false
+attribute=#9c9;#000;false;false
+attribute_unknown=#fff;#000;false;false
+value=#f60;#000;false;false
+entity=#fff;#000;false;false
 
 # Diff
 #-------------------------------------------------------------------------------
 
-line_added=0x008B8B
-line_removed=0x6A5ACD
-line_changed=preprocessor
+line_added=#399;#000;false;false
+line_removed=#808040;#000;false;false
+line_changed=#9c9;#000;false;false

--- a/doc/making-a-release
+++ b/doc/making-a-release
@@ -3,6 +3,9 @@ For major releases:
 * Agree string freeze period for translations.
 * Try to synchronize release date with geany-plugins.
 
+If not updated during the release cycle, copy the latest versions themes from
+geany-themes to Geany source tree using scripts/update-themes.py.
+
 Update NEWS file - ideally each committer should review their changes
 and summarize the interesting ones.  Use `git log --author='name'`
 to filter commits by a particular developer name.

--- a/scripts/update-themes.py
+++ b/scripts/update-themes.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import glob
+import os
+import shutil
+import sys
+
+themes = [
+    # Public domain
+    'evg-ega-dark.conf',
+    'sleepy-pastel.conf',
+    'tango-dark.conf',
+
+    # MIT
+    'earthsong.conf',
+    'kurayami.conf',
+    'one-dark.conf',
+    'solarized-dark.conf',
+    'solarized-light.conf',
+
+    # 2-clause BSD
+    'kugel.conf',
+    'pygments.conf',
+
+    # GPL 2 or later
+    'alt.conf',
+    'black.conf',
+    'carbonfox.conf',
+    'darcula.conf',
+    'dark-colors.conf',
+    'dark.conf',
+    'dark-fruit-salad.conf',
+    'delt-dark.conf',
+    'epsilon.conf',
+    'grey8.conf',
+    'hacker.conf',
+    'mc.conf',
+    'metallic-bottle.conf',
+    'notepad-plus-plus.conf',
+    'oblivion2.conf',
+    'octagon.conf',
+    'retro.conf',
+    'spyder-dark.conf',
+    'steampunk.conf',
+    'tango-light.conf',
+    'ubuntu.conf',
+    'underthesea.conf',
+    'vibrant-ink.conf',
+
+    # LGPL 2 or later
+    'abc-dark.conf',
+    'abc-light.conf',
+    'bespin.conf',
+    'cyber-sugar.conf',
+    'github.conf',
+    'himbeere.conf',
+    'inkpot.conf',
+    'matcha.conf',
+    'slushpoppies.conf',
+    'tinge.conf',
+
+    # LGPL 2.1 or later
+    'gedit.conf',
+]
+
+ignored = [
+    # converted to Geany from https://github.com/mig/gedit-themes which does
+    # not mention any license or authors of individual themes
+    'fluffy.conf',
+    'railcasts2.conf',
+    'zenburn.conf',
+
+    # exact license not yet clarified
+    'kary-pro-colors-dark.conf',
+    'kary-pro-colors-light.conf',
+    'monokai.conf',
+]
+
+usage_msg = 'Usage: update-themes.py <geany-themes/colorschemes> <geany/data/colorschemes>'
+
+if len(sys.argv) != 3:
+    print(usage_msg)
+    sys.exit(1)
+
+srcdir = os.path.abspath(sys.argv[1])
+dstdir = os.path.abspath(sys.argv[2])
+
+# some sanity checks
+if (not os.path.isdir(srcdir) or not os.path.isdir(dstdir) or
+    not os.path.isfile(srcdir + '/alt.conf') or not dstdir.endswith('data/colorschemes')):
+    print(usage_msg)
+    sys.exit(1)
+
+os.chdir(srcdir)
+
+new_theme = False
+source_themes = glob.glob('*.conf')
+
+for theme in source_themes:
+    if theme in ignored:
+        continue
+    if theme not in themes:
+        print(f'Theme {theme} not listed in update-themes.py - update it and re-run agagin')
+        continue
+    if not os.path.isfile(dstdir + f'/{theme}'):
+        new_theme = True
+        print(f'New theme: {theme}')
+    shutil.copy(theme, dstdir)
+
+if new_theme:
+    print("\nDon't forget to add the newly added themes to data/Makefile.am !!!")
+
+os.chdir(dstdir)
+dst_themes = glob.glob('*.conf')
+
+extra_dst_themes = set(dst_themes) - set(source_themes)
+if extra_dst_themes:
+    print((f'\nWarning: themes {extra_dst_themes} found in Geany themes directory but not in geany-themes. '
+           f'Should these be added to geany-themes?'))


### PR DESCRIPTION
This patch:
- adds a scripts/update-themes.py script copying themes with compatible licenses (themes with no explicit license are skipped for now)
- copies these themes under data/colorschemes
- adds lgpl-2.0.txt, lgpl-2.1.txt, gpl-3.0.txt to data/colorschemes to cover themes not falling under Geany'sGPL 2.0 or later

Fixes #4035.