### PR TITLE
Make sure that parents appear before their children when constructing symbol tree

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -324,6 +324,56 @@ static gint compare_symbol_lines(gconstpointer a, gconstpointer b)
 }
 
 
+static gboolean is_symbol_within_parent(const TMTag *tag, const TMTag *parent)
+{
+	const gchar *scope_sep = tm_parser_scope_separator(tag->lang);
+	guint scope_len = 0;
+
+	if (EMPTY(tag->scope))
+		return FALSE;
+
+	if (!EMPTY(parent->scope))
+	{
+		if (!g_str_has_prefix(tag->scope, parent->scope))
+			return FALSE;
+		scope_len = strlen(parent->scope);
+
+		if (!g_str_has_prefix(tag->scope + scope_len, scope_sep))
+			return FALSE;
+		scope_len += strlen(scope_sep);
+	}
+
+	if (!g_str_has_prefix(tag->scope + scope_len, parent->name))
+		return FALSE;
+	scope_len += strlen(parent->name);
+
+	if (tag->scope[scope_len] == '\0')
+		return TRUE;
+
+	if (!g_str_has_prefix(tag->scope + scope_len, scope_sep))
+		return FALSE;
+
+	return TRUE;
+}
+
+
+/* for symbol tree construction make sure that symbol parents appear before
+ * their children in the list */
+static gint compare_symbol_parent_first(gconstpointer a, gconstpointer b)
+{
+	const TMTag *tag_a = TM_TAG(a);
+	const TMTag *tag_b = TM_TAG(b);
+
+	if (is_symbol_within_parent(tag_a, tag_b))
+		return 1;
+
+	if (is_symbol_within_parent(tag_b, tag_a))
+		return -1;
+
+	return compare_symbol_lines(a, b);
+}
+
+
 static GList *get_tag_list(GeanyDocument *doc, TMTagType tag_types)
 {
 	GList *tag_names = NULL;
@@ -375,7 +425,7 @@ static GList *get_tag_list(GeanyDocument *doc, TMTagType tag_types)
 			g_free(full_tagname);
 		}
 	}
-	tag_names = g_list_sort(tag_names, compare_symbol_lines);
+	tag_names = g_list_sort(tag_names, compare_symbol_parent_first);
 
 	g_strfreev(tf_strv);
 

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -327,7 +327,7 @@ static gint compare_symbol_lines(gconstpointer a, gconstpointer b)
 static gboolean is_symbol_within_parent(const TMTag *tag, const TMTag *parent)
 {
 	const gchar *scope_sep = tm_parser_scope_separator(tag->lang);
-	guint scope_len = 0;
+	gsize scope_len = 0;
 
 	if (EMPTY(tag->scope))
 		return FALSE;


### PR DESCRIPTION
The symbol tree construction code assumes that tag parents appear before their children. At the moment tag list is sorted by line numbers which works for C structs
```C
struct Foo {
    int bar;
    int baz;
}
```
where the tag Foo (which is a parent of bar and baz) is sorted before bar and baz. However, this doesn't work when the name of the struct (or a variable of an anonymous struct) follows the struct members such as in the following SystemVerilog example:
```systemverilog
struct packed {
    byte s_a, s_b, s_c;
    string s_str;
} s_member;
```
Here the members are sorted before the parent and the symbol tree construction code doesn't work correctly.

This patch sorts symbols so that parents are sorted before their members - only if tags aren't in a parent-child relationship the original sorting by line is performed.

@b4n Does this look alright to you?

Fixes #4060.