### PR TITLE
tests/ctags: Allow testing filetypes with no suffix patterns

### DIFF
--- a/tests/ctags/runner.sh
+++ b/tests/ctags/runner.sh
@@ -14,7 +14,10 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # related configuration files
 mkdir -p "$CONFDIR" || exit 99
 mkdir -p "$CONFDIR/filedefs/" || exit 99
-cp "${top_srcdir:-../..}"/data/filetype_extensions.conf "$CONFDIR" || exit 99
+# Add *.Filetype_unittest extension so we can match filetypes for which there
+# are no extension patterns, like e.g. Meson.
+sed 's/^\([^=[]\{1,\}\)\(=[^;]\{1,\}\(;[^;]\{1,\}\)*\);*$/\1\2;*.\1_unittest;/' \
+  < "${top_srcdir:-../..}"/data/filetype_extensions.conf > "$CONFDIR/filetype_extensions.conf" || exit 99
 cp "${top_srcdir:-../..}"/data/filedefs/filetypes.* "$CONFDIR/filedefs/" || exit 99
 
 shift


### PR DESCRIPTION
Filetypes need not have a filename suffix pattern (like e.g. `*.c`), but can have other form of patterns (e.g. `Makefile`, `meson.build`, etc.), or even no patterns at all.

Such less common patterns make it impossible to match them in unittests, as filenames used there need to be of the form `test_*`.

Fix this by adding a fake extension to each filetype that is the name of the filetype followed with `_unittest`, e.g. `CMake_unittest` or `Meson_unittest`.

Fixes #4074.