### PR TITLE
Fix some warnings on macOS with clang

### DIFF
--- a/ctags/gnu_regex/regcomp.c
+++ b/ctags/gnu_regex/regcomp.c
@@ -212,10 +212,7 @@ const size_t __re_error_msgid_idx[] attribute_hidden =
    are set in BUFP on entry.  */
 
 const char *
-re_compile_pattern (pattern, length, bufp)
-    const char *pattern;
-    size_t length;
-    struct re_pattern_buffer *bufp;
+re_compile_pattern (const char *pattern, size_t length, struct re_pattern_buffer *bufp)
 {
   reg_errcode_t ret;
 
@@ -253,8 +250,7 @@ reg_syntax_t re_syntax_options;
    defined in regex.h.  We return the old syntax.  */
 
 reg_syntax_t
-re_set_syntax (syntax)
-    reg_syntax_t syntax;
+re_set_syntax (reg_syntax_t syntax)
 {
   reg_syntax_t ret = re_syntax_options;
 
@@ -266,8 +262,7 @@ weak_alias (__re_set_syntax, re_set_syntax)
 #endif
 
 int
-re_compile_fastmap (bufp)
-    struct re_pattern_buffer *bufp;
+re_compile_fastmap (struct re_pattern_buffer *bufp)
 {
   re_dfa_t *dfa = (re_dfa_t *) bufp->buffer;
   char *fastmap = bufp->fastmap;
@@ -465,10 +460,7 @@ re_compile_fastmap_iter (regex_t *bufp, const re_dfastate_t *init_state,
    the return codes and their meanings.)  */
 
 int
-regcomp (preg, pattern, cflags)
-    regex_t *__restrict preg;
-    const char *__restrict pattern;
-    int cflags;
+regcomp (regex_t *__restrict preg, const char *__restrict pattern, int cflags)
 {
   reg_errcode_t ret;
   reg_syntax_t syntax = ((cflags & REG_EXTENDED) ? RE_SYNTAX_POSIX_EXTENDED
@@ -635,8 +627,7 @@ free_dfa_content (re_dfa_t *dfa)
 /* Free dynamically allocated space used by PREG.  */
 
 void
-regfree (preg)
-    regex_t *preg;
+regfree (regex_t *preg)
 {
   re_dfa_t *dfa = (re_dfa_t *) preg->buffer;
   if (BE (dfa != NULL, 1))

--- a/ctags/gnu_regex/regex.h
+++ b/ctags/gnu_regex/regex.h
@@ -350,7 +350,7 @@ typedef enum
 #ifdef __USE_GNU
 # define __REPB_PREFIX(name) name
 #else
-# define __REPB_PREFIX(name) __##name
+# define __REPB_PREFIX(name) __priv_##name
 #endif
 
 struct re_pattern_buffer

--- a/ctags/gnu_regex/regexec.c
+++ b/ctags/gnu_regex/regexec.c
@@ -218,12 +218,8 @@ static reg_errcode_t extend_buffers (re_match_context_t *mctx)
    We return 0 if we find a match and REG_NOMATCH if not.  */
 
 int
-regexec (preg, string, nmatch, pmatch, eflags)
-    const regex_t *__restrict preg;
-    const char *__restrict string;
-    size_t nmatch;
-    regmatch_t pmatch[];
-    int eflags;
+regexec (const regex_t *__restrict preg, const char *__restrict string,
+    size_t nmatch, regmatch_t pmatch[], int eflags)
 {
   reg_errcode_t err;
   int start, length;
@@ -306,11 +302,8 @@ compat_symbol (libc, __compat_regexec, regexec, GLIBC_2_0);
    match was found and -2 indicates an internal error.  */
 
 int
-re_match (bufp, string, length, start, regs)
-    struct re_pattern_buffer *bufp;
-    const char *string;
-    int length, start;
-    struct re_registers *regs;
+re_match (struct re_pattern_buffer *bufp, const char *string, int length,
+    int start, struct re_registers *regs)
 {
   return re_search_stub (bufp, string, length, start, 0, length, regs, 1);
 }
@@ -319,11 +312,7 @@ weak_alias (__re_match, re_match)
 #endif
 
 int
-re_search (bufp, string, length, start, range, regs)
-    struct re_pattern_buffer *bufp;
-    const char *string;
-    int length, start, range;
-    struct re_registers *regs;
+re_search (struct re_pattern_buffer *bufp, const char *string, int length, int start, int range, struct re_registers *regs)
 {
   return re_search_stub (bufp, string, length, start, range, length, regs, 0);
 }
@@ -332,11 +321,9 @@ weak_alias (__re_search, re_search)
 #endif
 
 int
-re_match_2 (bufp, string1, length1, string2, length2, start, regs, stop)
-    struct re_pattern_buffer *bufp;
-    const char *string1, *string2;
-    int length1, length2, start, stop;
-    struct re_registers *regs;
+re_match_2 (struct re_pattern_buffer *bufp, const char *string1,
+    int length1, const char *string2, int length2, int start,
+    struct re_registers *regs, int stop)
 {
   return re_search_2_stub (bufp, string1, length1, string2, length2,
 			   start, 0, regs, stop, 1);
@@ -346,11 +333,9 @@ weak_alias (__re_match_2, re_match_2)
 #endif
 
 int
-re_search_2 (bufp, string1, length1, string2, length2, start, range, regs, stop)
-    struct re_pattern_buffer *bufp;
-    const char *string1, *string2;
-    int length1, length2, start, range, stop;
-    struct re_registers *regs;
+re_search_2 (struct re_pattern_buffer *bufp, const char *string1,
+    int length1, const char *string2, int length2, int start, int range,
+    struct re_registers *regs, int stop)
 {
   return re_search_2_stub (bufp, string1, length1, string2, length2,
 			   start, range, regs, stop, 0);
@@ -360,12 +345,10 @@ weak_alias (__re_search_2, re_search_2)
 #endif
 
 static int
-re_search_2_stub (bufp, string1, length1, string2, length2, start, range, regs,
-		  stop, ret_len)
-    struct re_pattern_buffer *bufp;
-    const char *string1, *string2;
-    int length1, length2, start, range, stop, ret_len;
-    struct re_registers *regs;
+re_search_2_stub (struct re_pattern_buffer *bufp, const char *string1,
+                  int length1, const char *string2, int length2,
+                  int start, int range, struct re_registers *regs,
+                  int stop, int ret_len)
 {
   const char *str;
   int rval;
@@ -410,11 +393,9 @@ re_search_2_stub (bufp, string1, length1, string2, length2, start, range, regs,
    otherwise the position of the match is returned.  */
 
 static int
-re_search_stub (bufp, string, length, start, range, stop, regs, ret_len)
-    struct re_pattern_buffer *bufp;
-    const char *string;
-    int length, start, range, stop, ret_len;
-    struct re_registers *regs;
+re_search_stub (struct re_pattern_buffer *bufp, const char *string,
+    int length, int start, int range, int stop, struct re_registers *regs,
+    int ret_len)
 {
   reg_errcode_t result;
   regmatch_t *pmatch;
@@ -501,10 +482,7 @@ re_search_stub (bufp, string, length, start, range, stop, regs, ret_len)
 }
 
 static unsigned
-re_copy_regs (regs, pmatch, nregs, regs_allocated)
-    struct re_registers *regs;
-    regmatch_t *pmatch;
-    int nregs, regs_allocated;
+re_copy_regs (struct re_registers *regs, regmatch_t *pmatch, int nregs, int regs_allocated)
 {
   int rval = REGS_REALLOCATE;
   int i;
@@ -570,11 +548,8 @@ re_copy_regs (regs, pmatch, nregs, regs_allocated)
    freeing the old data.  */
 
 void
-re_set_registers (bufp, regs, num_regs, starts, ends)
-    struct re_pattern_buffer *bufp;
-    struct re_registers *regs;
-    unsigned num_regs;
-    regoff_t *starts, *ends;
+re_set_registers (struct re_pattern_buffer *bufp, struct re_registers *regs,
+    unsigned num_regs, regoff_t *starts, regoff_t *ends)
 {
   if (num_regs)
     {
@@ -621,13 +596,9 @@ re_exec (s)
    (START + RANGE >= 0 && START + RANGE <= LENGTH)  */
 
 static reg_errcode_t
-re_search_internal (preg, string, length, start, range, stop, nmatch, pmatch,
-		    eflags)
-    const regex_t *preg;
-    const char *string;
-    int length, start, range, stop, eflags;
-    size_t nmatch;
-    regmatch_t pmatch[];
+re_search_internal (const regex_t *preg, const char *string, int length,
+                    int start, int range, int stop, size_t nmatch,
+                    regmatch_t pmatch[], int eflags)
 {
   reg_errcode_t err;
   const re_dfa_t *dfa = (const re_dfa_t *) preg->buffer;
@@ -940,8 +911,7 @@ re_search_internal (preg, string, length, start, range, stop, nmatch, pmatch,
 }
 
 static reg_errcode_t
-prune_impossible_nodes (mctx)
-     re_match_context_t *mctx;
+prune_impossible_nodes (re_match_context_t *mctx)
 {
   const re_dfa_t *const dfa = mctx->dfa;
   int halt_node, match_last;

--- a/ctags/parsers/geany_lcpp.c
+++ b/ctags/parsers/geany_lcpp.c
@@ -646,11 +646,9 @@ static int skipToEndOfCxxRawLiteralString (void)
 static int skipToEndOfChar (void)
 {
 	int c;
-	int count = 0;
 
 	while ((c = getcAndCollect ()) != EOF)
 	{
-	    ++count;
 		if (c == BACKSLASH)
 			getcAndCollect ();  /* throw away next character, too */
 		else if (c == SINGLE_QUOTE)

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -106,8 +106,6 @@ static GeanyFiletypeGroupID get_group(const gchar *name)
 
 static GeanyFiletypeGroupID get_filetype_group(const gchar *title, const gchar *name)
 {
-	GeanyFiletypeGroupID ret;
-
 	if (g_strcmp0(name, "None") == 0)
 		return GEANY_FILETYPE_GROUP_NONE;
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -289,7 +289,6 @@ gint socket_init(gint argc, gchar **argv, G_GNUC_UNUSED gushort socket_port, con
 #else
 	gchar *display_name = NULL;
 	const gchar *hostname = g_get_host_name();
-	GdkDisplay *display = gdk_display_get_default();
 	gchar *p;
 
 	/* On OS X with quartz backend gdk_display_get_name() returns hostname
@@ -297,6 +296,7 @@ gint socket_init(gint argc, gchar **argv, G_GNUC_UNUSED gushort socket_port, con
 	 * as display name is a X11 specific thing). This call can lead to network
 	 * query and block for several seconds so better skip it. */
 #ifndef GDK_WINDOWING_QUARTZ
+	GdkDisplay *display = gdk_display_get_default();
 	if (display != NULL)
 		display_name = g_strdup(gdk_display_get_name(display));
 #endif


### PR DESCRIPTION
Related to now merged #4181 and some warnings it produces during compilation on macOS now.

In addition, there are some general "unused variable" warning eliminations.