### PR TITLE
Re-enable Forth ctags parser and add unit test for it

### DIFF
--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -196,7 +196,7 @@ static void init_builtin_filetypes(void)
 	FT_INIT( CMAKE,        NONE,         "CMake",            NULL                      );
 	FT_INIT( NSIS,         NSIS,         "NSIS",             NULL                      );
 	FT_INIT( ADA,          ADA,          "Ada",              NULL                      );
-	FT_INIT( FORTH,        NONE,         "Forth",            NULL                      );
+	FT_INIT( FORTH,        FORTH,        "Forth",            NULL                      );
 	FT_INIT( ASCIIDOC,     ASCIIDOC,     "Asciidoc",         NULL                      );
 	FT_INIT( ABAQUS,       ABAQUS,       "Abaqus",           NULL                      );
 	FT_INIT( BATCH,        BATCH,        "Batch",            NULL                      );

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -307,6 +307,7 @@ test_sources = \
 	simple.d						\
 	simple.diff						\
 	simple.docbook					\
+	simple.fth						\
 	simple.hs						\
 	simple.hx						\
 	simple.html						\

--- a/tests/ctags/simple.fth
+++ b/tests/ctags/simple.fth
@@ -1,0 +1,31 @@
+
+( https://rosettacode.org/wiki/FizzBuzz#Forth / https://skilldrick.github.io/easyforth/ ) 
+
+\ Works in gforth and other ANS forth. Other Forth may differ.
+
+10 constant DUMMY1
+12 CONSTANT DUMMY2
+
+variable dummy3
+variable dummy4
+VARIABLE dummy5
+
+11 dummy3 !
+13 dummy4 !
+
+: fizz?  \ a simple comment 
+3 mod 0 = dup if ." Fizz" then ;
+: buzz?  
+5 mod 0 = dup if ." Buzz" then ;
+
+: fizz-buzz?  
+dup fizz? swap buzz? or invert ;
+
+: do-fizz-buzz  
+25 1 do cr i fizz-buzz? if i . then loop ;
+
+do-fizz-buzz
+cr
+
+quit
+\ bye

--- a/tests/ctags/simple.fth.tags
+++ b/tests/ctags/simple.fth.tags
@@ -1,0 +1,18 @@
+DUMMY1Ì65536Ö0
+macro:      DUMMY1
+DUMMY2Ì65536Ö0
+macro:      DUMMY2
+buzz?Ì16Ö0
+function:   buzz?
+do-fizz-buzzÌ16Ö0
+function:   do-fizz-buzz
+dummy3Ì16384Ö0
+variable:   dummy3
+dummy4Ì16384Ö0
+variable:   dummy4
+dummy5Ì16384Ö0
+variable:   dummy5
+fizz-buzz?Ì16Ö0
+function:   fizz-buzz?
+fizz?Ì16Ö0
+function:   fizz?

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -304,6 +304,7 @@ ctags_tests = [
 	'ctags/simple.d.tags',
 	'ctags/simple.diff.tags',
 	'ctags/simple.docbook.tags',
+	'ctags/simple.fth.tags',
 	'ctags/simple.hs.tags',
 	'ctags/simple.hx.tags',
 	'ctags/simple.html.tags',


### PR DESCRIPTION
I accidentally disabled the forth parser in https://github.com/geany/geany/pull/3977

Also, https://github.com/geany/geany/pull/4013 missed unit tests for Forth.