### PR TITLE
Add filter for keybindings in preferences dialog

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -5533,6 +5533,20 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkEntry" id="entry_keybinding_filter">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="primary-icon-stock">gtk-find</property>
+                            <property name="secondary-icon-activatable">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+
+                        <child>
                           <object class="GtkScrolledWindow" id="scrolledwindow8">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
@@ -5551,7 +5565,7 @@
                           <packing>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
-                            <property name="position">1</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                         <child>
@@ -5573,7 +5587,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1648,6 +1648,17 @@ static gboolean pm_treeview_button_press_cb(GtkWidget *widget, GdkEventButton *e
 }
 
 
+static gboolean pm_treeview_key_press_cb(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
+{
+	if (event->keyval == GDK_KEY_f && (event->state & GEANY_PRIMARY_MOD_MASK))
+	{
+		gtk_widget_grab_focus(pm_widgets.filter_entry);
+		return TRUE;
+	}
+	return FALSE;
+}
+
+
 static gint pm_tree_sort_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b,
 		gpointer user_data)
 {
@@ -1740,6 +1751,7 @@ static void pm_prepare_treeview(GtkWidget *tree, GtkTreeStore *store)
 	g_signal_connect(sel, "changed", G_CALLBACK(pm_selection_changed), NULL);
 
 	g_signal_connect(tree, "button-press-event", G_CALLBACK(pm_treeview_button_press_cb), NULL);
+	g_signal_connect(tree, "key-press-event", G_CALLBACK(pm_treeview_key_press_cb), NULL);
 
 	/* filter */
 	filter_model = gtk_tree_model_filter_new(GTK_TREE_MODEL(store), NULL);

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1663,48 +1663,6 @@ static gint pm_tree_sort_func(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *
 }
 
 
-static gboolean pm_tree_search(const gchar *key, const gchar *haystack)
-{
-	gchar *normalized_string = NULL;
-	gchar *normalized_key = NULL;
-	gchar *case_normalized_string = NULL;
-	gchar *case_normalized_key = NULL;
-	gboolean matched = TRUE;
-
-	normalized_string = g_utf8_normalize(haystack, -1, G_NORMALIZE_ALL);
-	normalized_key = g_utf8_normalize(key, -1, G_NORMALIZE_ALL);
-
-	if (normalized_string != NULL && normalized_key != NULL)
-	{
-		GString *stripped_key;
-		gchar **subkey, **subkeys;
-
-		case_normalized_string = g_utf8_casefold(normalized_string, -1);
-		case_normalized_key = g_utf8_casefold(normalized_key, -1);
-		stripped_key = g_string_new(case_normalized_key);
-		do {} while (utils_string_replace_all(stripped_key, "  ", " "));
-		subkeys = g_strsplit(stripped_key->str, " ", -1);
-		g_string_free(stripped_key, TRUE);
-		foreach_strv(subkey, subkeys)
-		{
-			if (strstr(case_normalized_string, *subkey) == NULL)
-			{
-				matched = FALSE;
-				break;
-			}
-		}
-		g_strfreev(subkeys);
-	}
-
-	g_free(normalized_key);
-	g_free(normalized_string);
-	g_free(case_normalized_key);
-	g_free(case_normalized_string);
-
-	return matched;
-}
-
-
 static gboolean pm_tree_filter_func(GtkTreeModel *model, GtkTreeIter *iter, gpointer user_data)
 {
 	Plugin *plugin;
@@ -1721,7 +1679,7 @@ static gboolean pm_tree_filter_func(GtkTreeModel *model, GtkTreeIter *iter, gpoi
 	filename = g_path_get_basename(plugin->filename);
 	haystack = g_strjoin(" ", plugin->info.name, plugin->info.description,
 					plugin->info.author, filename, NULL);
-	matched = pm_tree_search(key, haystack);
+	matched = utils_utf8_substring_match(key, haystack);
 	g_free(haystack);
 	g_free(filename);
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -181,7 +181,8 @@ static void kb_tree_view_change_button_clicked_cb(GtkWidget *button, KbData *kbd
 			GtkWidget *accel_label;
 			gchar *str;
 
-			dialog = gtk_dialog_new_with_buttons(_("Grab Key"), GTK_WINDOW(ui_widgets.prefs_dialog),
+			dialog = gtk_dialog_new_with_buttons(_("Assign Keybinding"),
+					GTK_WINDOW(ui_widgets.prefs_dialog),
 					GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
 					GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
 					GTK_STOCK_OK, GTK_RESPONSE_ACCEPT, NULL);

--- a/src/utils.h
+++ b/src/utils.h
@@ -338,6 +338,8 @@ gchar *utils_get_os_info_string(void);
 
 gchar *utils_utf8_strdown(const gchar *str);
 
+gboolean utils_utf8_substring_match(const gchar *key, const gchar *haystack);
+
 #endif /* GEANY_PRIVATE */
 
 G_END_DECLS


### PR DESCRIPTION
This adds a filter entry in the keybindings tab in the preferences dialog, similar to the filter entry in the plugin manager dialog.

![Screenshot_2025-01-12_14-38-50](https://github.com/user-attachments/assets/9e0f7fc9-ecf3-439c-bb9c-f872ff6ca442)


Remarks:
- only the action and group names are considered for filtering, not the keybindings
- ~~the categories are always shown (hiding them on no matching children isn't trivial)~~
- Ctrl-F in the TreeView sets focus to the filter entry
- Ctrl-F in the TreeView in the plugin manager dialog sets focus to the filter entry
- I also changed the dialog title of the assign keybinding dialog, as suggested in https://github.com/geany/geany/issues/4185

Closes #2848.