### PR TITLE
sh: enable lexer styles for command substitution and related styling

### DIFF
--- a/data/filedefs/filetypes.sh
+++ b/data/filedefs/filetypes.sh
@@ -19,6 +19,12 @@ here_q=here_doc
 [keywords]
 primary=break case continue do done elif else esac eval exit export fi for function goto if in integer return set shift then until while
 
+[lexer_properties]
+lexer.bash.styling.inside.string=0
+lexer.bash.styling.inside.backticks=1
+lexer.bash.styling.inside.parameter=1
+lexer.bash.styling.inside.heredoc=1
+lexer.bash.command.substitution=1
 
 [settings]
 # default extension used when saving files


### PR DESCRIPTION
Before the patch:

<img width="392" alt="Screenshot 2024-11-26 at 22 23 52" src="https://github.com/user-attachments/assets/d8a858cf-298f-4008-89ba-731c3e0a7de1">

After the patch:

<img width="392" alt="Screenshot 2024-11-26 at 22 23 17" src="https://github.com/user-attachments/assets/1b069e87-1365-40bc-bdd4-a15eaf01e340">

Fixes #1754
Fixes #1821