### PR TITLE
Allow pasting and autocompletion for multiple cursors

### DIFF
--- a/src/editor.c
+++ b/src/editor.c
@@ -4965,6 +4965,12 @@ static ScintillaObject *create_new_sci(GeanyEditor *editor)
 	/* input method editor's candidate window behaviour */
 	SSM(sci, SCI_SETIMEINTERACTION, editor_prefs.ime_interaction, 0);
 
+	/* paste to all cursor positions, not just the primary one */
+	SSM(sci, SCI_SETMULTIPASTE, SC_MULTIPASTE_EACH, 0);
+
+	/* perform autocomplete for all cursor positions, not just the primary one */
+	SSM(sci, SCI_AUTOCSETMULTI, SC_MULTIAUTOC_EACH , 0);
+
 	/* only connect signals if this is for the document notebook, not split window */
 	if (editor->sci == NULL)
 	{


### PR DESCRIPTION
Without this, when having a column mode caret, paste only inserts the text into the primary cursor position but not to all of them.

Similarly, without the patch, autocomplete only works for the primary cursor position only.

Fixes #625.

Closes #2328 (which is kind of absurd regarding how much discussion and commits it took to add 2 lines of code, and even when squashed, would  contain extra whitespace)