### PR TITLE
Avoid clang string-plus-int warning

### DIFF
--- a/tests/test_encodings.c
+++ b/tests/test_encodings.c
@@ -137,7 +137,7 @@ static void test_encodings_convert_utf8_to_utf8_auto(void)
 	G_STMT_START {																							\
 		gboolean has_bom = strncmp(str, UTF8_BOM, 3) == 0;													\
 		g_assert(success == assert_convert_to_utf8_auto(str, G_N_ELEMENTS(str) - 1, G_N_ELEMENTS(str) - 1,	\
-				forced_enc, str + (has_bom ? 3 : 0), G_N_ELEMENTS(str) - 1 - (has_bom ? 3 : 0),				\
+				forced_enc, &str[has_bom ? 3 : 0], G_N_ELEMENTS(str) - 1 - (has_bom ? 3 : 0),				\
 				forced_enc, has_bom, strlen(str) != G_N_ELEMENTS(str) - 1));								\
 	} G_STMT_END
 


### PR DESCRIPTION
Some versions of CLang warn when performing pointer arithmetic on strings, trying to avoid people thinking `+` is a string concatenation operator in C.  It's kind of silly, but given we only seem to have one of those instances, just "fix" it using array syntax instead.

PS: I was about to troll the compiler using syntax `&(has_bom ? 3 : 0)[str]` instead, but I figured it's probably not gonna annoy the compiler as much as the next contributor, so I backed out.