### PR TITLE
Workaround incorrect scaling of "reverse arrow" cursor under Windows and HiDPI screens

### DIFF
--- a/scintilla/gtk/PlatGTK.cxx
+++ b/scintilla/gtk/PlatGTK.cxx
@@ -1346,7 +1346,13 @@ void Window::SetCursor(Cursor curs) {
 		gdkCurs = gdk_cursor_new_for_display(pdisplay, GDK_HAND2);
 		break;
 	case Cursor::reverseArrow:
+#ifdef G_OS_WIN32
+		// GDK_RIGHT_PTR is scaled incorrectly under Windows with HiDPI screens (GTK 3.24);
+		// GDK_HAND2 is mapped to a native Windows cursor by GTK
+		gdkCurs = gdk_cursor_new_for_display(pdisplay, GDK_HAND2);
+#else
 		gdkCurs = gdk_cursor_new_for_display(pdisplay, GDK_RIGHT_PTR);
+#endif
 		break;
 	default:
 		gdkCurs = gdk_cursor_new_for_display(pdisplay, GDK_LEFT_PTR);


### PR DESCRIPTION
The GDK_RIGHT_PTR cursor is provided only by GTK - there's no native Windows cursor of this shape so GTK renders the cursor by itself from the cursor theme bitmap. The code doing this is apparently buggy and does not take into account HiDPI screens so on a screen with 300% scaling, the cursor is 3x smaller.

Workaround this by using GDK_HAND2 which maps to a native Windows cursor that doesn't suffer from this problem.

See https://sourceforge.net/p/scintilla/bugs/2460/