### PR TITLE
Improve CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,6 +57,9 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        config: |
+          paths-ignore:
+            - 'tests/ctags/**'
 
     - name: Install dependencies
       if: matrix.language == 'c-cpp'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,6 +59,7 @@ jobs:
         languages: ${{ matrix.language }}
 
     - name: Install dependencies
+      if: matrix.language == 'c-cpp'
       run: |
         sudo apt-get update -qq
         sudo apt-get install --assume-yes --no-install-recommends \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,8 +62,8 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install --assume-yes --no-install-recommends \
-          ccache \
-          gettext autopoint \
+          gettext \
+          autopoint \
           libtool \
           libgtk-3-dev \
           doxygen \


### PR DESCRIPTION
Ccache is probably not useful at all because the cached files are not persisted between workflow runs and might even confuse the analyse action.

Might close #4206.

c3d8941364150b0ef5431846c25f2c714c7ad08f excludes a Ctags test case which has invalid syntax. I'm not sure if the invalid syntax in this file is on purpose (upstream uctags has it as well) but it just doesn't matter for the CodeQL job.

6a8e566684e4376d369dafbaaae45ba0195f0cae removes "ccache" from the build which is of no use in this case as the cached files are not and should not preserved between workflow runs.

67091f721cf826381b99f62a6d5d0a219e8731d9 speeds up the Python scan a little bit as we now skip installing unnecessary dependencies.

