### PR TITLE
Fix GTK runtime errors generated by the plugin manager

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1922,7 +1922,8 @@ static void pm_show_dialog(GtkMenuItem *menuitem, gpointer user_data)
 	gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(swin), GTK_SHADOW_IN);
 	gtk_container_add(GTK_CONTAINER(swin), pm_widgets.tree);
 
-	label = geany_wrap_label_new(_("Choose which plugins should be loaded at startup:"));
+	label = gtk_label_new(_("Choose which plugins to load:"));
+	gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
 
 	/* plugin popup menu */
 	pm_widgets.popup_menu = gtk_menu_new();


### PR DESCRIPTION
The use of `geany_wrap_label_new()` together with the list below seems to interact in a strange way somehow and generate lots of runtime warnings/errors.

This is a (cowardly) attempt by fixing this without having to understand what is going on ;-). Simply using `gtk_label_new()` seems to resolve the issue.

Also, I think the text can be made a bit shorter in case the translation is too wide for some languages. The "at startup" is kind of misleading anyway since plugins are loaded immediately when checked in the box below and since this is a preference, it's remembered so I think it's pretty clear it happens at startup too.

Just a historical note - the text used to be much longer in the past so this is probably why  geany_wrap_label_new() was
used: https://github.com/geany/geany/commit/b0cd7b918bb0c53c8f2a5173027dc3087019a35d

Fixes #2065.