### PR TITLE
Bump required glib version to 2.56

### DIFF
--- a/m4/geany-gtk.m4
+++ b/m4/geany-gtk.m4
@@ -2,12 +2,12 @@ dnl GEANY_CHECK_GTK
 dnl Checks whether the GTK stack is available and new enough. Sets GTK_CFLAGS and GTK_LIBS.
 AC_DEFUN([GEANY_CHECK_GTK],
 [
-	gtk_modules="gtk+-3.0 >= 3.24 glib-2.0 >= 2.32"
-	gtk_modules_private="gio-2.0 >= 2.32 gmodule-no-export-2.0 gthread-2.0"
+	gtk_modules="gtk+-3.0 >= 3.24 glib-2.0 >= 2.56"
+	gtk_modules_private="gio-2.0 >= 2.56 gmodule-no-export-2.0 gthread-2.0"
 
 	PKG_CHECK_MODULES([GTK], [$gtk_modules $gtk_modules_private])
 	AC_SUBST([DEPENDENCIES], [$gtk_modules])
-	AS_VAR_APPEND([GTK_CFLAGS], [" -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_32"])
+	AS_VAR_APPEND([GTK_CFLAGS], [" -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56"])
 	dnl Disable all GTK deprecations
 	AS_VAR_APPEND([GTK_CFLAGS], [" -DGDK_DISABLE_DEPRECATION_WARNINGS"])
 	AC_SUBST([GTK_CFLAGS])

--- a/meson.build
+++ b/meson.build
@@ -11,8 +11,8 @@ cxx = meson.get_compiler('cpp')
 prefix = get_option('prefix')
 
 deps_in = [
-	['glib-2.0',    '2.32'],
-	['gmodule-2.0', '2.32'],
+	['glib-2.0',    '2.56'],
+	['gmodule-2.0', '2.56'],
 	['gtk+-3.0',    '3.24']
 ]
 
@@ -201,7 +201,7 @@ def_cflags = basic_cflags + [
 # we're using lots of deprecated stuff with gtk3 (often because there is no proper alternative!)
 	'-Wno-deprecated-declarations',
 	'-DGDK_DISABLE_DEPRECATION_WARNINGS',
-	'-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_32',
+	'-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56',
 	'-DGEANY_PREFIX="@0@"'.format(get_option('prefix')),
 	'-DGEANY_DOCDIR="@0@"'.format(join_paths(prefix, get_option('datadir'), 'doc'))
 ]

--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -84,9 +84,9 @@ typedef struct GeanyDocumentPrivate
 	/* Iter for this document within the Open Files treeview of the sidebar. */
 	GtkTreeIter		 iter;
 	/* Used by the Undo/Redo management code. */
-	GTrashStack		*undo_actions;
+	GSList			*undo_actions;
 	/* Used by the Undo/Redo management code. */
-	GTrashStack		*redo_actions;
+	GSList			*redo_actions;
 	/* Used so Undo/Redo works for encoding changes. */
 	FileEncoding	 saved_encoding;
 	gboolean		 colourise_needed;	/* use document.c:queue_colourise() instead */

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1030,10 +1030,6 @@ static const gchar *get_locale(void)
 GEANY_EXPORT_SYMBOL
 void main_init_headless(void)
 {
-#if ! GLIB_CHECK_VERSION(2, 36, 0)
-	g_type_init();
-#endif
-
 	app = g_new0(GeanyApp, 1);
 	memset(&main_status, 0, sizeof(GeanyStatus));
 	memset(&prefs, 0, sizeof(GeanyPrefs));
@@ -1083,13 +1079,6 @@ gint main_lib(gint argc, gchar **argv)
 	/* initialize TM before parsing command-line - needed for tag file generation */
 	app->tm_workspace = tm_get_workspace();
 	parse_command_line_options(&argc, &argv);
-
-#if ! GLIB_CHECK_VERSION(2, 32, 0)
-	/* Initialize GLib's thread system in case any plugins want to use it or their
-	 * dependencies (e.g. WebKit, Soup, ...). Deprecated since GLIB 2.32. */
-	if (!g_thread_supported())
-		g_thread_init(NULL);
-#endif
 
 #ifdef G_OS_UNIX
 	g_unix_signal_add(SIGTERM, signal_cb, GINT_TO_POINTER(SIGTERM));

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -70,10 +70,6 @@
 # include "geany.h"
 #endif
 
-#if ! GLIB_CHECK_VERSION(2, 31, 20) && ! defined(G_SPAWN_ERROR_TOO_BIG)
-# define G_SPAWN_ERROR_TOO_BIG G_SPAWN_ERROR_2BIG
-#endif
-
 #ifdef G_OS_WIN32
 /* Each 4KB under Windows seem to come in 2 portions, so 2K + 2K is more
    balanced than 4095 + 1. May be different on the latest Windows/glib? */

--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -681,31 +681,6 @@ gboolean tm_workspace_is_autocomplete_tag(TMTag *tag,
 }
 
 
-#if ! GLIB_CHECK_VERSION(2, 54, 0)
-static gboolean
-g_ptr_array_find (GPtrArray     *haystack,
-                  gconstpointer  needle,
-                  guint         *index_)
-{
-  guint i;
-
-  g_return_val_if_fail (haystack != NULL, FALSE);
-
-  for (i = 0; i < haystack->len; i++)
-    {
-      if (g_direct_equal (g_ptr_array_index (haystack, i), needle))
-        {
-          if (index_ != NULL)
-            *index_ = i;
-          return TRUE;
-        }
-    }
-
-  return FALSE;
-}
-#endif
-
-
 typedef struct
 {
 	TMSourceFile *file;


### PR DESCRIPTION
Since we depend on GTK 3.24 which was released in September 2018, we can also depend on a newer glib version from around that time since it will be provided by distros anyway (and not the ancient glib 2.32 from 2012). This can eliminate a few conditionals from the code.

At the end, I used 2.56 from March 2018 - originally I wanted to use 2.58 from August but it produces some depreciation warnings in Scintilla which would have to be addressed first.

I also had to replace now deprecated GTrashStack which Geany (mis)used for a simple stack implementation of undo/redo - I just used GSList instead.