### PR TITLE
regex: Remove unused variable

### DIFF
--- a/ctags/gnu_regex/regex_internal.c
+++ b/ctags/gnu_regex/regex_internal.c
@@ -694,7 +694,7 @@ re_string_reconstruct (re_string_t *pstr, int idx, int eflags)
 
 	      if (pstr->is_utf8)
 		{
-		  const unsigned char *raw, *p, *q, *end;
+		  const unsigned char *raw, *p, *end;
 
 		  /* Special case UTF-8.  Multi-byte chars start with any
 		     byte other than 0x80 - 0xbf.  */
@@ -723,13 +723,11 @@ re_string_reconstruct (re_string_t *pstr, int idx, int eflags)
 			  unsigned char buf[6];
 			  size_t mbclen;
 
-			  q = p;
 			  if (BE (pstr->trans != NULL, 0))
 			    {
 			      int i = mlen < 6 ? mlen : 6;
 			      while (--i >= 0)
 				buf[i] = pstr->trans[p[i]];
-			      q = buf;
 			    }
 			  /* XXX Don't use mbrtowc, we know which conversion
 			     to use (UTF-8 -> UCS4).  */


### PR DESCRIPTION
One more warning I overlooked in https://github.com/geany/geany/pull/4228.

clang reports:
```
[202/372] Compiling C object libregex.a.p/ctags_gnu_regex_regex.c.o
In file included from ../ctags/gnu_regex/regex.c:63:
../ctags/gnu_regex/regex_internal.c:697:36: warning: variable 'q' set but not used [-Wunused-but-set-variable]
  697 |                   const unsigned char *raw, *p, *q, *end;
      |                                                  ^
```