### PR TITLE
Silence spurious undocumented warnings when generating GI

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -739,7 +739,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = @WARN@
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters
@@ -755,7 +755,7 @@ WARN_IF_DOC_ERROR      = YES
 # documentation, but not about the absence of documentation.
 # The default value is: NO.
 
-WARN_NO_PARAMDOC       = YES
+WARN_NO_PARAMDOC       = @WARN@
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -101,6 +101,7 @@ Doxyfile: Doxyfile.in
 		-e 's,$(AT)HTML$(AT),YES,' \
 		-e 's,$(AT)XML$(AT),NO,' \
 		-e 's,$(AT)SORT$(AT),YES,' \
+		-e 's,$(AT)WARN$(AT),YES,' \
 		$< > $@ || ( $(RM) -f $@ ; exit 1 )
 
 doxygen_sources = \
@@ -141,6 +142,7 @@ Doxyfile-gi: Doxyfile.in
 		-e 's,$(AT)HTML$(AT),NO,' \
 		-e 's,$(AT)XML$(AT),YES,' \
 		-e 's,$(AT)SORT$(AT),NO,' \
+		-e 's,$(AT)WARN$(AT),NO,' \
 		$< > $@ || ( $(RM) -f $@ ; exit 1 )
 
 # we depend on Doxyfile.stamp not have this run in parallel with it to avoid

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -88,12 +88,14 @@ if doxygen.found()
 	doxcfg.set('HTML', 'YES')
 	doxcfg.set('XML', 'NO')
 	doxcfg.set('SORT', 'YES')
+	doxcfg.set('WARN', 'YES')
 
 	doxgicfg = doxcfg
 	doxgicfg.set('GIRONLY', '')
 	doxgicfg.set('HTML', 'NO')
 	doxgicfg.set('XML', 'YES')
 	doxgicfg.set('SORT', 'NO')
+	doxgicfg.set('WARN', 'NO')
 
 	dep_doxygen = files([
 		'plugins.dox',


### PR DESCRIPTION
Weirdly enough, if the HTML (or possibly LATEX?) output is not generated, Doxygen incorrectly warns about all parameters and return values not being documented.

Workaround this by disabling undocumented warnings when generating GI which only produces XML, and thus triggers the bug.

See https://stackoverflow.com/a/38745256