### PR TITLE
Hiding menubar, one more attempt

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -7596,6 +7596,15 @@
                           </object>
                         </child>
                         <child>
+                          <object class="GtkCheckMenuItem" id="menu_show_menubar1">
+                            <property name="visible">False</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Show Menuba_r</property>
+                            <property name="use-underline">True</property>
+                            <signal name="toggled" handler="on_menu_show_menubar1_toggled" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
                           <object class="GtkSeparatorMenuItem" id="menu_separator5">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>

--- a/data/geany.glade
+++ b/data/geany.glade
@@ -530,6 +530,21 @@
         <signal name="activate" handler="on_context_action1_activate" swapped="no"/>
       </object>
     </child>
+    <child>
+      <object class="GtkSeparatorMenuItem" id="show_menubar_separator1">
+        <property name="visible">False</property>
+        <property name="can-focus">False</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="show_menubar1">
+        <property name="visible">False</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">Show _Menubar</property>
+        <property name="use-underline">True</property>
+        <signal name="activate" handler="on_show_menubar1_activate" swapped="no"/>
+      </object>
+    </child>
   </object>
   <object class="GtkImage" id="image4056">
     <property name="visible">True</property>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3859,7 +3859,11 @@ Action                          Default shortcut          Description
 =============================== ========================= ==================================================
 Fullscreen                      F11  (C)                  Switches to fullscreen mode.
 
-Toggle Menubar                                            Shows or hides the menubar.
+Toggle Menubar                                            Shows or hides the menubar. In addition to the
+                                                          assigned keybinding, the menubar can be shown
+                                                          temporarily using F10 and then shown permanently
+                                                          using the corresponding item from the View menu
+                                                          or the editor context menu.
 
 Toggle Messages Window                                    Shows or hides the message window
                                                           (status and compiler messages).

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3859,8 +3859,10 @@ Action                          Default shortcut          Description
 =============================== ========================= ==================================================
 Fullscreen                      F11  (C)                  Switches to fullscreen mode.
 
-Toggle Messages Window                                    Toggles the message window (status and compiler
-                                                          messages) on and off.
+Toggle Menubar                                            Shows or hides the menubar.
+
+Toggle Messages Window                                    Shows or hides the message window
+                                                          (status and compiler messages).
 
 Toggle Sidebar                                            Shows or hides the sidebar.
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1370,6 +1370,15 @@ void on_menu_show_sidebar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer use
 }
 
 
+void on_menu_show_menubar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data)
+{
+	if (ignore_callback)
+		return;
+
+	ui_menubar_show_hide();
+}
+
+
 void on_show_menubar1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
 	ui_menubar_show_hide();

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1370,6 +1370,12 @@ void on_menu_show_sidebar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer use
 }
 
 
+void on_show_menubar1_activate(GtkMenuItem *menuitem, gpointer user_data)
+{
+	ui_menubar_show_hide();
+}
+
+
 static void on_menu_write_unicode_bom1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data)
 {
 	if (! ignore_callback)

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -1375,13 +1375,13 @@ void on_menu_show_menubar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer use
 	if (ignore_callback)
 		return;
 
-	ui_menubar_show_hide();
+	ui_menubar_show_hide(!ui_prefs.menubar_visible);
 }
 
 
 void on_show_menubar1_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	ui_menubar_show_hide();
+	ui_menubar_show_hide(!ui_prefs.menubar_visible);
 }
 
 

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -136,6 +136,8 @@ void on_menu_select_all1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_menu_show_sidebar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data);
 
+void on_show_menubar1_activate(GtkMenuItem *menuitem, gpointer user_data);
+
 void on_menu_comment_line1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_menu_uncomment_line1_activate(GtkMenuItem *menuitem, gpointer user_data);

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -136,6 +136,8 @@ void on_menu_select_all1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_menu_show_sidebar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data);
 
+void on_menu_show_menubar1_toggled(GtkCheckMenuItem *checkmenuitem, gpointer user_data);
+
 void on_show_menubar1_activate(GtkMenuItem *menuitem, gpointer user_data);
 
 void on_menu_comment_line1_activate(GtkMenuItem *menuitem, gpointer user_data);

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -606,6 +606,8 @@ static void init_default_kb(void)
 		"menu_toggle_all_additional_widgets1");
 	add_kb(group, GEANY_KEYS_VIEW_FULLSCREEN, cb_func_menu_fullscreen,
 		GDK_KEY_F11, 0, "menu_fullscreen", _("Fullscreen"), "menu_fullscreen1");
+	add_kb(group, GEANY_KEYS_TOGGLE_MENUBAR, NULL,
+		0, 0, "toggle_menubar", _("Toggle Menubar"), NULL);
 	add_kb(group, GEANY_KEYS_VIEW_MESSAGEWINDOW, cb_func_menu_messagewindow,
 		0, 0, "menu_messagewindow", _("Toggle Messages Window"),
 		"menu_show_messages_window1");
@@ -1637,6 +1639,27 @@ static gboolean cb_func_view_action(guint key_id)
 			break;
 		case GEANY_KEYS_VIEW_ZOOMRESET:
 			on_normal_size1_activate(NULL, NULL);
+			break;
+		case GEANY_KEYS_TOGGLE_MENUBAR:
+		{
+			GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
+			if (gtk_widget_is_visible(geany_menubar))
+			{
+				GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
+				GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
+				if (kb->key != 0)
+				{
+					gtk_widget_hide(geany_menubar);
+					gchar *val = gtk_accelerator_name(kb->key, kb->mods);
+					msgwin_status_add("Menubar has been hidden.  To reshow it, use: %s", val);
+					g_free(val);
+				}
+				else
+					msgwin_status_add("Menubar will not be hidden until after a keybinding to reshow it has been set.");
+			}
+			else
+				gtk_widget_show(geany_menubar);
+		}
 			break;
 		default:
 			break;

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1630,17 +1630,41 @@ static void on_toggle_menubar(GtkMenuItem *menuitem, gpointer user_data)
 	{
 		GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
 		GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
+
 		if (kb->key != 0)
 		{
 			gchar *val = gtk_accelerator_name(kb->key, kb->mods);
+			GtkWidget *item;
+
 			gtk_widget_hide(geany_menubar);
 			show = FALSE;
-			msgwin_status_add(_("Menubar has been hidden. To reshow it, use: %s"), val);
+
+			item = gtk_separator_menu_item_new();
+			gtk_container_add(GTK_CONTAINER(main_widgets.editor_menu), item);
+			gtk_widget_show(item);
+			ui_hookup_widget(main_widgets.editor_menu, item, "context_menu_menubar_item_separator");
+
+			item = gtk_menu_item_new_with_mnemonic(_("Show _Menubar"));
+			gtk_container_add(GTK_CONTAINER(main_widgets.editor_menu), item);
+			gtk_widget_show(item);
+			g_signal_connect(item, "activate", G_CALLBACK(on_toggle_menubar), NULL);
+			ui_hookup_widget(main_widgets.editor_menu, item, "context_menu_menubar_item");
+
+			msgwin_status_add(_("Menubar has been hidden. To reshow it, press %s or use the Show Menubar item from the context menu."), val);
 			g_free(val);
 		}
 	}
 	else
+	{
+		GtkWidget *item;
+
+		item = ui_lookup_widget(main_widgets.editor_menu, "context_menu_menubar_item_separator");
+		gtk_widget_destroy(item);
+		item = ui_lookup_widget(main_widgets.editor_menu, "context_menu_menubar_item");
+		gtk_widget_destroy(item);
+
 		gtk_widget_show(geany_menubar);
+	}
 
 	ui_prefs.menubar_visible = show;
 }

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1621,6 +1621,31 @@ static void cb_func_menu_opencolorchooser(G_GNUC_UNUSED guint key_id)
 }
 
 
+static void on_toggle_menubar(GtkMenuItem *menuitem, gpointer user_data)
+{
+	GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
+	gboolean show = TRUE;
+
+	if (gtk_widget_is_visible(geany_menubar))
+	{
+		GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
+		GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
+		if (kb->key != 0)
+		{
+			gchar *val = gtk_accelerator_name(kb->key, kb->mods);
+			gtk_widget_hide(geany_menubar);
+			show = FALSE;
+			msgwin_status_add(_("Menubar has been hidden. To reshow it, use: %s"), val);
+			g_free(val);
+		}
+	}
+	else
+		gtk_widget_show(geany_menubar);
+
+	ui_prefs.menubar_visible = show;
+}
+
+
 static gboolean cb_func_view_action(guint key_id)
 {
 	switch (key_id)
@@ -1641,29 +1666,8 @@ static gboolean cb_func_view_action(guint key_id)
 			on_normal_size1_activate(NULL, NULL);
 			break;
 		case GEANY_KEYS_TOGGLE_MENUBAR:
-		{
-			GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
-			gboolean show = TRUE;
-
-			if (gtk_widget_is_visible(geany_menubar))
-			{
-				GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
-				GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
-				if (kb->key != 0)
-				{
-					gchar *val = gtk_accelerator_name(kb->key, kb->mods);
-					gtk_widget_hide(geany_menubar);
-					show = FALSE;
-					msgwin_status_add(_("Menubar has been hidden. To reshow it, use: %s"), val);
-					g_free(val);
-				}
-			}
-			else
-				gtk_widget_show(geany_menubar);
-
-			ui_prefs.menubar_visible = show;
+			on_toggle_menubar(NULL, NULL);
 			break;
-		}
 		default:
 			break;
 	}

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1643,24 +1643,27 @@ static gboolean cb_func_view_action(guint key_id)
 		case GEANY_KEYS_TOGGLE_MENUBAR:
 		{
 			GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
+			gboolean show = TRUE;
+
 			if (gtk_widget_is_visible(geany_menubar))
 			{
 				GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
 				GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
 				if (kb->key != 0)
 				{
-					gtk_widget_hide(geany_menubar);
 					gchar *val = gtk_accelerator_name(kb->key, kb->mods);
-					msgwin_status_add("Menubar has been hidden.  To reshow it, use: %s", val);
+					gtk_widget_hide(geany_menubar);
+					show = FALSE;
+					msgwin_status_add(_("Menubar has been hidden. To reshow it, use: %s"), val);
 					g_free(val);
 				}
-				else
-					msgwin_status_add("Menubar will not be hidden until after a keybinding to reshow it has been set.");
 			}
 			else
 				gtk_widget_show(geany_menubar);
-		}
+
+			ui_prefs.menubar_visible = show;
 			break;
+		}
 		default:
 			break;
 	}

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1646,7 +1646,7 @@ static void on_menubar_deactivate(GtkMenuShell *shell, gpointer data)
 
 static void on_toggle_menubar(GtkMenuItem *menuitem, gpointer user_data)
 {
-	ui_menubar_show_hide();
+	ui_menubar_show_hide(!ui_prefs.menubar_visible);
 }
 
 

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -609,7 +609,7 @@ static void init_default_kb(void)
 	add_kb(group, GEANY_KEYS_VIEW_FULLSCREEN, cb_func_menu_fullscreen,
 		GDK_KEY_F11, 0, "menu_fullscreen", _("Fullscreen"), "menu_fullscreen1");
 	add_kb(group, GEANY_KEYS_TOGGLE_MENUBAR, NULL,
-		0, 0, "toggle_menubar", _("Toggle Menubar"), NULL);
+		0, 0, "toggle_menubar", _("Toggle Menubar"), "menu_show_menubar1");
 	add_kb(group, GEANY_KEYS_VIEW_MESSAGEWINDOW, cb_func_menu_messagewindow,
 		0, 0, "menu_messagewindow", _("Toggle Messages Window"),
 		"menu_show_messages_window1");

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1646,50 +1646,7 @@ static void on_menubar_deactivate(GtkMenuShell *shell, gpointer data)
 
 static void on_toggle_menubar(GtkMenuItem *menuitem, gpointer user_data)
 {
-	GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
-	gboolean show = TRUE;
-
-	if (gtk_widget_is_visible(geany_menubar))
-	{
-		GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
-		GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
-
-		if (kb->key != 0)
-		{
-			gchar *val = gtk_accelerator_name(kb->key, kb->mods);
-			GtkWidget *item;
-
-			gtk_widget_hide(geany_menubar);
-			show = FALSE;
-
-			item = gtk_separator_menu_item_new();
-			gtk_container_add(GTK_CONTAINER(main_widgets.editor_menu), item);
-			gtk_widget_show(item);
-			ui_hookup_widget(main_widgets.editor_menu, item, "context_menu_menubar_item_separator");
-
-			item = gtk_menu_item_new_with_mnemonic(_("Show _Menubar"));
-			gtk_container_add(GTK_CONTAINER(main_widgets.editor_menu), item);
-			gtk_widget_show(item);
-			g_signal_connect(item, "activate", G_CALLBACK(on_toggle_menubar), NULL);
-			ui_hookup_widget(main_widgets.editor_menu, item, "context_menu_menubar_item");
-
-			msgwin_status_add(_("Menubar has been hidden. To reshow it, press %s or use the Show Menubar item from the context menu."), val);
-			g_free(val);
-		}
-	}
-	else
-	{
-		GtkWidget *item;
-
-		item = ui_lookup_widget(main_widgets.editor_menu, "context_menu_menubar_item_separator");
-		gtk_widget_destroy(item);
-		item = ui_lookup_widget(main_widgets.editor_menu, "context_menu_menubar_item");
-		gtk_widget_destroy(item);
-
-		gtk_widget_show(geany_menubar);
-	}
-
-	ui_prefs.menubar_visible = show;
+	ui_menubar_show_hide();
 }
 
 

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -280,7 +280,7 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_PROJECT_NEW_FROM_FOLDER,			/**< Keybinding.
 												 * @since 2.0 (API 243) */
 	GEANY_KEYS_TOGGLE_MENUBAR,					/**< Keybinding.
-												 * @since 2.1 (API TODO) */
+												 * @since 2.2 (API 251) */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -279,6 +279,8 @@ enum GeanyKeyBindingID
 												 * @since 1.38 (API 240) */
 	GEANY_KEYS_PROJECT_NEW_FROM_FOLDER,			/**< Keybinding.
 												 * @since 2.0 (API 243) */
+	GEANY_KEYS_TOGGLE_MENUBAR,					/**< Keybinding.
+												 * @since 1.39 (API 241) */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -280,7 +280,7 @@ enum GeanyKeyBindingID
 	GEANY_KEYS_PROJECT_NEW_FROM_FOLDER,			/**< Keybinding.
 												 * @since 2.0 (API 243) */
 	GEANY_KEYS_TOGGLE_MENUBAR,					/**< Keybinding.
-												 * @since 1.39 (API 241) */
+												 * @since 2.1 (API TODO) */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -671,6 +671,13 @@ static void save_ui_prefs(GKeyFile *config)
 	g_key_file_set_boolean(config, PACKAGE, "symbols_group_by_type", ui_prefs.symbols_group_by_type);
 	g_key_file_set_string(config, PACKAGE, "color_picker_palette", ui_prefs.color_picker_palette);
 
+	/* Update and save current menubar state */
+	{
+		GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
+		ui_prefs.menubar_visible = gtk_widget_is_visible(geany_menubar);
+		g_key_file_set_boolean(config, PACKAGE, "menubar_visible", ui_prefs.menubar_visible);
+	}
+
 	/* get the text from the scribble textview */
 	{
 		GtkTextBuffer *buffer;
@@ -1098,6 +1105,7 @@ static void load_dialog_prefs(GKeyFile *config)
 
 static void load_ui_prefs(GKeyFile *config)
 {
+	ui_prefs.menubar_visible = utils_get_setting_boolean(config, PACKAGE, "menubar_visible", TRUE);
 	ui_prefs.sidebar_visible = utils_get_setting_boolean(config, PACKAGE, "sidebar_visible", TRUE);
 	ui_prefs.msgwindow_visible = utils_get_setting_boolean(config, PACKAGE, "msgwindow_visible", TRUE);
 	ui_prefs.fullscreen = utils_get_setting_boolean(config, PACKAGE, "fullscreen", FALSE);

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -40,6 +40,7 @@
 #include "encodingsprivate.h"
 #include "filetypes.h"
 #include "geanyobject.h"
+#include "keybindings.h"
 #include "main.h"
 #include "msgwindow.h"
 #include "prefs.h"
@@ -664,19 +665,13 @@ static void save_dialog_prefs(GKeyFile *config)
 
 static void save_ui_prefs(GKeyFile *config)
 {
+	g_key_file_set_boolean(config, PACKAGE, "menubar_visible", ui_prefs.menubar_visible);
 	g_key_file_set_boolean(config, PACKAGE, "sidebar_visible", ui_prefs.sidebar_visible);
 	g_key_file_set_boolean(config, PACKAGE, "statusbar_visible", interface_prefs.statusbar_visible);
 	g_key_file_set_boolean(config, PACKAGE, "msgwindow_visible", ui_prefs.msgwindow_visible);
 	g_key_file_set_boolean(config, PACKAGE, "fullscreen", ui_prefs.fullscreen);
 	g_key_file_set_boolean(config, PACKAGE, "symbols_group_by_type", ui_prefs.symbols_group_by_type);
 	g_key_file_set_string(config, PACKAGE, "color_picker_palette", ui_prefs.color_picker_palette);
-
-	/* Update and save current menubar state */
-	{
-		GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
-		ui_prefs.menubar_visible = gtk_widget_is_visible(geany_menubar);
-		g_key_file_set_boolean(config, PACKAGE, "menubar_visible", ui_prefs.menubar_visible);
-	}
 
 	/* get the text from the scribble textview */
 	{
@@ -1445,6 +1440,10 @@ void configuration_apply_settings(void)
 		ui_prefs.fullscreen = TRUE;
 		ui_set_fullscreen();
 	}
+
+	/* restore menubar state or hide on startup */
+	if (!ui_prefs.menubar_visible)
+		keybindings_send_command(GEANY_KEY_GROUP_VIEW, GEANY_KEYS_TOGGLE_MENUBAR);
 
 	msgwin_show_hide_tabs();
 }

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -1443,7 +1443,7 @@ void configuration_apply_settings(void)
 
 	/* restore menubar state or hide on startup */
 	if (!ui_prefs.menubar_visible)
-		ui_menubar_show_hide();
+		ui_menubar_show_hide(FALSE);
 
 	msgwin_show_hide_tabs();
 }

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -1443,7 +1443,7 @@ void configuration_apply_settings(void)
 
 	/* restore menubar state or hide on startup */
 	if (!ui_prefs.menubar_visible)
-		keybindings_send_command(GEANY_KEY_GROUP_VIEW, GEANY_KEYS_TOGGLE_MENUBAR);
+		ui_menubar_show_hide();
 
 	msgwin_show_hide_tabs();
 }

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1251,10 +1251,6 @@ gint main_lib(gint argc, gchar **argv)
 	gtk_widget_show(main_widgets.window);
 	main_status.main_window_realized = TRUE;
 
-	/* restore menubar state or hide on startup */
-	if (!ui_prefs.menubar_visible || interface_prefs.on_startup_hide_menubar)
-		keybindings_send_command(GEANY_KEY_GROUP_VIEW, GEANY_KEYS_TOGGLE_MENUBAR);
-
 	configuration_apply_settings();
 
 #ifdef HAVE_SOCKET

--- a/src/libmain.c
+++ b/src/libmain.c
@@ -1251,6 +1251,10 @@ gint main_lib(gint argc, gchar **argv)
 	gtk_widget_show(main_widgets.window);
 	main_status.main_window_realized = TRUE;
 
+	/* restore menubar state or hide on startup */
+	if (!ui_prefs.menubar_visible || interface_prefs.on_startup_hide_menubar)
+		keybindings_send_command(GEANY_KEY_GROUP_VIEW, GEANY_KEYS_TOGGLE_MENUBAR);
+
 	configuration_apply_settings();
 
 #ifdef HAVE_SOCKET

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -57,7 +57,7 @@ G_BEGIN_DECLS
  * @warning You should not test for values below 200 as previously
  * @c GEANY_API_VERSION was defined as an enum value, not a macro.
  */
-#define GEANY_API_VERSION 250
+#define GEANY_API_VERSION 251
 
 /* hack to have a different ABI when built with different GTK major versions
  * because loading plugins linked to a different one leads to crashes.

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2389,6 +2389,8 @@ void ui_init_prefs(void)
 		"warn_on_project_close", TRUE);
 	stash_group_add_spin_button_integer(group, &interface_prefs.tab_label_len,
 		"tab_label_length", 1000, "spin_tab_label_len");
+	stash_group_add_boolean(group, &interface_prefs.on_startup_hide_menubar,
+		"on_startup_hide_menubar", FALSE);
 }
 
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1022,6 +1022,36 @@ void ui_sidebar_show_hide(void)
 }
 
 
+void ui_menubar_show_hide(void)
+{
+	GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
+	GtkWidget *editor_separator_item = ui_lookup_widget(main_widgets.editor_menu, "show_menubar_separator1");
+	GtkWidget *editor_show_menubar_item = ui_lookup_widget(main_widgets.editor_menu, "show_menubar1");
+	GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
+	GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
+	gboolean show = TRUE;
+
+	if (gtk_widget_is_visible(geany_menubar))
+	{
+		if (kb->key != 0)
+		{
+			gchar *val = gtk_accelerator_name(kb->key, kb->mods);
+
+			msgwin_status_add(_("Menubar has been hidden. To reshow it, press %s or use the Show Menubar item from the context menu."), val);
+			g_free(val);
+
+			show = FALSE;
+		}
+	}
+
+	ui_prefs.menubar_visible = show;
+
+	gtk_widget_set_visible(geany_menubar, show);
+	gtk_widget_set_visible(editor_separator_item, !show);
+	gtk_widget_set_visible(editor_show_menubar_item, !show);
+}
+
+
 void ui_document_show_hide(GeanyDocument *doc)
 {
 	const gchar *widget_name;

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1022,7 +1022,7 @@ void ui_sidebar_show_hide(void)
 }
 
 
-void ui_menubar_show_hide(void)
+void ui_menubar_show_hide(gboolean show)
 {
 	GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
 	GtkWidget *menu_item = ui_lookup_widget(main_widgets.window, "menu_show_menubar1");
@@ -1030,19 +1030,15 @@ void ui_menubar_show_hide(void)
 	GtkWidget *editor_show_menubar_item = ui_lookup_widget(main_widgets.editor_menu, "show_menubar1");
 	GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
 	GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
-	gboolean show = TRUE;
 
-	if (gtk_widget_is_visible(geany_menubar))
+	if (!show && kb->key == 0)
+		return;  /* don't allow hiding menubar when no keybinding set */
+
+	if (!show)
 	{
-		if (kb->key != 0)
-		{
-			gchar *val = gtk_accelerator_name(kb->key, kb->mods);
-
-			msgwin_status_add(_("Menubar has been hidden. To reshow it, press %s or use the Show Menubar item from the context menu."), val);
-			g_free(val);
-
-			show = FALSE;
-		}
+		gchar *val = gtk_accelerator_name(kb->key, kb->mods);
+		msgwin_status_add(_("Menubar has been hidden. To reshow it, press %s or use the Show Menubar item from the context menu."), val);
+		g_free(val);
 	}
 
 	ui_prefs.menubar_visible = show;

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1025,6 +1025,7 @@ void ui_sidebar_show_hide(void)
 void ui_menubar_show_hide(void)
 {
 	GtkWidget *geany_menubar = ui_lookup_widget(main_widgets.window, "hbox_menubar");
+	GtkWidget *menu_item = ui_lookup_widget(main_widgets.window, "menu_show_menubar1");
 	GtkWidget *editor_separator_item = ui_lookup_widget(main_widgets.editor_menu, "show_menubar_separator1");
 	GtkWidget *editor_show_menubar_item = ui_lookup_widget(main_widgets.editor_menu, "show_menubar1");
 	GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
@@ -1046,7 +1047,12 @@ void ui_menubar_show_hide(void)
 
 	ui_prefs.menubar_visible = show;
 
+	ignore_callback = TRUE;
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menu_item), show);
+	ignore_callback = FALSE;
+
 	gtk_widget_set_visible(geany_menubar, show);
+	gtk_widget_set_visible(menu_item, !show);
 	gtk_widget_set_visible(editor_separator_item, !show);
 	gtk_widget_set_visible(editor_show_menubar_item, !show);
 }

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -2389,8 +2389,6 @@ void ui_init_prefs(void)
 		"warn_on_project_close", TRUE);
 	stash_group_add_spin_button_integer(group, &interface_prefs.tab_label_len,
 		"tab_label_length", 1000, "spin_tab_label_len");
-	stash_group_add_boolean(group, &interface_prefs.on_startup_hide_menubar,
-		"on_startup_hide_menubar", FALSE);
 }
 
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -74,6 +74,7 @@ typedef struct GeanyInterfacePrefs
 	gint			openfiles_path_mode;
 	/** number of characters of a filename to be visible on the tab label */
 	gint			tab_label_len;
+	gboolean		on_startup_hide_menubar;	/**< hide menubar on startup */
 }
 GeanyInterfacePrefs;
 
@@ -167,6 +168,7 @@ typedef struct UIPrefs
 	gboolean	sidebar_visible;
 	gint		sidebar_page;
 	gboolean	msgwindow_visible;
+	gboolean	menubar_visible;
 	gboolean	allow_always_save; /* if set, files can always be saved, even if unchanged */
 	gchar		*statusbar_template;
 	gboolean	new_document_after_close;

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -327,6 +327,8 @@ void ui_document_buttons_update(void);
 
 void ui_sidebar_show_hide(void);
 
+void ui_menubar_show_hide(void);
+
 void ui_document_show_hide(GeanyDocument *doc);
 
 void ui_set_search_entry_background(GtkWidget *widget, gboolean success);

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -327,7 +327,7 @@ void ui_document_buttons_update(void);
 
 void ui_sidebar_show_hide(void);
 
-void ui_menubar_show_hide(void);
+void ui_menubar_show_hide(gboolean show);
 
 void ui_document_show_hide(GeanyDocument *doc);
 

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -74,7 +74,6 @@ typedef struct GeanyInterfacePrefs
 	gint			openfiles_path_mode;
 	/** number of characters of a filename to be visible on the tab label */
 	gint			tab_label_len;
-	gboolean		on_startup_hide_menubar;	/**< hide menubar on startup */
 }
 GeanyInterfacePrefs;
 


### PR DESCRIPTION
Hiding menubar seems to be one of the more requested features (#633, https://github.com/geany/geany-plugins/issues/1380) and there are various PRs (#2972, https://github.com/geany/geany-plugins/pull/1138, plus I believe some geany-lua script) trying to implement it.

I think the feature makes sense (other editors offer features like "distraction-free" mode where all other widgets are hidden except the editing area), the only dangerous thing is that people might hide the menubar and won't be able to recover it back because they forgot the keybinding.

I based the patch on @xiota's implementation from #2972 (thanks!) with some modifications/additions:

1. I removed the configurability part of the patch - i.e. whether hiding the menubar is remembered on Geany restart or not. I understand this is a precaution against having the menubar "lost forever", on the other hand I don't like having a config option for every single small feature - these then start adding up and the result is that everyone gets lost in what's configurable and what not.
2. Instead, I added one more way to "recover" the menu bar - using the context menu. This may be the only UI element left if users hide all other widgets. The "Show menubar" item only appears when the  menubar is hidden; when shown, it's removed from the context menu so it doesn't occupy context menu space for people not using this feature.