### PR TITLE
Create geany.nsi with Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ foreach dep : deps_in
 endforeach
 
 glib = deps[0]
+gtk = deps[2]
 
 # detect libc
 glibc = false
@@ -187,6 +188,16 @@ configure_file(
 	install_dir: join_paths(prefix, get_option('libdir'), 'pkgconfig'),
 	output: 'geany.pc',
 	configuration: pcconf
+)
+
+configure_file(
+	input: 'geany.nsi.in',
+	install: false,
+	output: 'geany.nsi',
+	configuration: {
+		'VERSION': meson.project_version(),
+		'GTK_VERSION': gtk.version(),
+	}
 )
 
 # CFLAGS for basic stuff that only depends on libc


### PR DESCRIPTION
I noticed that with Meson we do not generate `geany.nsi` from `geany.nsi.in` as we do with Autotools.

This change could fix this.