### PR TITLE
Pass DESKTOP_STARTUP_ID via the socket to focus window

### DIFF
--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1056,6 +1056,18 @@ gint main_lib(gint argc, gchar **argv)
 #ifdef ENABLE_NLS
 	main_locale_init(utils_resource_dir(RESOURCE_DIR_LOCALE), GETTEXT_PACKAGE);
 #endif
+
+	/* Magic ID used on X11 and Wayland for bringing our existing window on top;
+	 * need to read it here, since GTK will clear this from the environment in
+	 * gtk_init () (called from parse_command_line_options () below). Need to
+	 * make a copy, since the value is not guaranteed to be valid after calling
+	 * unsetenv() (which is done by GTK). */
+#ifdef HAVE_SOCKET
+	gchar *desktop_startup_id = g_strdup(getenv("DESKTOP_STARTUP_ID"));
+	if (!desktop_startup_id)
+		desktop_startup_id = g_strdup(getenv("XDG_ACTIVATION_TOKEN"));
+#endif
+
 	/* initialize TM before parsing command-line - needed for tag file generation */
 	app->tm_workspace = tm_get_workspace();
 	parse_command_line_options(&argc, &argv);
@@ -1085,7 +1097,7 @@ gint main_lib(gint argc, gchar **argv)
 #endif
 		socket_info.lock_socket = -1;
 		socket_info.lock_socket_tag = 0;
-		socket_info.lock_socket = socket_init(argc, argv, socket_port);
+		socket_info.lock_socket = socket_init(argc, argv, socket_port, desktop_startup_id);
 		/* Quit if filenames were sent to first instance or the list of open
 		 * documents has been printed */
 		if ((socket_info.lock_socket == -2 /* socket exists */ && argc > 1) ||
@@ -1097,6 +1109,7 @@ gint main_lib(gint argc, gchar **argv)
 			g_free(app->datadir);
 			g_free(app->docdir);
 			g_free(app);
+			g_free(desktop_startup_id);
 			return 0;
 		}
 		/* Start a new instance if no command line strings were passed,
@@ -1107,6 +1120,7 @@ gint main_lib(gint argc, gchar **argv)
 			cl_options.new_instance = TRUE;
 		}
 	}
+	g_free(desktop_startup_id);
 #endif
 
 #ifdef G_OS_WIN32

--- a/src/socket.h
+++ b/src/socket.h
@@ -42,7 +42,7 @@ struct SocketInfo
 
 extern struct SocketInfo socket_info;
 
-gint socket_init(gint argc, gchar **argv, gushort socket_port);
+gint socket_init(gint argc, gchar **argv, gushort socket_port, const gchar *desktop_startup_id);
 
 gboolean socket_lock_input_cb(GIOChannel *source, GIOCondition condition, gpointer data);
 


### PR DESCRIPTION
Fixes #3531 at least on KDE Plasma (tested when opening files from Nautilus). On GNOME / Ubuntu there is not change, but things also do not work for Gedit, so that might be an issue on their side.

This works by looking for the `DESKTOP_STARTUP_ID` environment variable when Geany is started. Normally, this is consumed by GTK automatically to use the proper protocols ([Startup notification](https://specifications.freedesktop.org/startup-notification-spec/latest/
) or [xdg-activation](https://wayland.app/protocols/xdg-activation-v1
) on X11 and Wayland respectively). However, when activating an already running Geany instance, this needs to be passed onto it and supplied to GTK there.

This is done by adding a new message to the socket communication for this purpose. This is always parsed, but only has an effect if Geany is running on X11 or Wayland.

Tested (on Ubuntu 24.04):
 - KDE Plasma (kwin 5.27.11): Geany can focus itself with this patch (opening files from Nautilus)
 - GNOME (mutter 46.2): works if Geany is the default for a file type, no change if using the "Open with..." dialog (likely an issue with Nautilus as behavior is the same with other apps, e.g. Gedit)
 - Wayfire: always works, does not care about having a valid activation token
 
Not tested on X11, could potentially improve behavior there as well on WMs that are especially strict with focus stealing prevention.





