### PR TITLE
Allow shrinking the preferences dialog again

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -761,6 +761,7 @@
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
     <property name="modal">True</property>
+    <property name="default-width">600</property>
     <property name="icon-name">geany</property>
     <property name="type-hint">dialog</property>
     <property name="skip-pager-hint">True</property>

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1751,7 +1751,6 @@ void prefs_show_dialog(void)
 		ui_widgets.prefs_dialog = create_prefs_dialog();
 		gtk_widget_set_name(ui_widgets.prefs_dialog, "GeanyPrefsDialog");
 		gtk_window_set_transient_for(GTK_WINDOW(ui_widgets.prefs_dialog), GTK_WINDOW(main_widgets.window));
-		gtk_widget_set_size_request(ui_widgets.prefs_dialog, 600, -1);
 
 		/* init the file encoding combo boxes */
 		{


### PR DESCRIPTION
Use a more flexible way of setting the default preference window size to allow shrinking the window if desired.

Related to #4195.