### PR TITLE
Fix #4192 aftermath :boom: (sorry @eht16 :grin:)

### DIFF
--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1405,13 +1405,17 @@ static void kb_cell_edited_cb(GtkCellRendererText *cellrenderertext,
 {
 	if (path != NULL && new_text != NULL)
 	{
+		GtkTreeModel *filter_model = gtk_tree_view_get_model(kbdata->tree);
 		GtkTreeIter iter;
+		GtkTreeIter child_iter;
 
-		gtk_tree_model_get_iter_from_string(GTK_TREE_MODEL(kbdata->store), &iter, path);
-		if (gtk_tree_model_iter_has_child(GTK_TREE_MODEL(kbdata->store), &iter))
+		gtk_tree_model_get_iter_from_string(filter_model, &iter, path);
+		if (gtk_tree_model_iter_has_child(filter_model, &iter))
 			return;	/* ignore group items */
 
-		kb_change_iter_shortcut(kbdata, &iter, new_text);
+		gtk_tree_model_filter_convert_iter_to_child_iter(GTK_TREE_MODEL_FILTER(filter_model),
+				&child_iter, &iter);
+		kb_change_iter_shortcut(kbdata, &child_iter, new_text);
 	}
 }
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -203,9 +203,11 @@ static void kb_tree_view_change_button_clicked_cb(GtkWidget *button, KbData *kbd
 			gtk_widget_show_all(dialog);
 			if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
 			{
+				GtkTreeIter child_iter;
 				const gchar *new_text = gtk_label_get_text(GTK_LABEL(accel_label));
 
-				kb_change_iter_shortcut(kbdata, &iter, new_text);
+				gtk_tree_model_filter_convert_iter_to_child_iter(GTK_TREE_MODEL_FILTER(model), &child_iter, &iter);
+				kb_change_iter_shortcut(kbdata, &child_iter, new_text);
 			}
 			gtk_widget_destroy(dialog);
 


### PR DESCRIPTION
This should allow one to edit keybindings without too many surprises again.  I didn't review everything though, and just fixed the couple I found (I got hit :boom: by the first crash, and suspected the second one).