### PR TITLE
Backport ctags patches related to offset calculation

### DIFF
--- a/ctags/main/entry.c
+++ b/ctags/main/entry.c
@@ -932,7 +932,7 @@ static int   makePatternStringCommon (const tagEntryInfo *const tag,
 	}
 
 	length += putc_func(searchChar, output);
-	if ((tag->boundaryInfo & INPUT_BOUNDARY_START) == 0)
+	if ((tag->boundaryInfo & AREA_BOUNDARY_START) == 0)
 		length += putc_func('^', output);
 	length += appendInputLine (putc_func, line, Option.patternLengthLimit,
 							   output, &omitted);
@@ -1632,7 +1632,7 @@ extern void updateTagLine (tagEntryInfo *tag, unsigned long lineNumber,
 
 	tag->lineNumber = lineNumber;
 	tag->filePosition = filePosition;
-	tag->boundaryInfo = getNestedInputBoundaryInfo (lineNumber);
+	tag->boundaryInfo = getAreaBoundaryInfo (lineNumber);
 
 	if (entry && tag->lineNumber < tag->extensionFields._endLine)
 	{
@@ -2037,7 +2037,7 @@ static void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 	memset (e, 0, sizeof (tagEntryInfo));
 	e->lineNumberEntry = (bool) (Option.locate == EX_LINENUM);
 	e->lineNumber      = lineNumber;
-	e->boundaryInfo    = getNestedInputBoundaryInfo (lineNumber);
+	e->boundaryInfo    = getAreaBoundaryInfo (lineNumber);
 	e->langType        = langType_;
 	e->filePosition    = filePosition;
 	e->inputFileName   = inputFileName;

--- a/ctags/main/entry.c
+++ b/ctags/main/entry.c
@@ -2057,7 +2057,7 @@ static void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 
 	e->extensionFields.nth = NO_NTH_FIELD;
 
-	if (doesParserRunAsGuest ())
+	if (isAreaStacked ())
 		markTagExtraBit (e, XTAG_GUEST);
 	if (doesSubparserRun ())
 		markTagExtraBit (e, XTAG_SUBPARSER);

--- a/ctags/main/entry.h
+++ b/ctags/main/entry.h
@@ -74,7 +74,7 @@ struct sTagEntryInfo {
 											* Set in the cork queue; don't touch this.*/
 	unsigned int isSourceFileNameShared: 1; /* shares the value for sourceFileName.
 											 * Set in the cork queue; don't touch this.*/
-	unsigned int boundaryInfo: 2; /* info about nested input stream */
+	unsigned int boundaryInfo: 2; /* info about the stacked input area */
 	unsigned int inIntevalTab:1;
 
 	unsigned long lineNumber;     /* line number of tag;

--- a/ctags/main/lxpath.c
+++ b/ctags/main/lxpath.c
@@ -26,8 +26,10 @@
 
 extern  void updateXMLTagLine (tagEntryInfo *e, xmlNode *node)
 {
-	unsigned long lineNumber = XML_GET_LINE (node);
-	updateTagLine (e, lineNumber, getInputFilePositionForLine (lineNumber));
+	unsigned long abs_line = translateLineNumber (XML_GET_LINE (node));
+	MIOPos rela_pos = getInputFilePositionForLine (abs_line);
+
+	updateTagLine (e, abs_line, rela_pos);
 }
 
 static void simpleXpathMakeTag (xmlNode *node,

--- a/ctags/main/mio.c
+++ b/ctags/main/mio.c
@@ -1261,6 +1261,8 @@ int mio_getpos (MIO *mio, MIOPos *pos)
 {
 	int rv = -1;
 
+	memset (pos, 0, sizeof (*pos));
+
 	pos->type = mio->type;
 	if (mio->type == MIO_TYPE_FILE)
 		rv = fgetpos (mio->impl.file.fp, &pos->impl.file);

--- a/ctags/main/parse.c
+++ b/ctags/main/parse.c
@@ -4224,15 +4224,15 @@ static bool createTagsWithFallback1 (const langType language,
 	return tagFileResized;
 }
 
-extern bool runParserInNarrowedInputStream (const langType language,
-					       unsigned long startLine, long startCharOffset,
-					       unsigned long endLine, long endCharOffset,
-					       unsigned long sourceLineOffset,
-					       int promise)
+extern bool runParserInArea (const langType language,
+							 unsigned long startLine, long startCharOffset,
+							 unsigned long endLine, long endCharOffset,
+							 unsigned long sourceLineOffset,
+							 int promise)
 {
 	bool tagFileResized;
 
-	verbose ("runParserInNarrowedInputStream: %s; "
+	verbose ("runParserInArea: %s; "
 			 "file: %s, "
 			 "start(line: %lu, offset: %ld, srcline: %lu)"
 			 " - "
@@ -4242,14 +4242,13 @@ extern bool runParserInNarrowedInputStream (const langType language,
 			 startLine, startCharOffset, sourceLineOffset,
 			 endLine, endCharOffset);
 
-	pushNarrowedInputStream (
-				 doesParserRequireMemoryStream (language),
-				 startLine, startCharOffset,
-				 endLine, endCharOffset,
-				 sourceLineOffset,
-				 promise);
+	pushArea (doesParserRequireMemoryStream (language),
+			  startLine, startCharOffset,
+			  endLine, endCharOffset,
+			  sourceLineOffset,
+			  promise);
 	tagFileResized = createTagsWithFallback1 (language, NULL);
-	popNarrowedInputStream  ();
+	popArea  ();
 	return tagFileResized;
 
 }
@@ -5243,7 +5242,7 @@ extern void scheduleRunningBaseparser (int dependencyIndex)
 	}
 
 
-	makePromise(base_name, THIN_STREAM_SPEC);
+	makePromise(base_name, THIN_AREA_SPEC);
 }
 
 extern bool isParserMarkedNoEmission (void)

--- a/ctags/main/parse.c
+++ b/ctags/main/parse.c
@@ -4043,7 +4043,7 @@ static rescanReason createTagsForFile (const langType language,
 	parserDefinition *const lang = LanguageTable [language].def;
 	rescanReason rescan = RESCAN_NONE;
 
-	resetInputFile (language, passCount > 1);
+	resetInputFile (language, passCount > 1 && !isAreaStacked ());
 
 	Assert (lang->parser || lang->parser2);
 

--- a/ctags/main/parse_p.h
+++ b/ctags/main/parse_p.h
@@ -128,11 +128,11 @@ extern bool parseFileWithMio (const char *const fileName, MIO *mio, void *client
 extern bool parseRawBuffer(const char *fileName, unsigned char *buffer,
 			    size_t bufferSize, const langType language, void *clientData);
 
-extern bool runParserInNarrowedInputStream (const langType language,
-					       unsigned long startLine, long startCharOffset,
-					       unsigned long endLine, long endCharOffset,
-					       unsigned long sourceLineOffset,
-					       int promise);
+extern bool runParserInArea (const langType language,
+							 unsigned long startLine, long startCharOffset,
+							 unsigned long endLine, long endCharOffset,
+							 unsigned long sourceLineOffset,
+							 int promise);
 
 #ifdef HAVE_ICONV
 extern void freeEncodingResources (void);

--- a/ctags/main/promise.c
+++ b/ctags/main/promise.c
@@ -28,9 +28,9 @@
 struct promise {
 	langType lang;
 	unsigned long startLine;
-	long startCharOffset;
+	long startColumn;
 	unsigned long endLine;
-	long endCharOffset;
+	long endColumn;
 	unsigned long sourceLineOffset;
 	int parent_promise;
 	ptrArray *modifiers;
@@ -38,8 +38,8 @@ struct promise {
 
 typedef void ( *promiseInputModifier) (unsigned char * input,
 									   size_t size,
-									   unsigned long startLine, long startCharOffset,
-									   unsigned long endLine, long endCharOffset,
+									   unsigned long startLine, long startColumn,
+									   unsigned long endLine, long endColumn,
 									   void *data);
 typedef void ( *promiseDestroyAttachedData) (void *data);
 
@@ -63,8 +63,8 @@ static void attachPromiseModifier (int promise,
 
 
 int  makePromise   (const char *parser,
-		    unsigned long startLine, long startCharOffset,
-		    unsigned long endLine, long endCharOffset,
+		    unsigned long startLine, long startColumn,
+		    unsigned long endLine, long endColumn,
 		    unsigned long sourceLineOffset)
 {
 	struct promise *p;
@@ -72,18 +72,18 @@ int  makePromise   (const char *parser,
 	langType lang = LANG_IGNORE;
 
 	const bool is_thin_area_spec =
-		isThinAreaSpec(startLine, startCharOffset,
-					   endLine, endCharOffset,
+		isThinAreaSpec(startLine, startColumn,
+					   endLine, endColumn,
 					   sourceLineOffset);
 
 	if (!is_thin_area_spec
 		&& (startLine > endLine
-			|| (startLine == endLine && startCharOffset >= endCharOffset)))
+			|| (startLine == endLine && startColumn >= endColumn)))
 		return -1;
 
 	verbose("makePromise: %s start(line: %lu, offset: %ld, srcline: %lu), end(line: %lu, offset: %ld)\n",
-			parser? parser: "*", startLine, startCharOffset, sourceLineOffset,
-			endLine, endCharOffset);
+			parser? parser: "*", startLine, startColumn, sourceLineOffset,
+			endLine, endColumn);
 
 	if ((!is_thin_area_spec)
 		&& ( !isXtagEnabled (XTAG_GUEST)))
@@ -110,9 +110,9 @@ int  makePromise   (const char *parser,
 	p->parent_promise = current_promise;
 	p->lang = lang;
 	p->startLine = startLine;
-	p->startCharOffset = startCharOffset;
+	p->startColumn = startColumn;
 	p->endLine = endLine;
-	p->endCharOffset = endCharOffset;
+	p->endColumn = endColumn;
 	p->sourceLineOffset = sourceLineOffset;
 	p->modifiers = NULL;
 
@@ -182,9 +182,9 @@ bool forcePromises (void)
 		if (p->lang != LANG_IGNORE && isLanguageEnabled (p->lang))
 			tagFileResized = runParserInArea (p->lang,
 											  p->startLine,
-											  p->startCharOffset,
+											  p->startColumn,
 											  p->endLine,
-											  p->endCharOffset,
+											  p->endColumn,
 											  p->sourceLineOffset,
 											  i)
 				? true
@@ -228,8 +228,8 @@ static unsigned char* fill_or_skip (unsigned char *input, const unsigned char *c
 }
 
 static void line_filler (unsigned char *input, size_t const size,
-						 unsigned long const startLine, long const startCharOffset,
-						 unsigned long const endLine, long const endCharOffset,
+						 unsigned long const startLine, long const startColumn,
+						 unsigned long const endLine, long const endColumn,
 						 void *data)
 {
 	const ulongArray *lines = data;
@@ -310,8 +310,8 @@ static void collectModifiers(int promise, ptrArray *modifiers)
 }
 
 void runModifiers (int promise,
-				   unsigned long startLine, long startCharOffset,
-				   unsigned long endLine, long endCharOffset,
+				   unsigned long startLine, long startColumn,
+				   unsigned long endLine, long endColumn,
 				   unsigned char *input,
 				   size_t size)
 {
@@ -322,8 +322,8 @@ void runModifiers (int promise,
 	{
 		struct modifier *m = ptrArrayItem (modifiers, i - 1);
 		m->modifier (input, size,
-					 startLine, startCharOffset,
-					 endLine, endCharOffset,
+					 startLine, startColumn,
+					 endLine, endColumn,
 					 m->data);
 	}
 	ptrArrayDelete (modifiers);

--- a/ctags/main/promise.c
+++ b/ctags/main/promise.c
@@ -71,12 +71,12 @@ int  makePromise   (const char *parser,
 	int r;
 	langType lang = LANG_IGNORE;
 
-	const bool is_thin_stream_spec =
-		isThinStreamSpec(startLine, startCharOffset,
-						 endLine, endCharOffset,
-						 sourceLineOffset);
+	const bool is_thin_area_spec =
+		isThinAreaSpec(startLine, startCharOffset,
+					   endLine, endCharOffset,
+					   sourceLineOffset);
 
-	if (!is_thin_stream_spec
+	if (!is_thin_area_spec
 		&& (startLine > endLine
 			|| (startLine == endLine && startCharOffset >= endCharOffset)))
 		return -1;
@@ -85,7 +85,7 @@ int  makePromise   (const char *parser,
 			parser? parser: "*", startLine, startCharOffset, sourceLineOffset,
 			endLine, endCharOffset);
 
-	if ((!is_thin_stream_spec)
+	if ((!is_thin_area_spec)
 		&& ( !isXtagEnabled (XTAG_GUEST)))
 		return -1;
 
@@ -180,13 +180,13 @@ bool forcePromises (void)
 		struct promise *p = promises + i;
 
 		if (p->lang != LANG_IGNORE && isLanguageEnabled (p->lang))
-			tagFileResized = runParserInNarrowedInputStream (p->lang,
-															 p->startLine,
-															 p->startCharOffset,
-															 p->endLine,
-															 p->endCharOffset,
-															 p->sourceLineOffset,
-															 i)
+			tagFileResized = runParserInArea (p->lang,
+											  p->startLine,
+											  p->startCharOffset,
+											  p->endLine,
+											  p->endCharOffset,
+											  p->sourceLineOffset,
+											  i)
 				? true
 				: tagFileResized;
 	}

--- a/ctags/main/promise.c
+++ b/ctags/main/promise.c
@@ -109,11 +109,24 @@ int  makePromise   (const char *parser,
 	p = promises + promise_count;
 	p->parent_promise = current_promise;
 	p->lang = lang;
-	p->startLine = startLine;
-	p->startColumn = startColumn;
-	p->endLine = endLine;
-	p->endColumn = endColumn;
-	p->sourceLineOffset = sourceLineOffset;
+
+	if (is_thin_area_spec && isAreaStacked())
+	{
+		getAreaInfo (&p->startLine,
+					 &p->startColumn,
+					 &p->endLine,
+					 &p->endColumn);
+		p->sourceLineOffset = p->startLine;
+	}
+	else
+	{
+		p->startLine = startLine;
+		p->startColumn = startColumn;
+		p->endLine = endLine;
+		p->endColumn = endColumn;
+		p->sourceLineOffset = sourceLineOffset;
+	}
+
 	p->modifiers = NULL;
 
 	r = promise_count;

--- a/ctags/main/promise.h
+++ b/ctags/main/promise.h
@@ -17,19 +17,19 @@
 #include "parse.h"
 #include "numarray.h"
 
-#define EOL_CHAR_OFFSET -1
+#define EOL_COLUMN -1
 
 /* args (startLine): [absolute]
- * args (startCharOffset): [buggy]
+ * args (startColumn): [buggy]
  * args (endLine): [absolute]
- * args (endCharOffset): [absolute]
+ * args (endColumn): [absolute]
  * args (sourceLineOffset): [buggy]
  */
 /* parser can be NULL; give a name with promiseUpdateLanguage()
  * when the name can be determined. */
 int  makePromise   (const char *parser,
-		    unsigned long startLine, long startCharOffset,
-		    unsigned long endLine, long endCharOffset,
+		    unsigned long startLine, long startColumn,
+		    unsigned long endLine, long endColumn,
 		    unsigned long sourceLineOffset);
 
 /* Fill the line with white spaces.

--- a/ctags/main/promise.h
+++ b/ctags/main/promise.h
@@ -19,6 +19,12 @@
 
 #define EOL_CHAR_OFFSET -1
 
+/* args (startLine): [absolute]
+ * args (startCharOffset): [buggy]
+ * args (endLine): [absolute]
+ * args (endCharOffset): [absolute]
+ * args (sourceLineOffset): [buggy]
+ */
 /* parser can be NULL; give a name with promiseUpdateLanguage()
  * when the name can be determined. */
 int  makePromise   (const char *parser,

--- a/ctags/main/promise_p.h
+++ b/ctags/main/promise_p.h
@@ -19,13 +19,13 @@ void breakPromisesAfter (int promise);
 int getLastPromise (void);
 
 /* args (startLine): [buggy]
- * args (startCharOffset): [buggy]
+ * args (startColumn): [buggy]
  * args (endLine): [buggy]
- * args (endCharOffset): [buggy]
+ * args (endColumn): [buggy]
  */
 void runModifiers (int promise,
-				   unsigned long startLine, long startCharOffset,
-				   unsigned long endLine, long endCharOffset,
+				   unsigned long startLine, long startColumn,
+				   unsigned long endLine, long endColumn,
 				   unsigned char *input,
 				   size_t size);
 

--- a/ctags/main/promise_p.h
+++ b/ctags/main/promise_p.h
@@ -17,6 +17,12 @@
 bool forcePromises (void);
 void breakPromisesAfter (int promise);
 int getLastPromise (void);
+
+/* args (startLine): [buggy]
+ * args (startCharOffset): [buggy]
+ * args (endLine): [buggy]
+ * args (endCharOffset): [buggy]
+ */
 void runModifiers (int promise,
 				   unsigned long startLine, long startCharOffset,
 				   unsigned long endLine, long endCharOffset,

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -159,6 +159,26 @@ void callWithSavingPosition (MIO *mio,
 	mio_setpos (mio, &origin);
 }
 
+/* args (startLine): [absolute]
+   args (startColumn): [buggy]
+   args (endLine): [absolute]
+   args (endColumn): [absolute] */
+CTAGS_INLINE
+void getAreaInfo (unsigned long *startLine,
+				  long *startColumn,
+				  unsigned long *endLine,
+				  long *endColumn)
+{
+	if (startLine)
+		*startLine = File.areaInfo.startLine;
+	if (startColumn)
+		*startColumn = File.areaInfo.startColumn;
+	if (endLine)
+		*endLine = File.areaInfo.endLine;
+	if (endColumn)
+		*endColumn = File.areaInfo.endColumn;
+}
+
 extern int getInputColumnNumber (void)
 {
 	unsigned char *base = (unsigned char *) vStringValue (File.line);
@@ -176,8 +196,15 @@ extern int getInputColumnNumber (void)
 	}
 	else
 	{
-		/* At the first line of file. */
-		ret = mio_tell (File.mio) - (File.bomFound? 3: 0);
+		/* Read nothing yet. */
+		long guest_area_column = 0;
+		if (isAreaStacked ())
+		{
+			unsigned long startLine CTAGS_ATTR_UNUSED;
+			getAreaInfo (&startLine, &guest_area_column, NULL, NULL);
+			Assert (startLine == 1);
+		}
+		ret = guest_area_column;
 	}
 
 	return ret >= 0 ? ret : 0;

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -213,6 +213,11 @@ long getAreaStartOffset (void)
 	return File.areaInfo.startOffset;
 }
 
+extern long translateFileOffset (unsigned long offset)
+{
+	return getAreaStartOffset () + offset;
+}
+
 extern int getInputColumnNumber (void)
 {
 	int ret;

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -180,6 +180,26 @@ void getAreaInfo (unsigned long *startLine,
 		*endColumn = File.areaInfo.endColumn;
 }
 
+/* return: [absolute]
+ * If the area is not stacked, return 0.
+ * If the area is stacked, the line number of the start of the current
+ * area in the absolute coordinate system.
+ */
+static unsigned long getAreaStartLineNumber (void)
+{
+	unsigned long startLine = 0;
+
+	if (isAreaStacked())
+		getAreaInfo (&startLine, NULL, NULL, NULL);
+	return startLine;
+}
+
+extern unsigned long translateLineNumber (unsigned long line)
+{
+	unsigned long area_start_line = getAreaStartLineNumber ();
+	return (area_start_line? area_start_line - 1: 0) + line;
+}
+
 /* return: [absolute] */
 CTAGS_INLINE
 long getAreaStartOffset (void)

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -171,11 +171,10 @@ void callWithSavingPosition (MIO *mio,
    args (startColumn): [buggy]
    args (endLine): [absolute]
    args (endColumn): [absolute] */
-CTAGS_INLINE
-void getAreaInfo (unsigned long *startLine,
-				  long *startColumn,
-				  unsigned long *endLine,
-				  long *endColumn)
+extern void getAreaInfo (unsigned long *startLine,
+						 long *startColumn,
+						 unsigned long *endLine,
+						 long *endColumn)
 {
 	if (startLine)
 		*startLine = File.areaInfo.startLine;

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -138,6 +138,7 @@ static void     langStackClear(langStack *langStack);
 
 static MIOPos getInputFilePositionForLineFull (unsigned int line, enum areaCoord areaCoord);
 static MIOPos getInputFilePositionForFileOffset (long offset);
+static unsigned long getAreaStartLineNumber (void);
 
 /*
 *   DATA DEFINITIONS
@@ -152,6 +153,8 @@ static compoundPos StartOfLine;  /* holds deferred position of start of line */
 
 extern unsigned long getInputLineNumber (void)
 {
+	if (!File.currentLine && File.input.lineNumber == 1 && isAreaStacked ())
+		return getAreaStartLineNumber ();
 	return File.input.lineNumber;
 }
 
@@ -316,9 +319,10 @@ extern int getInputColumnNumber (void)
 		 *
 		 * dz = O + P - Q
 		 */
+		unsigned long ln = getInputLineNumber ();
 		ret = getAreaStartOffset ()
 			+ mio_tell (File.mio) - (File.bomFound? 3: 0)
-			- getInputFileOffsetForLine(File.input.lineNumber)
+			- getInputFileOffsetForLine(ln)
 			- File.ungetchIdx;
 	}
 	else
@@ -1068,7 +1072,7 @@ extern void closeInputFile (void)
 		if (Option.printTotals)
 		{
 			fileStatus *status = eStat (vStringValue (File.input.name));
-			addTotals (0, File.input.lineNumber - 1L, status->size);
+			addTotals (0, getInputLineNumber () - 1L, status->size);
 		}
 		mio_unref (File.mio);
 		File.mio = NULL;
@@ -1093,8 +1097,8 @@ static void fileNewline (bool crAdjustment, size_t posInAllLines)
 
 	File.input.lineNumber++;
 	File.source.lineNumber++;
-	DebugStatement ( if (Option.breakLine == File.input.lineNumber) lineBreak (); )
-	DebugStatement ( debugPrintf (DEBUG_RAW, "%6ld: ", File.input.lineNumber); )
+	DebugStatement ( if (Option.breakLine == getInputLineNumber ()) lineBreak (); )
+	DebugStatement ( debugPrintf (DEBUG_RAW, "%6ld: ", getInputLineNumber ()); )
 }
 
 extern void ungetcToInputFile (int c)

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -79,6 +79,7 @@ typedef struct sInputLineFposMap {
 } inputLineFposMap;
 
 typedef struct sAreaInfo {
+	long startOffset;
 	unsigned long startLine;
 	long startColumn;
 	unsigned long endLine;
@@ -179,6 +180,13 @@ void getAreaInfo (unsigned long *startLine,
 		*endColumn = File.areaInfo.endColumn;
 }
 
+/* return: [absolute] */
+CTAGS_INLINE
+long getAreaStartOffset (void)
+{
+	return File.areaInfo.startOffset;
+}
+
 extern int getInputColumnNumber (void)
 {
 	int ret;
@@ -237,11 +245,50 @@ extern int getInputColumnNumber (void)
 	}
 	else if (File.input.lineNumber)
 	{
-		/* When EOF is saw, currentLine is set to NULL.
-		 * So the way to calculate the offset at the end of file is tricky.
+		/* currentLine is set to NULL but File.input.lineNumber is not zero.
+		 * This implies the parser saw EOF.
+		 * The way to calculate the offset at the end of file is tricky.
+		 *
+		 * input file ---> +-----------------+
+		 *                 |                 |
+		 *                 |   [.............|
+		 *                 |.................|
+		 *                 |.....Z]          |
+		 *                 <-dz->
+		 *                 |                 |
+		 *                 +-----------------+
+		 *
+		 * We must calculate dz but we cannot use File.currentLine.
+		 *
+		 * input file ---> +-----------------+
+		 *                 |<========== O ===|
+		 *                 |==>[<============|
+		 *                 |======= P =======|
+		 *                 |====>Z]          |
+		 *                 <-dz->
+		 *                 |                 |
+		 *                 +-----------------+
+		 *
+		 * O => getAreaStartOffset ()
+		 * P => mio_tell (File.mio) - (File.bomFound? 3: 0)
+		 *
+		 * input file ---> +-----------------+
+		 *                 |<================|
+		 *                 |===[====Q========|
+		 *                 |=================|
+		 *                 |====>Z]          |
+		 *                 <-dz->
+		 *                 |                 |
+		 *                 +-----------------+
+		 *
+		 * Q => getInputFileOffsetForLine(File.input.lineNumber)
+		 *
+		 * dz = O + P - Q
 		 */
-		ret = (mio_tell (File.mio) - (File.bomFound? 3: 0))
-			- getInputFileOffsetForLine(File.input.lineNumber);
+		ret = getAreaStartOffset ()
+			+ mio_tell (File.mio) - (File.bomFound? 3: 0)
+			- getInputFileOffsetForLine(File.input.lineNumber)
+			- File.ungetchIdx;
 	}
 	else
 	{
@@ -1322,6 +1369,7 @@ extern void   pushArea (
 
 	File.mio = subio;
 	File.bomFound = false;
+	File.areaInfo.startOffset = p;
 	File.areaInfo.startLine = startLine;
 	File.areaInfo.startColumn = startColumn;
 	File.areaInfo.endLine = endLine;

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -147,6 +147,18 @@ extern unsigned long getInputLineNumber (void)
 	return File.input.lineNumber;
 }
 
+CTAGS_INLINE
+void callWithSavingPosition (MIO *mio,
+							 void (* fn) (MIO *, void *),
+							 void *data)
+{
+	MIOPos origin;
+
+	mio_getpos (mio, &origin);
+	fn (mio, data);
+	mio_setpos (mio, &origin);
+}
+
 extern int getInputLineOffset (void)
 {
 	unsigned char *base = (unsigned char *) vStringValue (File.line);
@@ -1125,23 +1137,41 @@ extern char *readLineRaw (vString *const vLine, MIO *const mio)
 /*  Places into the line buffer the contents of the line referenced by
  *  "location".
  */
-extern char *readLineFromBypass (
-		vString *const vLine, MIOPos location, long *const pSeekValue)
-{
-	MIOPos orignalPosition;
+struct readLineRawCbData {
+	MIOPos pos;
+	long *offset;
+	vString *vLine;
 	char *result;
+};
 
-	mio_getpos (File.mio, &orignalPosition);
-	mio_setpos (File.mio, &location);
-	mio_clearerr (File.mio);
-	if (pSeekValue != NULL)
-		*pSeekValue = mio_tell (File.mio);
-	result = readLineRaw (vLine, File.mio);
-	mio_setpos (File.mio, &orignalPosition);
+static void readLineRawCb (MIO *mio, void *data)
+{
+	struct readLineRawCbData *cb_data = data;
+
+	mio_setpos (mio, &cb_data->pos);
+	mio_clearerr (mio);
+	if (cb_data->offset)
+		*cb_data->offset = mio_tell (mio);
+
 	/* If the file is empty, we can't get the line
-	   for location 0. readLineFromBypass doesn't know
+	   for position 0. readLineFromBypass doesn't know
 	   what itself should do; just report it to the caller. */
-	return result;
+	cb_data->result = readLineRaw (cb_data->vLine, mio);
+}
+
+extern char *readLineFromBypass (
+		vString *const vLine, MIOPos pos, long *const offset)
+{
+	struct readLineRawCbData data = {
+		.pos = pos,
+		.offset = offset,
+		.vLine = vLine,
+		.result = NULL,
+	};
+
+	callWithSavingPosition (File.mio, readLineRawCb, &data);
+
+	return data.result;
 }
 
 extern void   pushArea (

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -1255,7 +1255,7 @@ extern void   pushArea (
 	File.source.lineNumberOrigin = ((sourceLineOffset == 0)? 0: sourceLineOffset - 1);
 }
 
-extern bool doesParserRunAsGuest (void)
+extern bool isAreaStacked (void)
 {
 	return !(File.areaInfo.startLine == 0
 			 && File.areaInfo.startColumn == 0
@@ -1267,8 +1267,7 @@ extern unsigned int getAreaBoundaryInfo (unsigned long lineNumber)
 {
 	unsigned int info;
 
-	if (!doesParserRunAsGuest())
-		/* Not in a stacked area  */
+	if (!isAreaStacked())
 		return 0;
 
 	info = 0;

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -59,8 +59,8 @@ typedef struct sInputFileInfo {
 	unsigned long lineNumber;/* line number in the input file */
 	unsigned long lineNumberOrigin; /* The value set to `lineNumber'
 					   when `resetInputFile' is called
-					   on the input stream.
-					   This is needed for nested stream. */
+					   on the area.
+					   This is needed for stacked area. */
 	bool isHeader;           /* is input file a header file? */
 } inputFileInfo;
 
@@ -78,12 +78,12 @@ typedef struct sInputLineFposMap {
 	unsigned int size;
 } inputLineFposMap;
 
-typedef struct sNestedInputStreamInfo {
+typedef struct sAreaInfo {
 	unsigned long startLine;
 	long startCharOffset;
 	unsigned long endLine;
 	long endCharOffset;
-} nestedInputStreamInfo;
+} areaInfo;
 
 typedef struct sInputFile {
 	vString    *path;          /* path of input file (if any) */
@@ -102,7 +102,7 @@ typedef struct sInputFile {
 	inputFileInfo input; /* name, lineNumber */
 	inputFileInfo source;
 
-	nestedInputStreamInfo nestedInputStreamInfo;
+	areaInfo areaInfo;
 
 	/* sourceTagPathHolder is a kind of trash box.
 	   The buffer pointed by tagPath field of source field can
@@ -135,7 +135,7 @@ static void     langStackClear(langStack *langStack);
 *   DATA DEFINITIONS
 */
 static inputFile File;  /* static read through functions */
-static inputFile BackupFile;	/* File is copied here when a nested parser is pushed */
+static inputFile BackupFile;	/* File is copied here when a guest parser is pushed */
 static compoundPos StartOfLine;  /* holds deferred position of start of line */
 
 /*
@@ -1144,7 +1144,7 @@ extern char *readLineFromBypass (
 	return result;
 }
 
-extern void   pushNarrowedInputStream (
+extern void   pushArea (
 				       bool useMemoryStreamInput,
 				       unsigned long startLine, long startCharOffset,
 				       unsigned long endLine, long endCharOffset,
@@ -1156,19 +1156,19 @@ extern void   pushNarrowedInputStream (
 	MIOPos tmp;
 	MIO *subio;
 
-	if (isThinStreamSpec (startLine, startCharOffset,
-						  endLine, endCharOffset,
-						  sourceLineOffset))
+	if (isThinAreaSpec (startLine, startCharOffset,
+						endLine, endCharOffset,
+						sourceLineOffset))
 	{
 		if ((!useMemoryStreamInput
 			 || mio_memory_get_data (File.mio, NULL)))
 		{
 			File.thinDepth++;
-			verbose ("push thin stream (%d)\n", File.thinDepth);
+			verbose ("push thin area (%d)\n", File.thinDepth);
 			return;
 		}
-		error(WARNING, "INTERNAL ERROR: though pushing thin MEMORY stream, "
-			  "underlying input stream is a FILE stream: %s@%s",
+		error(WARNING, "INTERNAL ERROR: though pushing MEMORY based thin area, "
+			  "underlying area is a FILE base: %s@%s",
 			  vStringValue (File.input.name), vStringValue (File.input.tagPath));
 		AssertNotReached ();
 	}
@@ -1215,10 +1215,10 @@ extern void   pushNarrowedInputStream (
 
 	File.mio = subio;
 	File.bomFound = false;
-	File.nestedInputStreamInfo.startLine = startLine;
-	File.nestedInputStreamInfo.startCharOffset = startCharOffset;
-	File.nestedInputStreamInfo.endLine = endLine;
-	File.nestedInputStreamInfo.endCharOffset = endCharOffset;
+	File.areaInfo.startLine = startLine;
+	File.areaInfo.startCharOffset = startCharOffset;
+	File.areaInfo.endLine = endLine;
+	File.areaInfo.endCharOffset = endCharOffset;
 
 	File.input.lineNumberOrigin = ((startLine == 0)? 0: startLine - 1);
 	File.source.lineNumberOrigin = ((sourceLineOffset == 0)? 0: sourceLineOffset - 1);
@@ -1226,31 +1226,31 @@ extern void   pushNarrowedInputStream (
 
 extern bool doesParserRunAsGuest (void)
 {
-	return !(File.nestedInputStreamInfo.startLine == 0
-			 && File.nestedInputStreamInfo.startCharOffset == 0
-			 && File.nestedInputStreamInfo.endLine == 0
-			 && File.nestedInputStreamInfo.endCharOffset == 0);
+	return !(File.areaInfo.startLine == 0
+			 && File.areaInfo.startCharOffset == 0
+			 && File.areaInfo.endLine == 0
+			 && File.areaInfo.endCharOffset == 0);
 }
 
-extern unsigned int getNestedInputBoundaryInfo (unsigned long lineNumber)
+extern unsigned int getAreaBoundaryInfo (unsigned long lineNumber)
 {
 	unsigned int info;
 
 	if (!doesParserRunAsGuest())
-		/* Not in a nested input stream  */
+		/* Not in a stacked area  */
 		return 0;
 
 	info = 0;
-	if (File.nestedInputStreamInfo.startLine == lineNumber
-	    && File.nestedInputStreamInfo.startCharOffset != 0)
-		info |= INPUT_BOUNDARY_START;
-	if (File.nestedInputStreamInfo.endLine == lineNumber
-	    && File.nestedInputStreamInfo.endCharOffset != 0)
-		info |= INPUT_BOUNDARY_END;
+	if (File.areaInfo.startLine == lineNumber
+	    && File.areaInfo.startCharOffset != 0)
+		info |= AREA_BOUNDARY_START;
+	if (File.areaInfo.endLine == lineNumber
+	    && File.areaInfo.endCharOffset != 0)
+		info |= AREA_BOUNDARY_END;
 
 	return info;
 }
-extern void   popNarrowedInputStream  (void)
+extern void   popArea  (void)
 {
 	if (File.thinDepth)
 	{
@@ -1319,9 +1319,9 @@ static langType langStackPop  (langStack *langStack)
 	return langStack->languages [ -- langStack->count ];
 }
 
-extern bool isThinStreamSpec(unsigned long startLine, long startCharOffset,
-							 unsigned long endLine, long endCharOffset,
-							 unsigned long sourceLineOffset)
+extern bool isThinAreaSpec (unsigned long startLine, long startCharOffset,
+							unsigned long endLine, long endCharOffset,
+							unsigned long sourceLineOffset)
 {
 	return (startLine == 0 &&
 			startCharOffset == 0 &&

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -118,6 +118,11 @@ typedef struct sInputFile {
 	time_t mtime;
 } inputFile;
 
+enum areaCoord {
+	AREA_COORD_ABS,
+	AREA_COORD_CURRENT,
+};
+
 static inputLangInfo inputLang;
 static langType sourceLang;
 
@@ -131,6 +136,8 @@ static void     langStackPush (langStack *langStack, langType type);
 static langType langStackPop  (langStack *langStack);
 static void     langStackClear(langStack *langStack);
 
+static MIOPos getInputFilePositionForLineFull (unsigned int line, enum areaCoord areaCoord);
+static MIOPos getInputFilePositionForFileOffset (long offset);
 
 /*
 *   DATA DEFINITIONS
@@ -356,10 +363,47 @@ static compoundPos* getInputFileCompoundPosForLine (unsigned int line)
 	return File.lineFposMap.pos + index;
 }
 
-extern MIOPos getInputFilePositionForLine (unsigned int line)
+
+/* case areaCoord == AREA_COORD_CURRENT:
+ *    return: [current],
+ *    args (line): [absolute]
+ *
+ * case areaCoord == AREA_COORD_ABS:
+ *    return: [absolute],
+ *    args (line): [absolute]
+ */
+static MIOPos getInputFilePositionForLineFull (unsigned int line, enum areaCoord posAreaCoord)
 {
+	if (line == 1 && File.lineFposMap.count == 0)
+	{
+		/* Any line is not read yet. */
+		MIOPos pos;
+
+		if (isAreaStacked() && (posAreaCoord == AREA_COORD_ABS))
+			mio_getpos (BackupFile.mio, &pos);
+		else
+			mio_getpos (File.mio, &pos);
+		return pos;
+	}
+
+	if (isAreaStacked() && (posAreaCoord == AREA_COORD_CURRENT))
+	{
+		unsigned long area_start_ln = getAreaStartLineNumber ();
+		long abs_offset = getInputFileOffsetForLine (line);
+		long area_start_offset = getInputFileOffsetForLine (area_start_ln);
+		long rela_offset = abs_offset - area_start_offset;
+		MIOPos rela_pos = getInputFilePositionForFileOffset (rela_offset);
+		return rela_pos;
+	}
+
 	compoundPos *cpos = getInputFileCompoundPosForLine (line);
 	return cpos->pos;
+}
+
+
+extern MIOPos getInputFilePositionForLine (unsigned int line)
+{
+	return getInputFilePositionForLineFull (line, AREA_COORD_CURRENT);
 }
 
 
@@ -369,6 +413,36 @@ extern long getInputFileOffsetForLine (unsigned int line)
 	long r = cpos->offset - (File.bomFound? 3: 0) - cpos->crAdjustment;
 	Assert (r >= 0);
 	return r;
+}
+
+struct mioGetposCallbackData {
+	MIOPos *pos;
+	long   offset;
+};
+
+static void tellAbsolutePosition (MIO *mio, void *data)
+{
+	struct mioGetposCallbackData *cb_data = data;
+
+	mio_seek (mio, cb_data->offset, SEEK_SET);
+	mio_getpos (mio, cb_data->pos);
+}
+
+/* return: [current],
+ * args (offset): [current] */
+static MIOPos getInputFilePositionForFileOffset (long offset)
+{
+	MIOPos pos;
+	struct mioGetposCallbackData data = {
+		.pos = &pos,
+		.offset = offset,
+	};
+
+	callWithSavingPosition (File.mio,
+							tellAbsolutePosition,
+							&data);
+
+	return pos;
 }
 
 extern langType getInputLanguage (void)

--- a/ctags/main/read.h
+++ b/ctags/main/read.h
@@ -136,6 +136,13 @@ extern MIOPos getInputFilePosition (void);
  * args (line): [buggy] */
 extern MIOPos getInputFilePositionForLine (unsigned int line);
 
+/* return: [absolute]
+ * args (line): [current]
+ *
+ * LINE argument is assumed 1 based.
+ */
+extern unsigned long translateLineNumber (unsigned long line);
+
 extern const char *getInputFileName (void);
 extern langType getInputLanguage (void);
 extern bool isInputLanguage (langType lang);

--- a/ctags/main/read.h
+++ b/ctags/main/read.h
@@ -119,8 +119,15 @@ extern unsigned long getInputLineNumber (void);
  * args (offset): [buggy] */
 extern unsigned long getInputLineNumberForFileOffset(long offset);
 
-/* return: [buggy] */
-extern int getInputLineOffset (void);
+/* Get the column number, the byte offset of the input from the
+ * begging of the line.
+ *
+ * This function works only if the parser uses getcFromInputFile().
+ * This function doesn't work if the parser uses readLineFromInputFile().
+ *
+ * return: [buggy]
+ */
+extern int getInputColumnNumber (void);
 
 /* return: [buggy] */
 extern MIOPos getInputFilePosition (void);

--- a/ctags/main/read.h
+++ b/ctags/main/read.h
@@ -115,8 +115,8 @@
 /* return: [absolute] */
 extern unsigned long getInputLineNumber (void);
 
-/* return: [buggy],
- * args (offset): [buggy] */
+/* return: [absolute],
+ * args (offset): [absolute] */
 extern unsigned long getInputLineNumberForFileOffset(long offset);
 
 /* Get the column number, the byte offset of the input from the
@@ -129,11 +129,11 @@ extern unsigned long getInputLineNumberForFileOffset(long offset);
  */
 extern int getInputColumnNumber (void);
 
-/* return: [buggy] */
+/* return: [current] */
 extern MIOPos getInputFilePosition (void);
 
-/* return: [buggy],
- * args (line): [buggy] */
+/* return: [current],
+ * args (line): [absolute] */
 extern MIOPos getInputFilePositionForLine (unsigned int line);
 
 /* return: [absolute]

--- a/ctags/main/read.h
+++ b/ctags/main/read.h
@@ -125,7 +125,7 @@ extern unsigned long getInputLineNumberForFileOffset(long offset);
  * This function works only if the parser uses getcFromInputFile().
  * This function doesn't work if the parser uses readLineFromInputFile().
  *
- * return: [buggy]
+ * return: [absolute]
  */
 extern int getInputColumnNumber (void);
 

--- a/ctags/main/read.h
+++ b/ctags/main/read.h
@@ -143,6 +143,11 @@ extern MIOPos getInputFilePositionForLine (unsigned int line);
  */
 extern unsigned long translateLineNumber (unsigned long line);
 
+/* return: [absolute]
+ * args (offset): [current]
+ */
+extern long translateFileOffset (unsigned long offset);
+
 extern const char *getInputFileName (void);
 extern langType getInputLanguage (void);
 extern bool isInputLanguage (langType lang);

--- a/ctags/main/read.h
+++ b/ctags/main/read.h
@@ -33,13 +33,103 @@
 *   FUNCTION PROTOTYPES
 */
 
-/* InputFile: reading from fp in inputFile with updating fields in input fields */
+/*
+ * We provide parsers some functions to get *locations*.
+ *
+ * We have three types of locations: line number, position, and
+ * offset.
+ *
+ * Area
+ * ----
+ * An *area* is a contentious part of an input file.
+ * If a parser runs as a *host parser*, the area covers whole the
+ * input file.
+ *
+ * input file ---> +-----------------+
+ *                 |<                |
+ *                 |                 |
+ *                 |      area       |
+ *                 |                 |
+ *                 |                >|
+ *                 +-----------------+
+ *
+ * When a *host parser* finds a sub area where another programming
+ * language is used, the parser can let another parser (*guest
+ * parser*) suitable for the language process the sub area.
+ *
+ * input file ---> +-----------------+
+ *                 |<      area      |
+ *                 |   [.............|
+ *                 |....area (sub)...|
+ *                 |....]            |
+ *                 |                >|
+ *                 +-----------------+
+ *
+ * Regardless of whether a parser runs as a host or guest, we
+ * call the area that the parser processes "the current area".
+ * We call the area that the host parser processes "the base area".
+ *
+ * From the view of a host parser, its current area and its
+ * base area are the same.
+ * From the vie of a guest parser, its current area and its
+ * base area are different.
+ *
+ * Coordinate system
+ * -----------------
+ * When dealing with the functions related to locations, we must
+ * consider the *coordinate system* of locations.
+ *
+ * *Absolute coordinate system* is a coordinate system that origin
+ * is at the start of the base area.
+ *
+ * *Current coordinate system* is a coordinate system that origin
+ * is at the start of the current area.
+ *
+ * Let's see an example.
+ *
+ * Consider calling a function getting a location from a parser
+ * running as a guest.
+ *
+ * input file ---> +-----------------+
+ *                 |<   base area    |
+ *                 |   [.........X...|
+ *                 |..current area...|
+ *                 |....]            |
+ *                 |                >|
+ *                 +-----------------+
+ *
+ * The line number for X is 2 in the absolute coordinate system.
+ * The line number for X is 1 in the current coordinate system.
+ */
+
+/* We have had many bugs caused by misunderstanding coordinate systems.
+ * So we use markers [absolute], [current] or [buggy] and put them
+ * on the declarations of functions getting locations.
+ *
+ * A function marked [buggy] may return [absolute] or [current]
+ * locations. We should have no [buggy] marker in the future.
+ *
+ * [rename] is a marker for functions that should be renamed.
+ */
+
+/* return: [absolute] */
 extern unsigned long getInputLineNumber (void);
+
+/* return: [buggy],
+ * args (offset): [buggy] */
 extern unsigned long getInputLineNumberForFileOffset(long offset);
+
+/* return: [buggy] */
 extern int getInputLineOffset (void);
-extern const char *getInputFileName (void);
+
+/* return: [buggy] */
 extern MIOPos getInputFilePosition (void);
+
+/* return: [buggy],
+ * args (line): [buggy] */
 extern MIOPos getInputFilePositionForLine (unsigned int line);
+
+extern const char *getInputFileName (void);
 extern langType getInputLanguage (void);
 extern bool isInputLanguage (langType lang);
 extern bool isInputHeaderFile (void);

--- a/ctags/main/read_p.h
+++ b/ctags/main/read_p.h
@@ -34,8 +34,8 @@ enum areaBoundaryFlag {
 extern const char *getInputLanguageName (void);
 extern const char *getInputFileTagPath (void);
 
-/* return: [buggy],
- * args (line): [buggy] */
+/* return: [absolute],
+ * args (line): [absolute] */
 extern long getInputFileOffsetForLine (unsigned int line);
 
 extern unsigned int countInputLanguageKinds (void);
@@ -61,7 +61,7 @@ extern void closeInputFile (void);
 extern void *getInputFileUserData(void);
 
 
-/* args (line): [buggy] */
+/* args (line): [absolute] */
 extern unsigned int getAreaBoundaryInfo (unsigned long lineNumber);
 
 extern const char *getSourceFileTagPath (void);

--- a/ctags/main/read_p.h
+++ b/ctags/main/read_p.h
@@ -79,15 +79,15 @@ extern time_t getInputFileMtime (void);
 extern char *readLineFromBypass (vString *const vLine, MIOPos location, long *const pSeekValue);
 
 /* args (startLine): [absolute]
- * args (startCharOffset): [buggy]
+ * args (startColumn): [buggy]
  * args (endLine): [absolute]
- * args (endCharOffset): [absolute]
+ * args (endColumn): [absolute]
  * args (sourceLineOffset): [buggy]
  */
 extern void   pushArea (
 				       bool useMemoryStreamInput,
-				       unsigned long startLine, long startCharOffset,
-				       unsigned long endLine, long endCharOffset,
+				       unsigned long startLine, long startColumn,
+				       unsigned long endLine, long endColumn,
 				       unsigned long sourceLineOffset,
 				       int promise);
 extern void   popArea  (void);
@@ -97,8 +97,8 @@ extern void   popArea  (void);
  * args (sourceLineOffset): [buggy]
  */
 #define THIN_AREA_SPEC 0, 0, 0, 0, 0
-extern bool isThinAreaSpec (unsigned long startLine, long startCharOffset,
-							unsigned long endLine, long endCharOffset,
+extern bool isThinAreaSpec (unsigned long startLine, long startColumn,
+							unsigned long endLine, long endColumn,
 							unsigned long sourceLineOffset);
 
 #endif  /* CTAGS_MAIN_READ_PRIVATE_H */

--- a/ctags/main/read_p.h
+++ b/ctags/main/read_p.h
@@ -43,7 +43,6 @@ extern unsigned int countInputLanguageRoles (int kindIndex);
 
 extern bool doesInputLanguageAllowNullTag (void);
 extern bool doesInputLanguageRequestAutomaticFQTag (const tagEntryInfo *e);
-extern bool doesParserRunAsGuest (void);
 extern bool doesSubparserRun (void);
 extern langType getLanguageForBaseParser (void);
 
@@ -91,6 +90,8 @@ extern void   pushArea (
 				       unsigned long sourceLineOffset,
 				       int promise);
 extern void   popArea  (void);
+
+extern bool isAreaStacked (void);
 
 /* args (startLine): [absolute]
  * args (endLine): [absolute]

--- a/ctags/main/read_p.h
+++ b/ctags/main/read_p.h
@@ -22,9 +22,9 @@
 *   DATA DECLARATIONS
 */
 
-enum nestedInputBoundaryFlag {
-	INPUT_BOUNDARY_START = 1UL << 0,
-	INPUT_BOUNDARY_END   = 1UL << 1,
+enum areaBoundaryFlag {
+	AREA_BOUNDARY_START = 1UL << 0,
+	AREA_BOUNDARY_END   = 1UL << 1,
 };
 
 /*
@@ -59,7 +59,7 @@ extern void resetInputFile (const langType language, bool resetLineFposMap_);
 extern void closeInputFile (void);
 extern void *getInputFileUserData(void);
 
-extern unsigned int getNestedInputBoundaryInfo (unsigned long lineNumber);
+extern unsigned int getAreaBoundaryInfo (unsigned long lineNumber);
 
 extern const char *getSourceFileTagPath (void);
 extern langType getSourceLanguage (void);
@@ -68,17 +68,17 @@ extern time_t getInputFileMtime (void);
 
 /* Bypass: reading from fp in inputFile WITHOUT updating fields in input fields */
 extern char *readLineFromBypass (vString *const vLine, MIOPos location, long *const pSeekValue);
-extern void   pushNarrowedInputStream (
+extern void   pushArea (
 				       bool useMemoryStreamInput,
 				       unsigned long startLine, long startCharOffset,
 				       unsigned long endLine, long endCharOffset,
 				       unsigned long sourceLineOffset,
 				       int promise);
-extern void   popNarrowedInputStream  (void);
+extern void   popArea  (void);
 
-#define THIN_STREAM_SPEC 0, 0, 0, 0, 0
-extern bool isThinStreamSpec(unsigned long startLine, long startCharOffset,
-							 unsigned long endLine, long endCharOffset,
-							 unsigned long sourceLineOffset);
+#define THIN_AREA_SPEC 0, 0, 0, 0, 0
+extern bool isThinAreaSpec (unsigned long startLine, long startCharOffset,
+							unsigned long endLine, long endCharOffset,
+							unsigned long sourceLineOffset);
 
 #endif  /* CTAGS_MAIN_READ_PRIVATE_H */

--- a/ctags/main/read_p.h
+++ b/ctags/main/read_p.h
@@ -34,6 +34,8 @@ enum areaBoundaryFlag {
 extern const char *getInputLanguageName (void);
 extern const char *getInputFileTagPath (void);
 
+/* return: [buggy],
+ * args (line): [buggy] */
 extern long getInputFileOffsetForLine (unsigned int line);
 
 extern unsigned int countInputLanguageKinds (void);
@@ -59,6 +61,8 @@ extern void resetInputFile (const langType language, bool resetLineFposMap_);
 extern void closeInputFile (void);
 extern void *getInputFileUserData(void);
 
+
+/* args (line): [buggy] */
 extern unsigned int getAreaBoundaryInfo (unsigned long lineNumber);
 
 extern const char *getSourceFileTagPath (void);
@@ -66,8 +70,20 @@ extern langType getSourceLanguage (void);
 
 extern time_t getInputFileMtime (void);
 
-/* Bypass: reading from fp in inputFile WITHOUT updating fields in input fields */
+/* Bypass : read a line at POS from the current area WITHOUT updating the state of the area.
+ * If OFFSET is not NULL, the function sets the offset value for POS.
+ *
+ * args (pos): [buggy]
+ * args (offset): [buggy]
+ */
 extern char *readLineFromBypass (vString *const vLine, MIOPos location, long *const pSeekValue);
+
+/* args (startLine): [absolute]
+ * args (startCharOffset): [buggy]
+ * args (endLine): [absolute]
+ * args (endCharOffset): [absolute]
+ * args (sourceLineOffset): [buggy]
+ */
 extern void   pushArea (
 				       bool useMemoryStreamInput,
 				       unsigned long startLine, long startCharOffset,
@@ -76,6 +92,10 @@ extern void   pushArea (
 				       int promise);
 extern void   popArea  (void);
 
+/* args (startLine): [absolute]
+ * args (endLine): [absolute]
+ * args (sourceLineOffset): [buggy]
+ */
 #define THIN_AREA_SPEC 0, 0, 0, 0, 0
 extern bool isThinAreaSpec (unsigned long startLine, long startCharOffset,
 							unsigned long endLine, long endCharOffset,

--- a/ctags/main/read_p.h
+++ b/ctags/main/read_p.h
@@ -102,4 +102,13 @@ extern bool isThinAreaSpec (unsigned long startLine, long startColumn,
 							unsigned long endLine, long endColumn,
 							unsigned long sourceLineOffset);
 
+/* args (startLine): [absolute]
+   args (startColumn): [buggy]
+   args (endLine): [absolute]
+   args (endColumn): [absolute] */
+extern void getAreaInfo (unsigned long *startLine,
+						 long *startColumn,
+						 unsigned long *endLine,
+						 long *endColumn);
+
 #endif  /* CTAGS_MAIN_READ_PRIVATE_H */

--- a/ctags/main/tokeninfo.h
+++ b/ctags/main/tokeninfo.h
@@ -55,7 +55,7 @@ struct tokenInfoClass {
 	ptrArray *backlog;
 
 	/* read_counter is incremented every time when reading a
-	 * new token from the input stream unless the new token is EOF.
+	 * new token from the input area unless the new token is EOF.
 	 *
 	 * When filling a tokenInfo from an entry in the backlog, we don't
 	 * regard it as "reading a new token".

--- a/ctags/parsers/html.c
+++ b/ctags/parsers/html.c
@@ -339,7 +339,7 @@ getNextChar:
 				ungetcToInputFile (d);
 				token->type = TOKEN_OTHER;
 			}
-			else if (d == '?' || d == '%')
+			else if (d == '?')
 			{
 				skipOtherScriptContent(d);
 				goto getNextChar;

--- a/ctags/parsers/php.c
+++ b/ctags/parsers/php.c
@@ -861,13 +861,14 @@ static bool isOpenScriptLanguagePhp (int c)
 	return true;
 }
 
-static int findPhpStart (void)
+static int findPhpStart (int *tagStartColumn)
 {
 	int c;
 	do
 	{
 		if ((c = getcFromInputFile ()) == '<')
 		{
+			*tagStartColumn = getInputColumnNumber () - 1;
 			c = getcFromInputFile ();
 			/* <?, <?= and <?php, but not <?xml */
 			if (c == '?')
@@ -932,14 +933,17 @@ getNextChar:
 	{
 		unsigned long startSourceLineNumber = getSourceLineNumber ();
 		unsigned long startLineNumber = getInputLineNumber ();
-		int startColumnNumber = getInputColumnNumber ();
 
-		c = findPhpStart ();
+		int startColumnNumber = getInputColumnNumber ();
+		int endColumnNumber;
+
+		c = findPhpStart (&endColumnNumber);
 		if (c != EOF)
 			InPhp = true;
+		else
+			endColumnNumber = getInputColumnNumber ();
 
 		unsigned long endLineNumber = getInputLineNumber ();
-		int endColumnNumber = getInputColumnNumber ();
 
 		makePromise ("HTML", startLineNumber, startColumnNumber,
 					 endLineNumber, endColumnNumber, startSourceLineNumber);

--- a/ctags/parsers/php.c
+++ b/ctags/parsers/php.c
@@ -932,17 +932,17 @@ getNextChar:
 	{
 		unsigned long startSourceLineNumber = getSourceLineNumber ();
 		unsigned long startLineNumber = getInputLineNumber ();
-		int startLineOffset = getInputLineOffset ();
+		int startColumnNumber = getInputColumnNumber ();
 
 		c = findPhpStart ();
 		if (c != EOF)
 			InPhp = true;
 
 		unsigned long endLineNumber = getInputLineNumber ();
-		int endLineOffset = getInputLineOffset ();
+		int endColumnNumber = getInputColumnNumber ();
 
-		makePromise ("HTML", startLineNumber, startLineOffset,
-					 endLineNumber, endLineOffset, startSourceLineNumber);
+		makePromise ("HTML", startLineNumber, startColumnNumber,
+					 endLineNumber, endColumnNumber, startSourceLineNumber);
 	}
 	else
 		c = getcFromInputFile ();

--- a/ctags/parsers/sql.c
+++ b/ctags/parsers/sql.c
@@ -655,7 +655,7 @@ static void makeSqlTag (tokenInfo *const token, const sqlKind kind)
 
 static void parseString (vString *const string, const int delimiter, int *promise)
 {
-	int offset[2];
+	int column[2];
 	unsigned long linenum[3];
 	enum { START, END, SOURCE };
 
@@ -668,7 +668,7 @@ static void parseString (vString *const string, const int delimiter, int *promis
 	{
 		c0 = getcFromInputFile ();
 		linenum[START] = getInputLineNumber ();
-		offset[START]  = getInputLineOffset ();
+		column[START]  = getInputColumnNumber ();
 		linenum[SOURCE] = getSourceLineNumber ();
 		ungetcToInputFile(c0);
 	}
@@ -692,11 +692,11 @@ static void parseString (vString *const string, const int delimiter, int *promis
 			{
 				ungetcToInputFile(c);
 				linenum[END] = getInputLineNumber ();
-				offset[END]  = getInputLineOffset ();
+				column[END]  = getInputColumnNumber ();
 				(void)getcFromInputFile ();
 				*promise = makePromise (NULL,
-										linenum [START], offset [START],
-										linenum [END], offset [END],
+										linenum [START], column [START],
+										linenum [END], column [END],
 										linenum [SOURCE]);
 			}
 			end = true;
@@ -739,7 +739,7 @@ static bool isCCFlag(const char *str)
  */
 static tokenType parseDollarQuote (vString *const string, const int delimiter, int *promise)
 {
-	int offset[2];
+	int column[2];
 	unsigned long linenum[3];
 	enum { START, END, SOURCE };
 
@@ -786,7 +786,7 @@ static tokenType parseDollarQuote (vString *const string, const int delimiter, i
 	if (promise)
 	{
 		linenum[START] = getInputLineNumber ();
-		offset[START]  = getInputLineOffset ();
+		column[START]  = getInputColumnNumber ();
 		linenum[SOURCE] = getSourceLineNumber ();
 	}
 
@@ -833,12 +833,12 @@ static tokenType parseDollarQuote (vString *const string, const int delimiter, i
 				if (promise)
 				{
 					linenum[END] = getInputLineNumber ();
-					offset[END]  = getInputLineOffset ();
-					if (offset[END] > len)
-						offset[END] -= len;
+					column[END]  = getInputColumnNumber ();
+					if (column[END] > len)
+						column[END] -= len;
 					*promise = makePromise (NULL,
-											linenum [START], offset [START],
-											linenum [END], offset [END],
+											linenum [START], column [START],
+											linenum [END], column [END],
 											linenum [SOURCE]);
 				}
 				break;

--- a/tests/ctags/Makefile.am
+++ b/tests/ctags/Makefile.am
@@ -366,6 +366,7 @@ test_sources = \
 	vhdl-process.vhd				\
 	vhdl-type.vhd					\
 	whitespaces.php					\
+	wp-guest.php					\
 	$(NULL)
 test_results = $(test_sources:=.tags)
 

--- a/tests/ctags/wp-guest.php
+++ b/tests/ctags/wp-guest.php
@@ -1,0 +1,57 @@
+<?php get_header(); ?>
+
+<div id="top">
+ <div class="inner">
+  <br clear="all" />
+<div id="logo">
+<h2><a href="<?php bloginfo('url'); ?>"><?php bloginfo('name'); ?></a></h2>
+<p>
+  <?php bloginfo('description'); ?>
+</p>
+</div>
+<div id="pages">
+<ul class="menubar" id="menubar">
+  <li><a href="<?php bloginfo('url'); ?>">Accueil</a></li>
+  <?php montheme_list_pages( array( 'depth' => 1 ) ); ?>
+</ul>
+<!--[if !IE]><-->
+<script type="text/javascript">
+  initMenu (document.getElementById ('menubar'), 0);
+</script>
+<!--><![endif]-->
+</div>
+ </div>
+</div>
+
+<div id="body">
+  <main id="content">
+
+  <?php if (have_posts()) : while (have_posts()) : the_post(); ?><br /><br />
+
+  <article class="post" id="post-<?php the_ID(); ?>">
+
+   <div class="storycontent">
+
+    <h3><a href="<?php the_permalink() ?>" rel="bookmark"><?php the_title(); ?></a></h3>
+   
+    <div class="storybody"><br /><?php the_content(__('(more...)')); ?></div>
+    <p class="postmetadata"></p>
+    
+   </div>
+     <div class="storybody"><?php comments_template(); // Get wp-comments.php template ?></div>
+  </article>
+
+
+  <?php endwhile; else: ?>
+  <p><?php _e('Sorry, no posts matched your criteria.'); ?></p>
+  <?php endif; ?>
+
+  <?php posts_nav_link(' &#8212; ', __('&laquo; Previous Page'), __('Next Page &raquo;')); ?>
+
+  </main>
+  <aside id="left"><?php get_sidebar(); ?></aside>
+</div>
+
+<?php function dummy() {} /* just to generate some PHP tag */  ?>
+
+<?php get_footer(); ?>

--- a/tests/ctags/wp-guest.php.tags
+++ b/tests/ctags/wp-guest.php.tags
@@ -1,0 +1,2 @@
+dummyÌ16Í()Ö0
+function:   dummy()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -362,7 +362,8 @@ ctags_tests = [
 	'ctags/vhdl-port.vhd.tags',
 	'ctags/vhdl-process.vhd.tags',
 	'ctags/vhdl-type.vhd.tags',
-	'ctags/whitespaces.php.tags'
+	'ctags/whitespaces.php.tags',
+	'ctags/wp-guest.php.tags'
 ]
 
 runner = find_program('ctags/runner.sh')


### PR DESCRIPTION
See https://github.com/universal-ctags/ctags/pull/4212, https://github.com/universal-ctags/ctags/pull/4097.

While applying the patches, I also noticed that some didn't apply because https://github.com/universal-ctags/ctags/pull/4223 added some preparation patches so I added some of these too.

I had to apply some of the patches manually because they didn't apply cleanly but I'm reasonably confident I didn't introduce any mess on the way. The main affected file is `read.c` and when diffed against the current uctags version, it's more or less identical.

Finally, I also added https://github.com/universal-ctags/ctags/pull/4231 as it seemed it might be related and also https://github.com/universal-ctags/ctags/commit/f3488d9bcfb882d30a6d97a4f87bacb328212202 which seemed to be worth having.

I don't know what exactly triggers the crashes so someone (@etkaar @b4n) should check if it really

Fixes #3939
Fixes https://github.com/geany/geany/issues/4270