### PR TITLE
Move long label from glade to prefs.c and use geany_wrap_label for it

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -3175,21 +3175,6 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="label247">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Note: To apply these settings to all currently open documents, use &lt;i&gt;Project-&gt;Apply Default Indentation&lt;/i&gt;.</property>
-                        <property name="use-markup">True</property>
-                        <property name="wrap">True</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
                       <object class="GtkFrame" id="frame27">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1701,6 +1701,12 @@ void prefs_show_dialog(void)
 		gtk_misc_set_padding(GTK_MISC(label), 6, 0);
 		gtk_box_pack_start(GTK_BOX(ui_lookup_widget(ui_widgets.prefs_dialog,
 			"label_project_indent_warning")), label, FALSE, TRUE, 5);
+		label = geany_wrap_label_new(_("Note: To apply these settings to all currently open documents, use <i>Project->Apply Default Indentation</i>."));
+		gtk_widget_show(label);
+		gtk_label_set_use_markup(GTK_LABEL(label), TRUE);
+		gtk_misc_set_padding(GTK_MISC(label), 6, 0);
+		gtk_box_pack_start(GTK_BOX(ui_lookup_widget(ui_widgets.prefs_dialog,
+			"label_project_indent_warning")), label, FALSE, TRUE, 5);
 
 		/* add the clear icon to GtkEntry widgets in the dialog */
 		{


### PR DESCRIPTION
This is done similarly to other long strings from the prefs dialog. Makes the dialog less wide under some locales.