### PR TITLE
tagmanager: (System)Verilog: don't tag module of instances

### DIFF
--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -1649,6 +1649,9 @@ gboolean tm_parser_enable_role(TMParserType lang, gchar kind)
 			 * tags and we can't tell which is which just by kind. By disabling
 			 * roles for this kind, we only get package definition tags. */
 			return kind != 'p';
+		case TM_PARSER_VERILOG:
+		case TM_PARSER_SYSVERILOG:
+			return kind != 'm';
 	}
 	return TRUE;
 }

--- a/src/tagmanager/tm_parser.c
+++ b/src/tagmanager/tm_parser.c
@@ -799,8 +799,8 @@ static TMParserMapGroup group_VERILOG[] = {
 	{N_("Interfaces"), TM_ICON_STRUCT, tm_tag_interface_t | tm_tag_union_t},
 	{N_("Package"), TM_ICON_NAMESPACE, tm_tag_package_t},
 	{N_("Members"), TM_ICON_MEMBER, tm_tag_member_t},
-	{N_("Structs"), TM_ICON_STRUCT, tm_tag_struct_t},
-	{N_("Typedefs / Enums"), TM_ICON_STRUCT, tm_tag_typedef_t | tm_tag_enum_t},
+	{N_("Structs / Unions / Enums"), TM_ICON_OTHER, tm_tag_struct_t | tm_tag_enum_t},
+	{N_("Typedefs"), TM_ICON_STRUCT, tm_tag_typedef_t},
 };
 
 static TMParserMapEntry map_SYSVERILOG[] = {

--- a/tests/ctags/sysverilog.sv
+++ b/tests/ctags/sysverilog.sv
@@ -135,9 +135,9 @@ module testbench;
     generate
         for (genvar j = 0; j < NUM_UUT; j++) begin : uut_gen
             logic [UUT_WIDTH-1:0] data_out;
-            a_module #( // NB: this SHOULDN'T be detected as a module declaration (ctags bug)
+            a_module #(
                 .WIDTH (UUT_WIDTH)
-            ) uut ( // but this should be detected as an instance (ctags works)
+            ) uut (
                 .valid (valid_uut[j]),
                 .*
             );

--- a/tests/ctags/sysverilog.sv.tags
+++ b/tests/ctags/sysverilog.sv.tags
@@ -24,8 +24,6 @@ WIDTHÌ8Îa_moduleÖ0
 field:      a_module :: WIDTH
 a_moduleÌ1024Ö0
 prototype:  a_module
-a_moduleÌ1024Îtestbench.uut_genÖ0
-prototype:  testbench.uut_gen :: a_module
 be_filteredÌ16384Îa_moduleÖ0
 variable:   a_module :: be_filtered
 be_filtered_genÌ256Îa_moduleÖ0
@@ -74,8 +72,6 @@ gen_signalsÌ4ÎtestbenchÖ0Ïgenerate_signals
 enumerator: generate_signals testbench :: gen_signals
 generate_signalsÌ1024Ö0
 prototype:  generate_signals
-generate_signalsÌ1024ÎtestbenchÖ0
-prototype:  testbench :: generate_signals
 iÌ16384Îa_moduleÖ0
 variable:   a_module :: i
 iÌ16384Îa_module.main_blockÖ0


### PR DESCRIPTION
Fixes #4072 (re: `my_module inst (d, q);` creating tags for both the instance `inst` and the module `my_module`).
The unit tests have been updated accordingly.

Also includes a minor amendment to #4039 to fix the tag grouping for SystemVerilog so that enum objects are put in the same group as struct/union objects, which makes more sense than putting them in the same group as typedefs (which are types, not objects).