### PR TITLE
set last X properly on various selection changes, correct order of caret/anchor for select all

### DIFF
--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -591,6 +591,7 @@ GEANY_API_SYMBOL
 void sci_set_selection_start(ScintillaObject *sci, gint position)
 {
 	SSM(sci, SCI_SETSELECTIONSTART, (uptr_t) position, 0);
+	SSM(sci, SCI_CHOOSECARETX, 0, 0);
 }
 
 
@@ -601,12 +602,14 @@ GEANY_API_SYMBOL
 void sci_set_selection_end(ScintillaObject *sci, gint position)
 {
 	SSM(sci, SCI_SETSELECTIONEND, (uptr_t) position, 0);
+	SSM(sci, SCI_CHOOSECARETX, 0, 0);
 }
 
 
 void sci_set_selection(ScintillaObject *sci, gint anchorPos, gint currentPos)
 {
 	SSM(sci, SCI_SETSEL, (uptr_t) anchorPos, currentPos);
+	SSM(sci, SCI_CHOOSECARETX, 0, 0);
 }
 
 
@@ -1320,6 +1323,7 @@ void sci_select_all(ScintillaObject *sci)
 {
 	SSM(sci, SCI_SELECTALL, 0, 0);
 	SSM(sci, SCI_SWAPMAINANCHORCARET, 0, 0);
+	SSM(sci, SCI_CHOOSECARETX, 0, 0);
 }
 
 

--- a/src/sciwrappers.c
+++ b/src/sciwrappers.c
@@ -1319,6 +1319,7 @@ void sci_indicator_clear(ScintillaObject *sci, gint pos, gint len)
 void sci_select_all(ScintillaObject *sci)
 {
 	SSM(sci, SCI_SELECTALL, 0, 0);
+	SSM(sci, SCI_SWAPMAINANCHORCARET, 0, 0);
 }
 
 


### PR DESCRIPTION
when executing the command "Select Line" (e.g. assigning it a keyboard shortcut), Geany still remembers the last X incorrectly, so Shift-Down and other keys don't work well. this PR sets the last X correctly for this case and many other cases.

the caret/anchor is also swapped for select all. previously the selection was not in the natural forward direction and therefore very strange. almost every other editor including in this textarea in most browsers has it the correct way.