### PR TITLE
Add %d %e %p to print_external, align meaning of %f with build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Makefile.in
 /config.status
 /config.sub
 /configure
+/configure~
 /data/filedefs/filetypes.python
 /debian
 /depcomp

--- a/src/printing.c
+++ b/src/printing.c
@@ -581,7 +581,7 @@ void printing_page_setup_gtk(void)
 /* simple file print using an external tool */
 static void print_external(GeanyDocument *doc)
 {
-	gchar *cmdline;
+	gchar *cmdline = NULL;
 
 	if (doc->file_name == NULL)
 		return;
@@ -593,8 +593,8 @@ static void print_external(GeanyDocument *doc)
 		return;
 	}
 
-	cmdline = g_strdup(printing_prefs.external_print_cmd);
-	utils_str_replace_all(&cmdline, "%f", doc->file_name);
+	/* replace d, e, f and p placeholders in cmdline */
+	cmdline = utils_replace_placeholder(doc, printing_prefs.external_print_cmd, "defp");
 
 	if (dialogs_show_question(
 			_("The file \"%s\" will be printed with the following command:\n\n%s"),

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,6 +32,8 @@
 #include <glib.h>
 #include <gdk/gdk.h> /* for GdkColor */
 
+#include "document.h"
+
 G_BEGIN_DECLS
 
 /** Returns @c TRUE if @a ptr is @c NULL or @c *ptr is @c FALSE. */
@@ -339,6 +341,8 @@ gchar *utils_get_os_info_string(void);
 gchar *utils_utf8_strdown(const gchar *str);
 
 gboolean utils_utf8_substring_match(const gchar *key, const gchar *haystack);
+
+gchar *utils_replace_placeholder(const GeanyDocument *doc, const gchar *src, const gchar *needles);
 
 #endif /* GEANY_PRIVATE */
 


### PR DESCRIPTION
Dear Geany-team,

I have **_added functionality_** to `print_external`. More specific, I have included/aligned most of the replacements that are present in the build dialog box:

- replace `%d` with the absolute path
- replace `%e` with the filename (excluding extension)
- replace `%f` with the filename (including extension)
- replace `%p` with the absolute path/filename (including extension)

This would permit to use external print commands like:

`cat "%p" | prt1403 -e -y -u PYNCKELS -j %e -o "%p".pdf -`

which would create an output as shown in the joined file.

During development, I have noticed a file `config~`. I have **_added this name_** to `.gitignore`

I would be much obliged if you could accept this PR.

[hellowrl.f08.pdf](https://github.com/user-attachments/files/18974393/hellowrl.f08.pdf)
