### PR TITLE
Set some reasonable minimum width for the preferences dialog

### DIFF
--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1646,6 +1646,7 @@ void prefs_show_dialog(void)
 		ui_widgets.prefs_dialog = create_prefs_dialog();
 		gtk_widget_set_name(ui_widgets.prefs_dialog, "GeanyPrefsDialog");
 		gtk_window_set_transient_for(GTK_WINDOW(ui_widgets.prefs_dialog), GTK_WINDOW(main_widgets.window));
+		gtk_widget_set_size_request(ui_widgets.prefs_dialog, 600, -1);
 
 		/* init the file encoding combo boxes */
 		{


### PR DESCRIPTION
Because of more compact font on Windows, the Preferences dialog is too narrow on Windows after https://github.com/geany/geany/pull/4099.