### PR TITLE
Split label in saveactions preferences to make the dialog less wide

### DIFF
--- a/plugins/saveactions.c
+++ b/plugins/saveactions.c
@@ -1439,7 +1439,7 @@ GtkWidget *plugin_configure(GtkDialog *dialog)
 		gtk_box_pack_start(GTK_BOX(inner_vbox), hbox, FALSE, FALSE, 0);
 
 		label = gtk_label_new_with_mnemonic(
-			_("Date/_Time format for backup files (for a list of available conversion specifiers see https://docs.gtk.org/glib/method.DateTime.format.html):"));
+			_("Date/_Time format for backup files (see https://docs.gtk.org/glib/method.DateTime.format.html):"));
 		gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
 		gtk_box_pack_start(GTK_BOX(inner_vbox), label, FALSE, FALSE, 7);
 
@@ -1528,9 +1528,7 @@ GtkWidget *plugin_configure(GtkDialog *dialog)
 		gtk_box_pack_start(GTK_BOX(inner_vbox), hbox, FALSE, FALSE, 0);
 
 		help_label = gtk_label_new(
-			_("<i>If you set the Instant Save directory to a directory "
-				"which is not automatically cleared,\nyou will need to cleanup instantly saved files "
-				"manually. The Instant Save plugin will not delete the created files.</i>"));
+			_("<i>The plugin will not delete the files created in this directory.</i>"));
 		gtk_label_set_use_markup(GTK_LABEL(help_label), TRUE);
 		gtk_misc_set_alignment(GTK_MISC(help_label), 0, 0.5);
 		gtk_widget_set_margin_left(help_label, 12);


### PR DESCRIPTION
(not completely clear from the screenshots below because github normalizes image widths to fit the display area)

Before the patch

<img width="976" alt="Screenshot 2024-11-21 at 14 55 39" src="https://github.com/user-attachments/assets/acfabbb4-cbbf-468d-aa06-e748b6eb9043">

After the patch

<img width="810" alt="Screenshot 2024-11-21 at 15 00 01" src="https://github.com/user-attachments/assets/84b13619-04fb-4e40-a42e-faa9b09cdbf1">
