### PR TITLE
Improve search/replace dialog sizing under various locales

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -52,6 +52,8 @@
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 
+#define MIN_DLG_BUTTON_SIZE 130
+
 enum
 {
 	GEANY_RESPONSE_FIND = 1,
@@ -466,19 +468,28 @@ static void create_find_dialog(void)
 	GtkWidget *label, *entry, *sbox, *vbox;
 	GtkWidget *exp, *bbox, *button, *check_close;
 
-	find_dlg.dialog = gtk_dialog_new_with_buttons(_("Find"),
-		GTK_WINDOW(main_widgets.window), GTK_DIALOG_DESTROY_WITH_PARENT,
-		GTK_STOCK_CLOSE, GTK_RESPONSE_CANCEL, NULL);
+	find_dlg.dialog = gtk_dialog_new();
+	gtk_window_set_title(GTK_WINDOW(find_dlg.dialog), _("Find"));
+	gtk_window_set_transient_for(GTK_WINDOW(find_dlg.dialog), GTK_WINDOW(main_widgets.window));
+	gtk_window_set_destroy_with_parent(GTK_WINDOW(find_dlg.dialog), TRUE);
+
 	vbox = ui_dialog_vbox_new(GTK_DIALOG(find_dlg.dialog));
 	gtk_widget_set_name(find_dlg.dialog, "GeanyDialogSearch");
 	gtk_box_set_spacing(GTK_BOX(vbox), 9);
 
+	button = gtk_button_new_from_stock(GTK_STOCK_CLOSE);
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
+	gtk_dialog_add_action_widget(GTK_DIALOG(find_dlg.dialog), button,
+		GTK_RESPONSE_CANCEL);
+
 	button = ui_button_new_with_image(GTK_STOCK_GO_BACK, _("_Previous"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
 	gtk_dialog_add_action_widget(GTK_DIALOG(find_dlg.dialog), button,
 		GEANY_RESPONSE_FIND_PREVIOUS);
 	ui_hookup_widget(find_dlg.dialog, button, "btn_previous");
 
 	button = ui_button_new_with_image(GTK_STOCK_GO_FORWARD, _("_Next"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
 	gtk_dialog_add_action_widget(GTK_DIALOG(find_dlg.dialog), button,
 		GEANY_RESPONSE_FIND);
 
@@ -515,24 +526,7 @@ static void create_find_dialog(void)
 	g_signal_connect_after(exp, "activate",
 		G_CALLBACK(on_expander_activated), &find_dlg.all_expanded);
 
-	bbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
-
-	button = gtk_button_new_with_mnemonic(_("_Mark"));
-	gtk_widget_set_tooltip_text(button,
-			_("Mark all matches in the current document"));
-	gtk_container_add(GTK_CONTAINER(bbox), button);
-	g_signal_connect(button, "clicked", G_CALLBACK(send_find_dialog_response),
-		GINT_TO_POINTER(GEANY_RESPONSE_MARK));
-
-	button = gtk_button_new_with_mnemonic(_("In Sessi_on"));
-	gtk_container_add(GTK_CONTAINER(bbox), button);
-	g_signal_connect(button, "clicked", G_CALLBACK(send_find_dialog_response),
-		GINT_TO_POINTER(GEANY_RESPONSE_FIND_IN_SESSION));
-
-	button = gtk_button_new_with_mnemonic(_("_In Document"));
-	gtk_container_add(GTK_CONTAINER(bbox), button);
-	g_signal_connect(button, "clicked", G_CALLBACK(send_find_dialog_response),
-		GINT_TO_POINTER(GEANY_RESPONSE_FIND_IN_FILE));
+	bbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 
 	/* close window checkbox */
 	check_close = gtk_check_button_new_with_mnemonic(_("Close _dialog"));
@@ -540,12 +534,28 @@ static void create_find_dialog(void)
 	gtk_button_set_focus_on_click(GTK_BUTTON(check_close), FALSE);
 	gtk_widget_set_tooltip_text(check_close,
 			_("Disable this option to keep the dialog open"));
-	gtk_container_add(GTK_CONTAINER(bbox), check_close);
-	gtk_button_box_set_child_secondary(GTK_BUTTON_BOX(bbox), check_close, TRUE);
+	gtk_box_pack_start(GTK_BOX(bbox), check_close, TRUE, TRUE, 0);
 
-	ui_hbutton_box_copy_layout(
-		GTK_BUTTON_BOX(gtk_dialog_get_action_area(GTK_DIALOG(find_dlg.dialog))),
-		GTK_BUTTON_BOX(bbox));
+	button = gtk_button_new_with_mnemonic(_("_Mark"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
+	gtk_widget_set_tooltip_text(button,
+			_("Mark all matches in the current document"));
+	gtk_container_add(GTK_CONTAINER(bbox), button);
+	g_signal_connect(button, "clicked", G_CALLBACK(send_find_dialog_response),
+		GINT_TO_POINTER(GEANY_RESPONSE_MARK));
+
+	button = gtk_button_new_with_mnemonic(_("In Sessi_on"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
+	gtk_container_add(GTK_CONTAINER(bbox), button);
+	g_signal_connect(button, "clicked", G_CALLBACK(send_find_dialog_response),
+		GINT_TO_POINTER(GEANY_RESPONSE_FIND_IN_SESSION));
+
+	button = gtk_button_new_with_mnemonic(_("_In Document"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
+	gtk_container_add(GTK_CONTAINER(bbox), button);
+	g_signal_connect(button, "clicked", G_CALLBACK(send_find_dialog_response),
+		GINT_TO_POINTER(GEANY_RESPONSE_FIND_IN_FILE));
+
 	gtk_container_add(GTK_CONTAINER(exp), bbox);
 	gtk_container_add(GTK_CONTAINER(vbox), exp);
 }
@@ -621,22 +631,32 @@ static void create_replace_dialog(void)
 		*check_close, *button, *rbox, *fbox, *vbox, *exp, *bbox;
 	GtkSizeGroup *label_size;
 
-	replace_dlg.dialog = gtk_dialog_new_with_buttons(_("Replace"),
-		GTK_WINDOW(main_widgets.window), GTK_DIALOG_DESTROY_WITH_PARENT,
-		GTK_STOCK_CLOSE, GTK_RESPONSE_CANCEL, NULL);
+	replace_dlg.dialog = gtk_dialog_new();
+	gtk_window_set_title(GTK_WINDOW(replace_dlg.dialog), _("Replace"));
+	gtk_window_set_transient_for(GTK_WINDOW(replace_dlg.dialog), GTK_WINDOW(main_widgets.window));
+	gtk_window_set_destroy_with_parent(GTK_WINDOW(replace_dlg.dialog), TRUE);
+
 	vbox = ui_dialog_vbox_new(GTK_DIALOG(replace_dlg.dialog));
 	gtk_box_set_spacing(GTK_BOX(vbox), 9);
 	gtk_widget_set_name(replace_dlg.dialog, "GeanyDialogSearch");
 
+	button = gtk_button_new_from_stock(GTK_STOCK_CLOSE);
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
+	gtk_dialog_add_action_widget(GTK_DIALOG(replace_dlg.dialog), button,
+		GTK_RESPONSE_CANCEL);
+
 	button = gtk_button_new_from_stock(GTK_STOCK_FIND);
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
 	gtk_dialog_add_action_widget(GTK_DIALOG(replace_dlg.dialog), button,
 		GEANY_RESPONSE_FIND);
 	button = gtk_button_new_with_mnemonic(_("_Replace"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
 	gtk_button_set_image(GTK_BUTTON(button),
 		gtk_image_new_from_stock(GTK_STOCK_FIND_AND_REPLACE, GTK_ICON_SIZE_BUTTON));
 	gtk_dialog_add_action_widget(GTK_DIALOG(replace_dlg.dialog), button,
 		GEANY_RESPONSE_REPLACE);
 	button = gtk_button_new_with_mnemonic(_("Replace & Fi_nd"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
 	gtk_button_set_image(GTK_BUTTON(button),
 		gtk_image_new_from_stock(GTK_STOCK_FIND_AND_REPLACE, GTK_ICON_SIZE_BUTTON));
 	gtk_dialog_add_action_widget(GTK_DIALOG(replace_dlg.dialog), button,
@@ -699,24 +719,7 @@ static void create_replace_dialog(void)
 	g_signal_connect_after(exp, "activate",
 		G_CALLBACK(on_expander_activated), &replace_dlg.all_expanded);
 
-	bbox = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
-
-	button = gtk_button_new_with_mnemonic(_("In Sessi_on"));
-	gtk_container_add(GTK_CONTAINER(bbox), button);
-	g_signal_connect(button, "clicked", G_CALLBACK(send_replace_dialog_response),
-		GINT_TO_POINTER(GEANY_RESPONSE_REPLACE_IN_SESSION));
-
-	button = gtk_button_new_with_mnemonic(_("_In Document"));
-	gtk_container_add(GTK_CONTAINER(bbox), button);
-	g_signal_connect(button, "clicked", G_CALLBACK(send_replace_dialog_response),
-		GINT_TO_POINTER(GEANY_RESPONSE_REPLACE_IN_FILE));
-
-	button = gtk_button_new_with_mnemonic(_("In Se_lection"));
-	gtk_widget_set_tooltip_text(button,
-		_("Replace all matches found in the currently selected text"));
-	gtk_container_add(GTK_CONTAINER(bbox), button);
-	g_signal_connect(button, "clicked", G_CALLBACK(send_replace_dialog_response),
-		GINT_TO_POINTER(GEANY_RESPONSE_REPLACE_IN_SEL));
+	bbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 
 	/* close window checkbox */
 	check_close = gtk_check_button_new_with_mnemonic(_("Close _dialog"));
@@ -724,12 +727,28 @@ static void create_replace_dialog(void)
 	gtk_button_set_focus_on_click(GTK_BUTTON(check_close), FALSE);
 	gtk_widget_set_tooltip_text(check_close,
 			_("Disable this option to keep the dialog open"));
-	gtk_container_add(GTK_CONTAINER(bbox), check_close);
-	gtk_button_box_set_child_secondary(GTK_BUTTON_BOX(bbox), check_close, TRUE);
+	gtk_box_pack_start(GTK_BOX(bbox), check_close, TRUE, TRUE, 0);
 
-	ui_hbutton_box_copy_layout(
-		GTK_BUTTON_BOX(gtk_dialog_get_action_area(GTK_DIALOG(replace_dlg.dialog))),
-		GTK_BUTTON_BOX(bbox));
+	button = gtk_button_new_with_mnemonic(_("In Sessi_on"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
+	gtk_container_add(GTK_CONTAINER(bbox), button);
+	g_signal_connect(button, "clicked", G_CALLBACK(send_replace_dialog_response),
+		GINT_TO_POINTER(GEANY_RESPONSE_REPLACE_IN_SESSION));
+
+	button = gtk_button_new_with_mnemonic(_("_In Document"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
+	gtk_container_add(GTK_CONTAINER(bbox), button);
+	g_signal_connect(button, "clicked", G_CALLBACK(send_replace_dialog_response),
+		GINT_TO_POINTER(GEANY_RESPONSE_REPLACE_IN_FILE));
+
+	button = gtk_button_new_with_mnemonic(_("In Se_lection"));
+	gtk_widget_set_size_request(button, MIN_DLG_BUTTON_SIZE, -1);
+	gtk_widget_set_tooltip_text(button,
+		_("Replace all matches found in the currently selected text"));
+	gtk_container_add(GTK_CONTAINER(bbox), button);
+	g_signal_connect(button, "clicked", G_CALLBACK(send_replace_dialog_response),
+		GINT_TO_POINTER(GEANY_RESPONSE_REPLACE_IN_SEL));
+
 	gtk_container_add(GTK_CONTAINER(exp), bbox);
 	gtk_container_add(GTK_CONTAINER(vbox), exp);
 }

--- a/src/search.c
+++ b/src/search.c
@@ -526,6 +526,7 @@ static void create_find_dialog(void)
 		G_CALLBACK(on_expander_activated), &find_dlg.all_expanded);
 
 	bbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
+	gtk_widget_set_margin_top(bbox, 6);
 
 	/* close window checkbox */
 	check_close = gtk_check_button_new_with_mnemonic(_("Close _dialog"));
@@ -719,6 +720,7 @@ static void create_replace_dialog(void)
 		G_CALLBACK(on_expander_activated), &replace_dlg.all_expanded);
 
 	bbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
+	gtk_widget_set_margin_top(bbox, 6);
 
 	/* close window checkbox */
 	check_close = gtk_check_button_new_with_mnemonic(_("Close _dialog"));

--- a/src/search.c
+++ b/src/search.c
@@ -373,9 +373,8 @@ static GtkWidget *add_find_checkboxes(GtkDialog *dialog)
 	gtk_box_pack_start(GTK_BOX(mbox), checkbox5, FALSE, FALSE, 0);
 
 	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
-	gtk_box_set_homogeneous(GTK_BOX(hbox), TRUE);
-	gtk_container_add(GTK_CONTAINER(hbox), fbox);
-	gtk_container_add(GTK_CONTAINER(hbox), mbox);
+	gtk_box_pack_start(GTK_BOX(hbox), fbox, TRUE, TRUE, 0);
+	gtk_box_pack_start(GTK_BOX(hbox), mbox, TRUE, TRUE, 0);
 	return hbox;
 }
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1640,33 +1640,6 @@ void ui_entry_add_activate_backward_signal(GtkEntry *entry)
 }
 
 
-static void add_to_size_group(GtkWidget *widget, gpointer size_group)
-{
-	g_return_if_fail(GTK_IS_SIZE_GROUP(size_group));
-	gtk_size_group_add_widget(GTK_SIZE_GROUP(size_group), widget);
-}
-
-
-/* Copies the spacing and layout of the master GtkHButtonBox and synchronises
- * the width of each button box's children.
- * Should be called after all child widgets have been packed. */
-void ui_hbutton_box_copy_layout(GtkButtonBox *master, GtkButtonBox *copy)
-{
-	GtkSizeGroup *size_group;
-
-	gtk_box_set_spacing(GTK_BOX(copy), 10);
-	gtk_button_box_set_layout(copy, gtk_button_box_get_layout(master));
-
-	/* now we need to put the widest widget from each button box in a size group,
-	* but we don't know the width before they are drawn, and for different label
-	* translations the widest widget can vary, so we just add all widgets. */
-	size_group = gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL);
-	gtk_container_foreach(GTK_CONTAINER(master), add_to_size_group, size_group);
-	gtk_container_foreach(GTK_CONTAINER(copy), add_to_size_group, size_group);
-	g_object_unref(size_group);
-}
-
-
 static gboolean tree_model_find_text(GtkTreeModel *model,
 		GtkTreeIter *iter, gint column, const gchar *text)
 {

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -241,8 +241,6 @@ gchar *ui_menu_item_get_text(GtkMenuItem *menu_item);
 
 void ui_dialog_set_primary_button_order(GtkDialog *dialog, gint response, ...);
 
-void ui_hbutton_box_copy_layout(GtkButtonBox *master, GtkButtonBox *copy);
-
 void ui_combo_box_prepend_text_once(GtkComboBoxText *combo, const gchar *text);
 
 void ui_setup_open_button_callback(GtkWidget *open_btn, const gchar *title,


### PR DESCRIPTION
**Problem 1**
In Czech for instance, the "In Session" button is translated as "Ve všech otevřených souborech" (meaning "in all open files"). Since the sizing of buttons is homogenous, all of them pick this size (including the "close window" checkbox on the left) and the result is a ridiculously wide search dialog that is impossible to shrink for users:

<img width="1070" alt="Screenshot 2024-12-05 at 19 51 16" src="https://github.com/user-attachments/assets/8c83ab2b-c1d2-4c2e-90e9-22f1a0221657">

I dropped the homogenous spacing but to simulate it, I set the minimum size of all the buttons to 130px so buttons containing shorter labels (which are most of them in practice) still have the same size. The result looks much more reasonable:

<img width="670" alt="Screenshot 2024-12-05 at 20 01 51" src="https://github.com/user-attachments/assets/172cff1b-4e86-41ee-98cb-e795790a23d3">

**Problem 2**
In German, for instance, a translation in the first column of checkboxes is much wider than in the second column but again, the two columns are sized homogeneously so there is a lot of wasted space in the second column.

<img width="863" alt="Screenshot 2024-12-05 at 19 56 50" src="https://github.com/user-attachments/assets/d492887f-f0b8-4f4f-aac3-9b92ee91b00d">

The second patch drops the homogenous spacing so the second column can be shorter:

<img width="670" alt="Screenshot 2024-12-05 at 20 02 53" src="https://github.com/user-attachments/assets/707961dc-ffb5-4efb-b848-d5a22ff35a34">

**Problem 3**
Finally, I noticed that the vertical distance between the "Find All" expander and the "Close dialog" checkbox below it is too low and the text looks a bit crowded. I added a 6px padding there. (Check the screenshots above to see the before/after change.)
