### PR TITLE
Make the label in custom date format dialog shorter

### DIFF
--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -724,8 +724,7 @@ static void insert_date(GeanyDocument *doc, gint pos, const gchar *date_style)
 	else
 	{
 		gchar *str = dialogs_show_input(_("Custom Date Format"), GTK_WINDOW(main_widgets.window),
-				_("Enter here a custom date and time format. "
-				"For a list of available conversion specifiers see https://docs.gtk.org/glib/method.DateTime.format.html."),
+				_("Custom date format (see https://docs.gtk.org/glib/method.DateTime.format.html):"),
 				ui_prefs.custom_date_format);
 		if (str)
 			SETPTR(ui_prefs.custom_date_format, str);


### PR DESCRIPTION
Before:
<img width="990" alt="Screenshot 2024-12-11 at 14 11 40" src="https://github.com/user-attachments/assets/da127f54-3520-4cc3-b276-9ab601d3eba5" />

After:
<img width="581" alt="Screenshot 2024-12-11 at 14 15 59" src="https://github.com/user-attachments/assets/53015fa5-dbc6-4822-bfae-256106672be8" />

Note that since this is Geany code, it would also be possible to use GeanyWrapLabel here. However, the dialog is created using `dialogs_show_input()` to plugins and plugins might not expect that.

(Hopefully the last of my "too wide dialog" patches ;-)

Fixes #3625.