### PR TITLE
meson: Stop using features deprecated in our base target version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -136,8 +136,8 @@ else
 	cdata.set('GEANY_DATA_DIR', join_paths(prefix, get_option('datadir'), 'geany'))
 	cdata.set('GEANY_DOC_DIR', join_paths(prefix, get_option('datadir'), 'doc', 'geany'))
 endif
-cdata.set('top_srcdir', meson.source_root())
-cdata.set('top_builddir', meson.build_root())
+cdata.set('top_srcdir', meson.project_source_root())
+cdata.set('top_builddir', meson.project_build_root())
 
 # for geany.pc (adapted from GTK+)
 pcconf = cdata
@@ -923,7 +923,7 @@ executable('geany',
 	link_with: libgeany,
 	c_args: geany_cflags + [ '-DG_LOG_DOMAIN="Geany"' ],
 	dependencies: deps,
-	build_rpath: meson.build_root(),
+	build_rpath: meson.project_build_root(),
 	install_rpath: '$ORIGIN/../' + get_option('libdir'),
 	install: true,
 	win_subsystem: 'windows',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -367,8 +367,8 @@ ctags_tests = [
 runner = find_program('ctags/runner.sh')
 foreach t : ctags_tests
 	test(t, runner,
-	     args: [join_paths(meson.build_root(), 'geany'), files(t)],
-	     env: ['top_srcdir='+meson.source_root(), 'top_builddir=' + meson.build_root()])
+	     args: [join_paths(meson.project_build_root(), 'geany'), files(t)],
+	     env: ['top_srcdir='+meson.project_source_root(), 'top_builddir=' + meson.project_build_root()])
 endforeach
 
 process_order_sources = files([
@@ -377,8 +377,8 @@ process_order_sources = files([
 	'ctags/process_order_2.h'
 ])
 test('ctags/processing-order', runner,
-     args: [join_paths(meson.build_root(), 'geany'), '--result', process_order_sources],
-     env: ['top_srcdir='+meson.source_root(), 'top_builddir='+meson.build_root()])
+     args: [join_paths(meson.project_build_root(), 'geany'), '--result', process_order_sources],
+     env: ['top_srcdir='+meson.project_source_root(), 'top_builddir='+meson.project_build_root()])
 test('utils', executable('test_utils', 'test_utils.c', dependencies: test_deps))
 test('sidebar', executable('test_sidebar', 'test_sidebar.c', dependencies: test_deps))
 test('encodings', executable('test_encodings', 'test_encodings.c', dependencies: test_deps))


### PR DESCRIPTION
Stop using features deprecated in Meson 0.56, given we depend on it.