### PR TITLE
Use filter model for symbol tree filtering as well

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -8353,11 +8353,9 @@
                             <property name="tooltip-text" translatable="yes">Filter the symbol list using the entered text. Separate multiple filters with a space.</property>
                             <property name="invisible-char">•</property>
                             <property name="primary-icon-stock">gtk-find</property>
-                            <property name="secondary-icon-stock">gtk-clear</property>
                             <property name="primary-icon-activatable">False</property>
                             <signal name="activate" handler="on_entry_tagfilter_activate" swapped="no"/>
                             <signal name="changed" handler="on_entry_tagfilter_changed" swapped="no"/>
-                            <signal name="icon-press" handler="on_entry_tagfilter_icon_press" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -8409,11 +8407,9 @@
                             <property name="tooltip-text" translatable="yes">Filter the document list using the entered text. Separate multiple filters with a space.</property>
                             <property name="invisible-char">•</property>
                             <property name="primary-icon-stock">gtk-find</property>
-                            <property name="secondary-icon-stock">gtk-clear</property>
                             <property name="primary-icon-activatable">False</property>
                             <signal name="activate" handler="on_entry_docfilter_activate" swapped="no"/>
                             <signal name="changed" handler="on_entry_docfilter_changed" swapped="no"/>
-                            <signal name="icon-press" handler="on_entry_docfilter_icon_press" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -446,14 +446,7 @@ void on_entry_tagfilter_changed(GtkAction *action, gpointer user_data)
 		return;
 
 	filter_entry = GTK_ENTRY(ui_lookup_widget(main_widgets.window, "entry_tagfilter"));
-	g_free(doc->priv->tag_filter);
-	doc->priv->tag_filter = g_strdup(gtk_entry_get_text(filter_entry));
-
-	/* make sure the tree is fully re-created so it appears correctly
-	 * after applying filter */
-	if (doc->priv->tag_store)
-		gtk_tree_store_clear(doc->priv->tag_store);
-	sidebar_update_tag_list(doc, TRUE);
+	sidebar_tagtree_set_filter(doc, gtk_entry_get_text(filter_entry));
 }
 
 
@@ -551,7 +544,6 @@ static void handle_switch_page(GeanyDocument *doc)
 	if (doc != NULL)
 	{
 		GtkEntry *filter_entry = GTK_ENTRY(ui_lookup_widget(main_widgets.window, "entry_tagfilter"));
-		const gchar *entry_text = gtk_entry_get_text(filter_entry);
 
 		sidebar_select_openfiles_item(doc);
 		ui_save_buttons_toggle(doc->changed);
@@ -560,13 +552,8 @@ static void handle_switch_page(GeanyDocument *doc)
 		ui_update_popup_reundo_items(doc);
 		ui_document_show_hide(doc); /* update the document menu */
 		build_menu_update(doc);
-		if (g_strcmp0(entry_text, doc->priv->tag_filter) != 0)
-		{
-			/* calls sidebar_update_tag_list() in on_entry_tagfilter_changed() */
-			gtk_entry_set_text(filter_entry, doc->priv->tag_filter);
-		}
-		else
-			sidebar_update_tag_list(doc, TRUE);
+		sidebar_update_tag_list(doc, FALSE);
+		gtk_entry_set_text(filter_entry, doc->priv->tag_filter);
 		document_highlight_tags(doc);
 
 		document_check_disk_status(doc, TRUE);

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -450,13 +450,6 @@ void on_entry_tagfilter_changed(GtkAction *action, gpointer user_data)
 }
 
 
-void on_entry_tagfilter_icon_press(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event, gpointer user_data)
-{
-	if (event->button.button == 1)
-		gtk_entry_set_text(entry, "");
-}
-
-
 void on_entry_tagfilter_activate(GtkEntry *entry, gpointer user_data)
 {
 	GeanyDocument *doc = document_get_current();
@@ -478,13 +471,6 @@ void on_entry_docfilter_changed(GtkAction *action, gpointer user_data)
 
 	filter_entry = GTK_ENTRY(ui_lookup_widget(main_widgets.window, "entry_docfilter"));
 	sidebar_openfiles_set_filter(gtk_entry_get_text(filter_entry));
-}
-
-
-void on_entry_docfilter_icon_press(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event, gpointer user_data)
-{
-	if (event->button.button == 1)
-		gtk_entry_set_text(entry, "");
 }
 
 

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -74,13 +74,9 @@ void on_toolbar_search_entry_activate(GtkAction *action, const gchar *text, gpoi
 
 void on_entry_tagfilter_changed(GtkAction *action, gpointer user_data);
 
-void on_entry_tagfilter_icon_press(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event, gpointer user_data);
-
 void on_entry_tagfilter_activate(GtkEntry *entry, gpointer user_data);
 
 void on_entry_docfilter_changed(GtkAction *action, gpointer user_data);
-
-void on_entry_docfilter_icon_press(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event, gpointer user_data);
 
 void on_entry_docfilter_activate(GtkEntry *entry, gpointer user_data);
 

--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -1739,6 +1739,7 @@ static void on_sidebar_switch_page(GtkNotebook *notebook,
 
 void sidebar_init(void)
 {
+	GtkEntry *filter_entry;
 	StashGroup *group;
 
 	openfiles_filter = g_strdup("");
@@ -1762,6 +1763,11 @@ void sidebar_init(void)
 		G_CALLBACK(sidebar_tabs_show_hide), NULL);
 	g_signal_connect_after(main_widgets.sidebar_notebook, "switch-page",
 		G_CALLBACK(on_sidebar_switch_page), NULL);
+
+	filter_entry = GTK_ENTRY(ui_lookup_widget(main_widgets.window, "entry_docfilter"));
+	ui_entry_add_clear_icon(filter_entry);
+	filter_entry = GTK_ENTRY(ui_lookup_widget(main_widgets.window, "entry_tagfilter"));
+	ui_entry_add_clear_icon(filter_entry);
 }
 
 #define WIDGET(w) w && GTK_IS_WIDGET(w)

--- a/src/sidebar.h
+++ b/src/sidebar.h
@@ -47,6 +47,7 @@ enum
 	SYMBOLS_COLUMN_NAME,
 	SYMBOLS_COLUMN_TAG,
 	SYMBOLS_COLUMN_TOOLTIP,
+	SYMBOLS_COLUMN_VISIBLE,
 	SYMBOLS_N_COLUMNS
 };
 
@@ -76,6 +77,8 @@ void sidebar_init(void);
 void sidebar_finalize(void);
 
 void sidebar_update_tag_list(GeanyDocument *doc, gboolean update);
+
+void sidebar_tagtree_set_filter(GeanyDocument *doc, const gchar *filter);
 
 void sidebar_openfiles_add(GeanyDocument *doc);
 

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -328,58 +328,21 @@ static GList *get_tag_list(GeanyDocument *doc, TMTagType tag_types)
 {
 	GList *tag_names = NULL;
 	guint i;
-	gchar **tf_strv;
 
 	g_return_val_if_fail(doc, NULL);
 
 	if (! doc->tm_file || ! doc->tm_file->tags_array)
 		return NULL;
 
-	tf_strv = g_strsplit_set(doc->priv->tag_filter, " ", -1);
-
 	for (i = 0; i < doc->tm_file->tags_array->len; ++i)
 	{
 		TMTag *tag = TM_TAG(doc->tm_file->tags_array->pdata[i]);
 
 		if (tag->type & tag_types)
-		{
-			gboolean filtered = FALSE;
-			gchar **val;
-			gchar *full_tagname = g_strconcat(tag->scope ? tag->scope : "",
-				tag->scope ? tm_parser_scope_separator_printable(tag->lang) : "",
-				tag->name, NULL);
-			gchar *normalized_tagname = g_utf8_normalize(full_tagname, -1, G_NORMALIZE_ALL);
-
-			foreach_strv(val, tf_strv)
-			{
-				gchar *normalized_val = g_utf8_normalize(*val, -1, G_NORMALIZE_ALL);
-
-				if (normalized_tagname != NULL && normalized_val != NULL)
-				{
-					gchar *case_normalized_tagname = g_utf8_casefold(normalized_tagname, -1);
-					gchar *case_normalized_val = g_utf8_casefold(normalized_val, -1);
-
-					filtered = strstr(case_normalized_tagname, case_normalized_val) == NULL;
-					g_free(case_normalized_tagname);
-					g_free(case_normalized_val);
-				}
-				g_free(normalized_val);
-
-				if (filtered)
-					break;
-			}
-			if (!filtered)
-				tag_names = g_list_prepend(tag_names, tag);
-
-			g_free(normalized_tagname);
-			g_free(full_tagname);
-		}
+			tag_names = g_list_prepend(tag_names, tag);
 	}
-	tag_names = g_list_sort(tag_names, compare_symbol_lines);
 
-	g_strfreev(tf_strv);
-
-	return tag_names;
+	return g_list_sort(tag_names, compare_symbol_lines);
 }
 
 
@@ -656,11 +619,18 @@ static guint tag_hash(gconstpointer v)
 /* like gtk_tree_view_expand_to_path() but with an iter */
 static void tree_view_expand_to_iter(GtkTreeView *view, GtkTreeIter *iter)
 {
-	GtkTreeModel *model = gtk_tree_view_get_model(view);
-	GtkTreePath *path = gtk_tree_model_get_path(model, iter);
+	GtkTreeModel *filter_model = gtk_tree_view_get_model(view);
+	GtkTreeModel *store_model = gtk_tree_model_filter_get_model(
+		GTK_TREE_MODEL_FILTER(filter_model));
+	GtkTreePath *path = gtk_tree_model_get_path(store_model, iter);
+	GtkTreePath *filter_path = gtk_tree_model_filter_convert_child_path_to_path(
+		GTK_TREE_MODEL_FILTER(filter_model), path);
 
-	gtk_tree_view_expand_to_path(view, path);
+	if (filter_path)
+		gtk_tree_view_expand_to_path(view, filter_path);
+
 	gtk_tree_path_free(path);
+	gtk_tree_path_free(filter_path);
 }
 
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -486,8 +486,8 @@ gboolean utils_utf8_substring_match(const gchar *key, const gchar *haystack)
 	gchar *case_normalized_key = NULL;
 	gboolean matched = TRUE;
 
-	g_return_val_if_fail(key != NULL, FALSE);
-	g_return_val_if_fail(haystack != NULL, FALSE);
+	if (!key || !haystack)
+		return FALSE;
 
 	normalized_string = g_utf8_normalize(haystack, -1, G_NORMALIZE_ALL);
 	normalized_key = g_utf8_normalize(key, -1, G_NORMALIZE_ALL);


### PR DESCRIPTION
The result is a full "3D" tree with parents instead of the flattened tree that was displayed previously when using filtering.

There is a slight functionality difference between the original version and this one. Filtering is performed against visible entries and previously it was done against the full tag name including scope so results can differ. Could be modified if the current version isn't what's expected.