### PR TITLE
Focus the search/replace dialog after the wrap dialog is dismissed

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -2307,42 +2307,6 @@ gboolean document_search_bar_find(GeanyDocument *doc, const gchar *text, gboolea
 }
 
 
-/* like dialogs_show_question_full() but makes the non-cancel button default */
-static gboolean show_wrap_search_dialog(GtkWidget *parent, const gchar *search_text)
-{
-	gboolean ret;
-	GtkWidget *dialog;
-	GtkWidget *btn;
-	gchar *question_text;
-
-	if (parent == NULL && main_status.main_window_realized)
-		parent = main_widgets.window;
-
-	question_text = g_strdup_printf(_("\"%s\" was not found."), search_text);
-
-	dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
-		GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
-		GTK_BUTTONS_NONE, "%s", question_text);
-	gtk_widget_set_name(dialog, "GeanyDialog");
-	gtk_window_set_title(GTK_WINDOW(dialog), _("Question"));
-	gtk_window_set_icon_name(GTK_WINDOW(dialog), "geany");
-
-	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
-		"%s", _("Wrap search and find again?"));
-
-	gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_NO);
-	btn = gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_FIND, GTK_RESPONSE_YES);
-	gtk_widget_grab_default(btn);
-
-	ret = gtk_dialog_run(GTK_DIALOG(dialog));
-
-	gtk_widget_destroy(dialog);
-	g_free(question_text);
-
-	return ret == GTK_RESPONSE_YES;
-}
-
-
 /* General search function, used from the find dialog.
  * Returns -1 on failure or the start position of the matching text.
  * Will skip past any selection, ignoring it.
@@ -2406,7 +2370,7 @@ gint document_find_text(GeanyDocument *doc, const gchar *text, const gchar *orig
 
 		/* we searched only part of the document, so ask whether to wraparound. */
 		if (search_prefs.always_wrap ||
-			show_wrap_search_dialog(parent, original_text))
+			search_show_wrap_dialog(parent, original_text))
 		{
 			gint ret;
 

--- a/src/document.c
+++ b/src/document.c
@@ -2316,7 +2316,7 @@ gboolean document_search_bar_find(GeanyDocument *doc, const gchar *text, gboolea
  */
 gint document_find_text(GeanyDocument *doc, const gchar *text, const gchar *original_text,
 		GeanyFindFlags flags, gboolean search_backwards, GeanyMatchInfo **match_,
-		gboolean scroll, GtkWidget *parent)
+		gboolean scroll)
 {
 	gint selection_end, selection_start, search_pos;
 
@@ -2370,12 +2370,12 @@ gint document_find_text(GeanyDocument *doc, const gchar *text, const gchar *orig
 
 		/* we searched only part of the document, so ask whether to wraparound. */
 		if (search_prefs.always_wrap ||
-			search_show_wrap_dialog(parent, original_text))
+			search_show_wrap_dialog(original_text))
 		{
 			gint ret;
 
 			sci_set_current_position(doc->editor->sci, (search_backwards) ? sci_len : 0, FALSE);
-			ret = document_find_text(doc, text, original_text, flags, search_backwards, match_, scroll, parent);
+			ret = document_find_text(doc, text, original_text, flags, search_backwards, match_, scroll);
 			if (ret == -1)
 			{	/* return to original cursor position if not found */
 				sci_set_current_position(doc->editor->sci, selection_start, FALSE);
@@ -2416,7 +2416,7 @@ gint document_replace_text(GeanyDocument *doc, const gchar *find_text, const gch
 	if (selection_end == selection_start)
 	{
 		/* no selection so just find the next match */
-		document_find_text(doc, find_text, original_find_text, flags, search_backwards, NULL, TRUE, NULL);
+		document_find_text(doc, find_text, original_find_text, flags, search_backwards, NULL, TRUE);
 		return -1;
 	}
 	/* there's a selection so go to the start before finding to search through it
@@ -2426,7 +2426,7 @@ gint document_replace_text(GeanyDocument *doc, const gchar *find_text, const gch
 	else
 		sci_goto_pos(doc->editor->sci, selection_start, TRUE);
 
-	search_pos = document_find_text(doc, find_text, original_find_text, flags, search_backwards, &match, TRUE, NULL);
+	search_pos = document_find_text(doc, find_text, original_find_text, flags, search_backwards, &match, TRUE);
 	/* return if the original selected text did not match (at the start of the selection) */
 	if (search_pos != selection_start)
 	{

--- a/src/document.h
+++ b/src/document.h
@@ -261,7 +261,7 @@ gboolean document_search_bar_find(GeanyDocument *doc, const gchar *text, gboolea
 
 gint document_find_text(GeanyDocument *doc, const gchar *text, const gchar *original_text,
 		GeanyFindFlags flags, gboolean search_backwards, GeanyMatchInfo **match_,
-		gboolean scroll, GtkWidget *parent);
+		gboolean scroll);
 
 gint document_replace_text(GeanyDocument *doc, const gchar *find_text, const gchar *original_find_text,
 		const gchar *replace_text, GeanyFindFlags flags, gboolean search_backwards);

--- a/src/search.c
+++ b/src/search.c
@@ -436,7 +436,7 @@ void search_find_selection(GeanyDocument *doc, gboolean search_backwards)
 	{
 		setup_find_next(s);	/* allow find next/prev */
 
-		if (document_find_text(doc, s, NULL, 0, search_backwards, NULL, FALSE, NULL) > -1)
+		if (document_find_text(doc, s, NULL, 0, search_backwards, NULL, FALSE) > -1)
 			editor_display_current_line(doc->editor, 0.3F);
 		g_free(s);
 	}
@@ -1148,7 +1148,7 @@ void search_show_find_in_files_dialog_full(const gchar *text, const gchar *dir)
 
 
 /* like dialogs_show_question_full() but makes the non-cancel button default */
-gboolean search_show_wrap_dialog(GtkWidget *parent, const gchar *search_text)
+gboolean search_show_wrap_dialog(const gchar *search_text)
 {
 	gboolean ret;
 	GtkWidget *dialog;
@@ -1164,12 +1164,9 @@ gboolean search_show_wrap_dialog(GtkWidget *parent, const gchar *search_text)
 	if (visible_dialog)
 		gtk_widget_hide(visible_dialog);
 
-	if (parent == NULL)
-		parent = main_widgets.window;
-
 	question_text = g_strdup_printf(_("\"%s\" was not found."), search_text);
 
-	dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
+	dialog = gtk_message_dialog_new(GTK_WINDOW(main_widgets.window),
 		GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
 		GTK_BUTTONS_NONE, "%s", question_text);
 	gtk_widget_set_name(dialog, "GeanyDialog");
@@ -1402,7 +1399,7 @@ on_find_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 			case GEANY_RESPONSE_FIND_PREVIOUS:
 			{
 				gint result = document_find_text(doc, search_data.text, search_data.original_text, search_data.flags,
-					(response == GEANY_RESPONSE_FIND_PREVIOUS), NULL, TRUE, GTK_WIDGET(find_dlg.dialog));
+					(response == GEANY_RESPONSE_FIND_PREVIOUS), NULL, TRUE);
 				ui_set_search_entry_background(find_dlg.entry, (result > -1));
 				check_close = search_prefs.hide_find_dialog;
 				break;
@@ -1560,7 +1557,7 @@ on_replace_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 				search_backwards_re);
 			if (rep != -1)
 				document_find_text(doc, find, original_find, search_flags_re, search_backwards_re,
-					NULL, TRUE, NULL);
+					NULL, TRUE);
 			break;
 		}
 		case GEANY_RESPONSE_REPLACE:
@@ -1571,7 +1568,7 @@ on_replace_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		case GEANY_RESPONSE_FIND:
 		{
 			gint result = document_find_text(doc, find, original_find, search_flags_re,
-								search_backwards_re, NULL, TRUE, GTK_WIDGET(dialog));
+								search_backwards_re, NULL, TRUE);
 			ui_set_search_entry_background(replace_dlg.find_entry, (result > -1));
 			break;
 		}
@@ -2366,7 +2363,7 @@ void search_find_again(gboolean change_direction)
 	{
 		gboolean forward = ! search_data.backwards;
 		gint result = document_find_text(doc, search_data.text, search_data.original_text, search_data.flags,
-			change_direction ? forward : !forward, NULL, FALSE, NULL);
+			change_direction ? forward : !forward, NULL, FALSE);
 
 		if (result > -1)
 			editor_display_current_line(doc->editor, 0.3F);

--- a/src/search.c
+++ b/src/search.c
@@ -49,7 +49,6 @@
 #include <string.h>
 #include <ctype.h>
 
-#include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 
 enum
@@ -1145,6 +1144,42 @@ void search_show_find_in_files_dialog_full(const gchar *text, const gchar *dir)
 	gtk_widget_show(fif_dlg.dialog);
 	/* bring the dialog back in the foreground in case it is already open but the focus is away */
 	gtk_window_present(GTK_WINDOW(fif_dlg.dialog));
+}
+
+
+/* like dialogs_show_question_full() but makes the non-cancel button default */
+gboolean search_show_wrap_dialog(GtkWidget *parent, const gchar *search_text)
+{
+	gboolean ret;
+	GtkWidget *dialog;
+	GtkWidget *btn;
+	gchar *question_text;
+
+	if (parent == NULL)
+		parent = main_widgets.window;
+
+	question_text = g_strdup_printf(_("\"%s\" was not found."), search_text);
+
+	dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
+		GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_QUESTION,
+		GTK_BUTTONS_NONE, "%s", question_text);
+	gtk_widget_set_name(dialog, "GeanyDialog");
+	gtk_window_set_title(GTK_WINDOW(dialog), _("Question"));
+	gtk_window_set_icon_name(GTK_WINDOW(dialog), "geany");
+
+	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
+		"%s", _("Wrap search and find again?"));
+
+	gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_NO);
+	btn = gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_FIND, GTK_RESPONSE_YES);
+	gtk_widget_grab_default(btn);
+
+	ret = gtk_dialog_run(GTK_DIALOG(dialog));
+
+	gtk_widget_destroy(dialog);
+	g_free(question_text);
+
+	return ret == GTK_RESPONSE_YES;
 }
 
 

--- a/src/search.c
+++ b/src/search.c
@@ -1153,7 +1153,16 @@ gboolean search_show_wrap_dialog(GtkWidget *parent, const gchar *search_text)
 	gboolean ret;
 	GtkWidget *dialog;
 	GtkWidget *btn;
+	GtkWidget *visible_dialog = NULL;
 	gchar *question_text;
+
+	if (find_dlg.dialog && gtk_widget_is_visible(find_dlg.dialog))
+		visible_dialog = find_dlg.dialog;
+	else if (replace_dlg.dialog && gtk_widget_is_visible(replace_dlg.dialog))
+		visible_dialog = replace_dlg.dialog;
+
+	if (visible_dialog)
+		gtk_widget_hide(visible_dialog);
 
 	if (parent == NULL)
 		parent = main_widgets.window;
@@ -1178,6 +1187,9 @@ gboolean search_show_wrap_dialog(GtkWidget *parent, const gchar *search_text)
 
 	gtk_widget_destroy(dialog);
 	g_free(question_text);
+
+	if (visible_dialog && ret == GTK_RESPONSE_YES)
+		gtk_widget_show(visible_dialog);
 
 	return ret == GTK_RESPONSE_YES;
 }

--- a/src/search.h
+++ b/src/search.h
@@ -27,7 +27,7 @@
 #ifndef GEANY_SEARCH_H
 #define GEANY_SEARCH_H 1
 
-#include <gtk/gtk.h>
+#include <glib.h>
 
 
 G_BEGIN_DECLS
@@ -120,7 +120,7 @@ void search_show_replace_dialog(void);
 
 void search_show_find_in_files_dialog_full(const gchar *text, const gchar *dir);
 
-gboolean search_show_wrap_dialog(GtkWidget *parent, const gchar *search_text);
+gboolean search_show_wrap_dialog(const gchar *search_text);
 
 void geany_match_info_free(GeanyMatchInfo *info);
 

--- a/src/search.h
+++ b/src/search.h
@@ -27,7 +27,7 @@
 #ifndef GEANY_SEARCH_H
 #define GEANY_SEARCH_H 1
 
-#include <glib.h>
+#include <gtk/gtk.h>
 
 
 G_BEGIN_DECLS
@@ -119,6 +119,8 @@ void search_show_find_dialog(void);
 void search_show_replace_dialog(void);
 
 void search_show_find_in_files_dialog_full(const gchar *text, const gchar *dir);
+
+gboolean search_show_wrap_dialog(GtkWidget *parent, const gchar *search_text);
 
 void geany_match_info_free(GeanyMatchInfo *info);
 


### PR DESCRIPTION
At the moment, when "Always wrap search" and "Hide the find dialog" are disabled in preferences, after performing wrap and dismissing the wrap dialog, the editor is focused instead of the search/replace dialog again. This interrupts keyboard-based user interaction with the dialog as users have to manually re-focus the search/replace dialog.

I haven't found a way to re-focus the search/replace dialog without hiding it first. But I actually think hiding the search/replace dialog when the wrap dialog is shown is a cleaner UI than having the two dialogs on top of each other.

Fixes #4021.