### PR TITLE
filebrowser: Eliminate runtime error when preferences confirmed

### DIFF
--- a/plugins/filebrowser.c
+++ b/plugins/filebrowser.c
@@ -317,7 +317,7 @@ static void refresh(void)
 	GSList *list, *node;
 
 	/* don't clear when the new path doesn't exist */
-	if (! g_file_test(current_dir, G_FILE_TEST_EXISTS))
+	if (! current_dir || ! g_file_test(current_dir, G_FILE_TEST_EXISTS))
 		return;
 
 	clear();


### PR DESCRIPTION
Steps to reproduce:
1. Start Geany and make sure that the file browser plugin is loaded and that the Files tab hasn't been shown yet (some other tab is displayed after Geany start)
2. Open Plugin Preferences and confirm it with OK.
3. In the terminal you get
```
(geany:942499): GLib-CRITICAL **: 00:36:11.316: g_file_test: assertion 'filename != NULL' failed
```
This happens because when the Files tab isn't shown, the current_dir isn't updated and is still set to NULL when the preferences dialog appears.