### PR TITLE
Fix %p build placeholder, and various placeholder replacement fixes and improvements

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -5668,7 +5668,15 @@
                                       <object class="GtkEntry" id="entry_print_external_cmd">
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Path to the command for printing files (use %f for the filename)</property>
+                                        <property name="tooltip-markup" translatable="yes">Command for printing files.
+
+Supported placeholders are:
+• &lt;tt&gt;%d&lt;/tt&gt;: the directory containing the file.
+• &lt;tt&gt;%e&lt;/tt&gt;: the file name without path nor extension.
+• &lt;tt&gt;%f&lt;/tt&gt;: the file name without path.
+• &lt;tt&gt;%l&lt;/tt&gt;: the current line number in the file, starting at 1.
+• &lt;tt&gt;%p&lt;/tt&gt;: the directory of the current project, or equivalent to &lt;tt&gt;%d&lt;/tt&gt; if there are no project open.
+• &lt;tt&gt;%%&lt;/tt&gt;: a literal &lt;tt&gt;%&lt;/tt&gt; character.</property>
                                         <property name="primary-icon-activatable">False</property>
                                         <property name="secondary-icon-activatable">False</property>
                                       </object>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3338,11 +3338,12 @@ Before the command is run, the first occurrence of each of the following
 two character sequences in each of the command and working directory 
 fields is substituted by the items specified below:
 
-* %d - the absolute path to the directory of the current file.
-* %e - the name of the current file without the extension or path.
-* %f - the name of the current file without the path.
-* %p - if a project is open, the base path from the project.
-* %l - the line number at the current cursor position.
+* ``%%`` - a literal ``%`` sign.
+* ``%d`` - the absolute path to the directory of the current file.
+* ``%e`` - the name of the current file without the extension or path.
+* ``%f`` - the name of the current file without the path.
+* ``%p`` - if a project is open, the base path from the project.
+* ``%l`` - the line number at the current cursor position.
 
 .. note::
    If the base path set in `Project Properties`_ is not an absolute path, then it is
@@ -3429,16 +3430,16 @@ print command. However, the printed document contains no syntax highlighting.
 You can adjust the command to which the filename is passed in the preferences
 dialog. The default command is::
 
-    % lpr %f
+    % lpr "%d/%f"
 
-``%f`` will be substituted by the filename of the current file. Geany
-will not show errors from the command itself, so you should make
-sure that it works before(e.g. by trying to execute it from the
-command line).
+See `Substitutions in commands and working directories`_ for available
+placeholders referencing the current file. Geany will not show errors from the
+command itself, so you should make sure that it works before (e.g. by trying
+to execute it from the command line).
 
 A nicer example, which many prefer is::
 
-    % a2ps -1 --medium=A4 -o - %f | xfprint4
+    % a2ps -1 --medium=A4 -o - "%d/%f" | xfprint4
 
 But this depends on a2ps and xfprint4. As a replacement for xfprint4,
 gtklp or similar programs can be used.

--- a/src/build.c
+++ b/src/build.c
@@ -786,11 +786,11 @@ static gchar *prepare_run_cmd(GeanyDocument *doc, gchar **working_dir, guint cmd
 
 	cmd = get_build_cmd(doc, GEANY_GBG_EXEC, cmdindex, NULL);
 
-	cmd_string_utf8 = utils_replace_placeholder(doc, cmd->command, "deflp");
+	cmd_string_utf8 = utils_replace_document_placeholders(doc, cmd->command);
 	cmd_working_dir =  cmd->working_dir;
 	if (EMPTY(cmd_working_dir))
 		cmd_working_dir = "%d";
-	working_dir_utf8 = utils_replace_placeholder(doc, cmd_working_dir, "deflp");
+	working_dir_utf8 = utils_replace_document_placeholders(doc, cmd_working_dir);
 	*working_dir = utils_get_locale_from_utf8(working_dir_utf8);
 
 	if (EMPTY(*working_dir) || ! g_file_test(*working_dir, G_FILE_TEST_EXISTS) ||
@@ -1163,8 +1163,8 @@ static void build_command(GeanyDocument *doc, GeanyBuildGroup grp, guint cmd, gc
 	else
 		full_command = cmdstr;
 
-	dir = utils_replace_placeholder(doc, buildcmd->working_dir, "deflp");
-	subs_command = utils_replace_placeholder(doc, full_command, "deflp");
+	dir = utils_replace_document_placeholders(doc, buildcmd->working_dir);
+	subs_command = utils_replace_document_placeholders(doc, full_command);
 	build_info.grp = grp;
 	build_info.cmd = cmd;
 	build_spawn_cmd(doc, subs_command, dir);

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -556,7 +556,7 @@ static void handle_switch_page(GeanyDocument *doc)
 		sidebar_select_openfiles_item(doc);
 		ui_save_buttons_toggle(doc->changed);
 		ui_set_window_title(doc);
-		ui_update_statusbar(doc, -1);
+		ui_update_statusbar(doc);
 		ui_update_popup_reundo_items(doc);
 		ui_document_show_hide(doc); /* update the document menu */
 		build_menu_update(doc);
@@ -657,7 +657,7 @@ static void convert_eol(gint mode)
 
 	sci_set_eol_mode(doc->editor->sci, mode);
 
-	ui_update_statusbar(doc, -1);
+	ui_update_statusbar(doc);
 }
 
 
@@ -869,7 +869,7 @@ static void on_set_file_readonly1_toggled(GtkCheckMenuItem *checkmenuitem, gpoin
 		doc->readonly = ! doc->readonly;
 		sci_set_readonly(doc->editor->sci, doc->readonly);
 		ui_update_tab_status(doc);
-		ui_update_statusbar(doc, -1);
+		ui_update_statusbar(doc);
 	}
 }
 
@@ -1387,7 +1387,7 @@ static void on_menu_write_unicode_bom1_toggled(GtkCheckMenuItem *checkmenuitem, 
 
 		doc->has_bom = ! doc->has_bom;
 
-		ui_update_statusbar(doc, -1);
+		ui_update_statusbar(doc);
 	}
 }
 
@@ -1726,7 +1726,7 @@ static void set_indent_type(GtkCheckMenuItem *menuitem, GeanyIndentType type)
 	g_return_if_fail(doc != NULL);
 
 	editor_set_indent(doc->editor, type, doc->editor->indent_width);
-	ui_update_statusbar(doc, -1);
+	ui_update_statusbar(doc);
 }
 
 
@@ -2034,7 +2034,7 @@ static void on_reset_indentation1_activate(GtkMenuItem *menuitem, gpointer user_
 	foreach_document(i)
 		document_apply_indent_settings(documents[i]);
 
-	ui_update_statusbar(NULL, -1);
+	ui_update_statusbar(NULL);
 	ui_document_show_hide(NULL);
 }
 
@@ -2054,7 +2054,7 @@ static void on_detect_type_from_file_activate(GtkMenuItem *menuitem, gpointer us
 	{
 		editor_set_indent_type(doc->editor, type);
 		ui_document_show_hide(doc);
-		ui_update_statusbar(doc, -1);
+		ui_update_statusbar(doc);
 	}
 }
 

--- a/src/document.c
+++ b/src/document.c
@@ -469,7 +469,7 @@ void document_set_text_changed(GeanyDocument *doc, gboolean changed)
 		ui_update_tab_status(doc);
 		ui_save_buttons_toggle(changed);
 		ui_set_window_title(doc);
-		ui_update_statusbar(doc, -1);
+		ui_update_statusbar(doc);
 	}
 }
 
@@ -1651,7 +1651,7 @@ gboolean document_reload_prompt(GeanyDocument *doc, const gchar *forced_enc)
 	{
 		result = document_reload_force(doc, forced_enc);
 		if (forced_enc != NULL)
-			ui_update_statusbar(doc, -1);
+			ui_update_statusbar(doc);
 	}
 	g_free(base_name);
 	return result;
@@ -2215,7 +2215,7 @@ gboolean document_save_file(GeanyDocument *doc, gboolean force)
 		document_update_tab_label(doc);
 
 		msgwin_status_add(_("File %s saved."), doc->file_name);
-		ui_update_statusbar(doc, -1);
+		ui_update_statusbar(doc);
 #ifdef HAVE_VTE
 		vte_cwd((doc->real_path != NULL) ? doc->real_path : doc->file_name, FALSE);
 #endif
@@ -2884,7 +2884,7 @@ void document_set_encoding(GeanyDocument *doc, const gchar *new_encoding)
 	g_free(doc->encoding);
 	doc->encoding = g_strdup(new_encoding);
 
-	ui_update_statusbar(doc, -1);
+	ui_update_statusbar(doc);
 	gtk_widget_set_sensitive(ui_lookup_widget(main_widgets.window, "menu_write_unicode_bom1"),
 			encodings_is_unicode_charset(doc->encoding));
 }
@@ -3021,7 +3021,7 @@ void document_undo(GeanyDocument *doc)
 				document_redo_add(doc, UNDO_BOM, GINT_TO_POINTER(doc->has_bom));
 
 				doc->has_bom = GPOINTER_TO_INT(action->data);
-				ui_update_statusbar(doc, -1);
+				ui_update_statusbar(doc);
 				ui_document_show_hide(doc);
 				break;
 			}
@@ -3033,7 +3033,7 @@ void document_undo(GeanyDocument *doc)
 				document_set_encoding(doc, (const gchar*)action->data);
 				g_free(action->data);
 
-				ui_update_statusbar(doc, -1);
+				ui_update_statusbar(doc);
 				ui_document_show_hide(doc);
 				break;
 			}
@@ -3045,7 +3045,7 @@ void document_undo(GeanyDocument *doc)
 
 				sci_set_eol_mode(doc->editor->sci, GPOINTER_TO_INT(action->data));
 
-				ui_update_statusbar(doc, -1);
+				ui_update_statusbar(doc);
 				ui_document_show_hide(doc);
 
 				/* When undoing, UNDO_EOL is always followed by UNDO_SCINTILLA
@@ -3073,7 +3073,7 @@ void document_undo(GeanyDocument *doc)
 				/* Restore the previous EOL mode. */
 				sci_set_eol_mode(doc->editor->sci, eol_mode);
 				/* This might affect the status bar and document menu, so update them. */
-				ui_update_statusbar(doc, -1);
+				ui_update_statusbar(doc);
 				ui_document_show_hide(doc);
 
 				document_redo_add(doc, UNDO_RELOAD, data);
@@ -3146,7 +3146,7 @@ void document_redo(GeanyDocument *doc)
 				document_undo_add_internal(doc, UNDO_BOM, GINT_TO_POINTER(doc->has_bom));
 
 				doc->has_bom = GPOINTER_TO_INT(action->data);
-				ui_update_statusbar(doc, -1);
+				ui_update_statusbar(doc);
 				ui_document_show_hide(doc);
 				break;
 			}
@@ -3157,7 +3157,7 @@ void document_redo(GeanyDocument *doc)
 				document_set_encoding(doc, (const gchar*)action->data);
 				g_free(action->data);
 
-				ui_update_statusbar(doc, -1);
+				ui_update_statusbar(doc);
 				ui_document_show_hide(doc);
 				break;
 			}
@@ -3167,7 +3167,7 @@ void document_redo(GeanyDocument *doc)
 
 				sci_set_eol_mode(doc->editor->sci, GPOINTER_TO_INT(action->data));
 
-				ui_update_statusbar(doc, -1);
+				ui_update_statusbar(doc);
 				ui_document_show_hide(doc);
 				break;
 			}
@@ -3188,7 +3188,7 @@ void document_redo(GeanyDocument *doc)
 				/* Restore the previous EOL mode. */
 				sci_set_eol_mode(doc->editor->sci, eol_mode);
 				/* This might affect the status bar and document menu, so update them. */
-				ui_update_statusbar(doc, -1);
+				ui_update_statusbar(doc);
 				ui_document_show_hide(doc);
 
 				document_undo_add_internal(doc, UNDO_RELOAD, data);

--- a/src/editor.c
+++ b/src/editor.c
@@ -517,7 +517,7 @@ static void on_update_ui(GeanyEditor *editor, G_GNUC_UNUSED SCNotification *nt)
 	/* brace highlighting */
 	editor_highlight_braces(editor, pos);
 
-	ui_update_statusbar(editor->document, pos);
+	ui_update_statusbar(editor->document);
 
 #if 0
 	/** experimental code for inverting selections */
@@ -4802,7 +4802,7 @@ static gboolean editor_check_colourise(GeanyEditor *editor)
 	/* now that the current document is colourised, fold points are now accurate,
 	 * so force an update of the current function/tag. */
 	symbols_get_current_function(NULL, NULL);
-	ui_update_statusbar(NULL, -1);
+	ui_update_statusbar(NULL);
 
 	return TRUE;
 }

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -1769,7 +1769,7 @@ static gboolean cb_func_switch_action(guint key_id)
 			{
 				GtkWidget *sci = GTK_WIDGET(doc->editor->sci);
 				if (gtk_widget_has_focus(sci))
-					ui_update_statusbar(doc, -1);
+					ui_update_statusbar(doc);
 				else
 					gtk_widget_grab_focus(sci);
 			}

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1309,7 +1309,7 @@ on_prefs_dialog_response(GtkDialog *dialog, gint response, gpointer user_data)
 		/* various preferences */
 		ui_save_buttons_toggle((doc != NULL) ? doc->changed : FALSE);
 		msgwin_show_hide_tabs();
-		ui_update_statusbar(doc, -1);
+		ui_update_statusbar(doc);
 		ui_set_window_title(doc);
 
 		/* store all settings */

--- a/src/printing.c
+++ b/src/printing.c
@@ -593,8 +593,8 @@ static void print_external(GeanyDocument *doc)
 		return;
 	}
 
-	/* replace d, e, f and p placeholders in cmdline */
-	cmdline = utils_replace_placeholder(doc, printing_prefs.external_print_cmd, "defp");
+	/* replace placeholders in cmdline */
+	cmdline = utils_replace_document_placeholders(doc, printing_prefs.external_print_cmd);
 
 	if (dialogs_show_question(
 			_("The file \"%s\" will be printed with the following command:\n\n%s"),

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -183,141 +183,135 @@ void ui_set_statusbar(gboolean log, const gchar *format, ...)
 }
 
 
-/* note: some comments below are for translators */
-static gchar *create_statusbar_statistics(GeanyDocument *doc,
-	guint line, guint vcol, guint pos)
+/* get column from position, including virtual space */
+static gint get_vcol(ScintillaObject *sci, gint pos)
 {
-	const gchar *cur_tag;
-	const gchar *fmt;
-	const gchar *expos;	/* % expansion position */
-	const gchar sp[] = "      ";
-	GString *stats_str;
-	ScintillaObject *sci = doc->editor->sci;
+	gint col;
 
-	if (!EMPTY(ui_prefs.statusbar_template))
-		fmt = ui_prefs.statusbar_template;
+	/* Add temporary fix for sci infinite loop in Document::GetColumn(int)
+	 * when current pos is beyond document end (can occur when removing
+	 * blocks of selected lines especially esp. brace sections near end of file). */
+	if (pos <= sci_get_length(sci))
+		col = sci_get_col_from_position(sci, pos);
 	else
-		fmt = _(DEFAULT_STATUSBAR_TEMPLATE);
+		col = 0;
 
-	stats_str = g_string_sized_new(120);
+	return col + sci_get_cursor_virtual_space(sci);
+}
 
-	while ((expos = strchr(fmt, '%')) != NULL)
+
+/* note: some comments below are for translators */
+static gboolean insert_statusbar_statistics(GString *stats_str, const gchar placeholder, gpointer data)
+{
+	GeanyDocument *doc = data;
+	const gchar sp[] = "      ";
+	ScintillaObject *sci = doc->editor->sci;
+	gint pos = sci_get_current_position(sci);
+
+	switch (placeholder)
 	{
-		/* append leading text before % char */
-		g_string_append_len(stats_str, fmt, expos - fmt);
-
-		switch (*++expos)
-		{
-			case 'l':
-				g_string_append_printf(stats_str, "%d", line + 1);
-				break;
-			case 'L':
-				g_string_append_printf(stats_str, "%d",
-					sci_get_line_count(doc->editor->sci));
-				break;
-			case 'c':
-				g_string_append_printf(stats_str, "%d", vcol);
-				break;
-			case 'C':
-				g_string_append_printf(stats_str, "%d", vcol + 1);
-				break;
-			case 'p':
-				g_string_append_printf(stats_str, "%u", pos);
-				break;
-			case 's':
-			{
-				gint len = sci_get_selected_text_length2(sci);
-				/* check if whole lines are selected */
-				if (!len || sci_get_col_from_position(sci,
-						sci_get_selection_start(sci)) != 0 ||
-					sci_get_col_from_position(sci,
-						sci_get_selection_end(sci)) != 0)
-					g_string_append_printf(stats_str, "%d", len);
-				else /* Translators: L = lines */
-					g_string_append_printf(stats_str, _("%dL"),
-						sci_get_lines_selected(doc->editor->sci) - 1);
-				break;
-			}
-			case 'n' :
-				g_string_append_printf(stats_str, "%d",
-					sci_get_selected_text_length2(doc->editor->sci));
-				break;
-			case 'w':
-				/* Translators: RO = read-only */
-				g_string_append(stats_str, (doc->readonly) ? _("RO ") :
-					/* Translators: OVR = overwrite/overtype, INS = insert */
-					(sci_get_overtype(doc->editor->sci) ? _("OVR") : _("INS")));
-				break;
-			case 'r':
-				if (doc->readonly)
-				{
-					g_string_append(stats_str, _("RO "));	/* Translators: RO = read-only */
-					g_string_append(stats_str, sp + 1);
-				}
-				break;
-			case 't':
-			{
-				switch (editor_get_indent_prefs(doc->editor)->type)
-				{
-					case GEANY_INDENT_TYPE_TABS:
-						g_string_append(stats_str, _("TAB"));
-						break;
-					case GEANY_INDENT_TYPE_SPACES:	/* Translators: SP = space */
-						g_string_append(stats_str, _("SP"));
-						break;
-					case GEANY_INDENT_TYPE_BOTH:	/* Translators: T/S = tabs and spaces */
-						g_string_append(stats_str, _("T/S"));
-						break;
-				}
-				break;
-			}
-			case 'm':
-				if (doc->changed)
-				{
-					/* Translators: MOD = modified */
-					g_string_append(stats_str, _("MOD"));
-					g_string_append(stats_str, sp);
-				}
-				break;
-			case 'M':
-				g_string_append(stats_str, utils_get_eol_short_name(sci_get_eol_mode(doc->editor->sci)));
-				break;
-			case 'e':
-				g_string_append(stats_str,
-					doc->encoding ? doc->encoding : _("unknown"));
-				if (encodings_is_unicode_charset(doc->encoding) && (doc->has_bom))
-				{
-					g_string_append_c(stats_str, ' ');
-					/* Translators: BOM = byte order mark */
-					g_string_append(stats_str, _("(with BOM)"));
-				}
-				break;
-			case 'f':
-				g_string_append(stats_str, filetypes_get_display_name(doc->file_type));
-				break;
-			case 'S':
-				symbols_get_current_scope(doc, &cur_tag);
-				g_string_append(stats_str, cur_tag);
-				break;
-			case 'Y':
-				g_string_append_c(stats_str, ' ');
-				g_string_append_printf(stats_str, "%d",
-					sci_get_style_at(doc->editor->sci, pos));
-				break;
-			default:
-				g_string_append_len(stats_str, expos, 1);
-		}
-
-		/* skip past %c chars */
-		if (*expos)
-			fmt = expos + 1;
-		else
+		case 'l':
+			g_string_append_printf(stats_str, "%d", sci_get_line_from_position(sci, pos) + 1);
 			break;
+		case 'L':
+			g_string_append_printf(stats_str, "%d", sci_get_line_count(sci));
+			break;
+		case 'c':
+			g_string_append_printf(stats_str, "%d", get_vcol(sci, pos));
+			break;
+		case 'C':
+			g_string_append_printf(stats_str, "%d", get_vcol(sci, pos) + 1);
+			break;
+		case 'p':
+			g_string_append_printf(stats_str, "%u", pos);
+			break;
+		case 's':
+		{
+			gint len = sci_get_selected_text_length2(sci);
+			/* check if whole lines are selected */
+			if (!len || sci_get_col_from_position(sci,
+					sci_get_selection_start(sci)) != 0 ||
+				sci_get_col_from_position(sci,
+					sci_get_selection_end(sci)) != 0)
+				g_string_append_printf(stats_str, "%d", len);
+			else /* Translators: L = lines */
+				g_string_append_printf(stats_str, _("%dL"),
+					sci_get_lines_selected(sci) - 1);
+			break;
+		}
+		case 'n' :
+			g_string_append_printf(stats_str, "%d",
+				sci_get_selected_text_length2(sci));
+			break;
+		case 'w':
+			/* Translators: RO = read-only */
+			g_string_append(stats_str, (doc->readonly) ? _("RO ") :
+				/* Translators: OVR = overwrite/overtype, INS = insert */
+				(sci_get_overtype(sci) ? _("OVR") : _("INS")));
+			break;
+		case 'r':
+			if (doc->readonly)
+			{
+				g_string_append(stats_str, _("RO "));	/* Translators: RO = read-only */
+				g_string_append(stats_str, sp + 1);
+			}
+			break;
+		case 't':
+		{
+			switch (editor_get_indent_prefs(doc->editor)->type)
+			{
+				case GEANY_INDENT_TYPE_TABS:
+					g_string_append(stats_str, _("TAB"));
+					break;
+				case GEANY_INDENT_TYPE_SPACES:	/* Translators: SP = space */
+					g_string_append(stats_str, _("SP"));
+					break;
+				case GEANY_INDENT_TYPE_BOTH:	/* Translators: T/S = tabs and spaces */
+					g_string_append(stats_str, _("T/S"));
+					break;
+			}
+			break;
+		}
+		case 'm':
+			if (doc->changed)
+			{
+				/* Translators: MOD = modified */
+				g_string_append(stats_str, _("MOD"));
+				g_string_append(stats_str, sp);
+			}
+			break;
+		case 'M':
+			g_string_append(stats_str, utils_get_eol_short_name(sci_get_eol_mode(sci)));
+			break;
+		case 'e':
+			g_string_append(stats_str,
+				doc->encoding ? doc->encoding : _("unknown"));
+			if (encodings_is_unicode_charset(doc->encoding) && (doc->has_bom))
+			{
+				g_string_append_c(stats_str, ' ');
+				/* Translators: BOM = byte order mark */
+				g_string_append(stats_str, _("(with BOM)"));
+			}
+			break;
+		case 'f':
+			g_string_append(stats_str, filetypes_get_display_name(doc->file_type));
+			break;
+		case 'S':
+		{
+			const gchar *cur_tag;
+			symbols_get_current_scope(doc, &cur_tag);
+			g_string_append(stats_str, cur_tag);
+			break;
+		}
+		case 'Y':
+			g_string_append_c(stats_str, ' ');
+			g_string_append_printf(stats_str, "%d", sci_get_style_at(sci, pos));
+			break;
+		default:
+			return FALSE;
 	}
-	/* add any remaining text */
-	g_string_append(stats_str, fmt);
 
-	return g_string_free(stats_str, FALSE);
+	return TRUE;
 }
 
 
@@ -334,23 +328,15 @@ void ui_update_statusbar(GeanyDocument *doc)
 
 	if (doc != NULL)
 	{
-		gint pos;
-		guint line, vcol;
+		const gchar *fmt;
 		gchar *stats_str;
 
-		pos = sci_get_current_position(doc->editor->sci);
-		line = sci_get_line_from_position(doc->editor->sci, pos);
-
-		/* Add temporary fix for sci infinite loop in Document::GetColumn(int)
-		 * when current pos is beyond document end (can occur when removing
-		 * blocks of selected lines especially esp. brace sections near end of file). */
-		if (pos <= sci_get_length(doc->editor->sci))
-			vcol = sci_get_col_from_position(doc->editor->sci, pos);
+		if (!EMPTY(ui_prefs.statusbar_template))
+			fmt = ui_prefs.statusbar_template;
 		else
-			vcol = 0;
-		vcol += sci_get_cursor_virtual_space(doc->editor->sci);
+			fmt = _(DEFAULT_STATUSBAR_TEMPLATE);
 
-		stats_str = create_statusbar_statistics(doc, line, vcol, pos);
+		stats_str = utils_replace_placeholders(fmt, insert_statusbar_statistics, doc);
 
 		/* can be overridden by status messages */
 		set_statusbar(stats_str, TRUE);

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -322,7 +322,7 @@ static gchar *create_statusbar_statistics(GeanyDocument *doc,
 
 
 /* updates the status bar document statistics */
-void ui_update_statusbar(GeanyDocument *doc, gint pos)
+void ui_update_statusbar(GeanyDocument *doc)
 {
 	g_return_if_fail(doc == NULL || doc->is_valid);
 
@@ -334,11 +334,11 @@ void ui_update_statusbar(GeanyDocument *doc, gint pos)
 
 	if (doc != NULL)
 	{
+		gint pos;
 		guint line, vcol;
 		gchar *stats_str;
 
-		if (pos == -1)
-			pos = sci_get_current_position(doc->editor->sci);
+		pos = sci_get_current_position(doc->editor->sci);
 		line = sci_get_line_from_position(doc->editor->sci, pos);
 
 		/* Add temporary fix for sci infinite loop in Document::GetColumn(int)
@@ -2032,7 +2032,7 @@ void ui_statusbar_showhide(gboolean state)
 	if (state)
 	{
 		gtk_widget_show(ui_widgets.statusbar);
-		ui_update_statusbar(NULL, -1);
+		ui_update_statusbar(NULL);
 	}
 	else
 		gtk_widget_hide(ui_widgets.statusbar);

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -285,7 +285,7 @@ void ui_init_stock_items(void);
 void ui_add_config_file_menu_item(const gchar *real_path, const gchar *label,
 		GtkContainer *parent);
 
-void ui_update_statusbar(GeanyDocument *doc, gint pos);
+void ui_update_statusbar(GeanyDocument *doc);
 
 
 /* This sets the window title according to the current filename. */

--- a/src/utils.c
+++ b/src/utils.c
@@ -2563,12 +2563,25 @@ static gboolean generate_document_replacements(GString *buffer,
 
 	/* %p is the project base path, if any */
 	if (placeholder == 'p' && app->project)
+	{
 		r = project_get_base_path();
+		if (! r) /* replace with nothing if it's empty */
+			r = g_strdup("");
+	}
 	else if (! doc || ! doc->file_name)
 	{
-		ui_set_statusbar(FALSE, _("failed to substitute %%%c: document has no path"), placeholder);
-		/* TODO: Shouldn't we rather return an empty string for known placeholders?
-		 *       That's not what the previous code did, though. */
+		/* replace valid placeholders with nothing as we don't have a meaningful value */
+		switch (placeholder)
+		{
+			case 'p':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'l':
+				ui_set_statusbar(FALSE, _("failed to substitute %%%c: document has no path"), placeholder);
+				r = g_strdup("");
+				break;
+		}
 	}
 	else
 	{

--- a/src/utils.c
+++ b/src/utils.c
@@ -2522,6 +2522,7 @@ gchar *utils_replace_placeholders(const gchar *str,
 {
 	GString *res;
 	const gchar *p;
+	const gchar *const base = str;
 
 	g_return_val_if_fail(insert_replacement != NULL, NULL);
 
@@ -2538,6 +2539,7 @@ gchar *utils_replace_placeholders(const gchar *str,
 			g_string_append_c(res, '%');
 		else if (! insert_replacement(res, *p, data))
 		{
+			geany_debug(_("Unknown placeholder \"%%%c\" in \"%s\""), *p, base);
 			/* unknown placeholder, leave it literally */
 			g_string_append_c(res, '%');
 			g_string_append_c(res, *p);

--- a/src/utils.c
+++ b/src/utils.c
@@ -2588,7 +2588,7 @@ static gboolean generate_document_replacements(GString *buffer,
 		switch (placeholder)
 		{
 			case 'p': /* we only end up here if no project are open, so fallback on %d */
-				ui_set_statusbar(FALSE, _("failed to substitute %%p, no project active"));
+				ui_set_statusbar(FALSE, _("no project active, %%p is substituted as %%d"));
 				/* fall through */
 			case 'd':
 				r = g_path_get_dirname(doc->file_name);

--- a/src/utils.c
+++ b/src/utils.c
@@ -2499,7 +2499,24 @@ gchar *utils_get_os_info_string(void)
 }
 
 
-static gchar *utils_replace_placeholders(const gchar *str,
+/*
+ * @brief Replace %-placeholders in a string
+ * @param str Format string including placeholders
+ * @param insert_replacement Callback function to insert placeholder replacements.
+ *                           It gets called with the buffer to which append the
+ *                           replacement, the placeholder character, and @p data.
+ *                           It should return whether the placeholder was handled
+ *                           or not.
+ * @param data User data to pass to the @p insert_replacement
+ * @returns A copy of @p str with placeholders replaced
+ *
+ * Replaces arbitrary placeholders in a printf-style format string.  Unknown
+ * placeholders are left unmodified in the resulting string.
+ * There is one special placeholder that is always handled and replaced, that
+ * is `%`: it is replaced with a literal "%"; that is `%%` results in `%`.
+ */
+GEANY_EXPORT_SYMBOL
+gchar *utils_replace_placeholders(const gchar *str,
 		gboolean (insert_replacement)(GString *buffer, gchar placeholder, gpointer data),
 		gpointer data)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -342,7 +342,7 @@ gchar *utils_utf8_strdown(const gchar *str);
 
 gboolean utils_utf8_substring_match(const gchar *key, const gchar *haystack);
 
-gchar *utils_replace_placeholder(const GeanyDocument *doc, const gchar *src, const gchar *needles);
+gchar *utils_replace_document_placeholders(const GeanyDocument *doc, const gchar *src);
 
 #endif /* GEANY_PRIVATE */
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -342,6 +342,10 @@ gchar *utils_utf8_strdown(const gchar *str);
 
 gboolean utils_utf8_substring_match(const gchar *key, const gchar *haystack);
 
+gchar *utils_replace_placeholders(const gchar *str,
+		gboolean (insert_replacement)(GString *buffer, gchar placeholder, gpointer data),
+		gpointer data);
+
 gchar *utils_replace_document_placeholders(const GeanyDocument *doc, const gchar *src);
 
 #endif /* GEANY_PRIVATE */

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -431,6 +431,56 @@ static void test_utils_get_initials(void)
 #undef CHECK_INITIALS
 }
 
+static gboolean replace_placeholders(GString *buffer, const gchar placeholder, gpointer data)
+{
+	g_assert_cmpint(GPOINTER_TO_INT(data), ==, 42);
+
+	switch (placeholder)
+	{
+		case 'a': g_string_append(buffer, "alpha"); break;
+		case 'b': g_string_append(buffer, "beta"); break;
+		case 'c': g_string_append(buffer, "charlie"); break;
+		case 'C': g_string_append(buffer, "Charlie"); break;
+		case 'd': g_string_append_printf(buffer, "%d", 42); break;
+		case 'f': g_string_append_printf(buffer, "%f", 4.2); break;
+		case 'g': g_string_append_printf(buffer, "%g", 4.2); break;
+		default: return FALSE;
+	}
+
+	return TRUE;
+}
+
+static void test_utils_replace_placeholders(void)
+{
+#define CHECK_PL(src, result) \
+	G_STMT_START {																				\
+		gchar *r = utils_replace_placeholders(src, replace_placeholders, GINT_TO_POINTER(42));	\
+		g_assert_cmpstr(r, ==, result);															\
+		g_free(r);																				\
+	} G_STMT_END
+
+	CHECK_PL("some thing", "some thing");
+	CHECK_PL("some %% thing", "some % thing");
+	/* a trailing % is kept */
+	CHECK_PL("some %% thing %", "some % thing %");
+	CHECK_PL("some %%f thing %%", "some %f thing %");
+	CHECK_PL("some %%f thing %%%", "some %f thing %%");
+	CHECK_PL("some %%f thing %%%%", "some %f thing %%");
+	CHECK_PL("some %%f thing %%%%%", "some %f thing %%%");
+	/* Some actual replacements */
+	CHECK_PL("some %a thing %%", "some alpha thing %");
+	CHECK_PL("some %b thing %%", "some beta thing %");
+	CHECK_PL("some %c thing %%", "some charlie thing %");
+	CHECK_PL("some %C thing %%", "some Charlie thing %");
+	CHECK_PL("some %d thing %%", "some 42 thing %");
+	CHECK_PL("some %f thing %%", "some 4.200000 thing %");
+	CHECK_PL("some %g thing %%", "some 4.2 thing %");
+	/* Unknown placeholder, left as-is */
+	CHECK_PL("some %z thing %%", "some %z thing %");
+
+#undef CHECK_PL
+}
+
 static void test_utils_replace_document_placeholders(void)
 {
 #define CHECK_DOC_PL(src, result) \
@@ -471,6 +521,7 @@ int main(int argc, char **argv)
 	UTIL_TEST_ADD("strv_find_lcs", test_utils_strv_find_lcs);
 	UTIL_TEST_ADD("strv_shorten_file_list", test_utils_strv_shorten_file_list);
 	UTIL_TEST_ADD("get_initals", test_utils_get_initials);
+	UTIL_TEST_ADD("replace_placeholders", test_utils_replace_placeholders);
 	UTIL_TEST_ADD("replace_document_placeholders", test_utils_replace_document_placeholders);
 
 	return g_test_run();

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -498,12 +498,12 @@ static void test_utils_replace_document_placeholders(void)
 	CHECK_DOC_PL("some %%f thing %%%", "some %f thing %%");
 	CHECK_DOC_PL("some %%f thing %%%%", "some %f thing %%");
 	CHECK_DOC_PL("some %%f thing %%%%%", "some %f thing %%%");
-	/* We give a NULL doc, so replacements are not made */
-	CHECK_DOC_PL("some %d thing %%", "some %d thing %");
-	CHECK_DOC_PL("some %e thing %%", "some %e thing %");
-	CHECK_DOC_PL("some %f thing %%", "some %f thing %");
-	CHECK_DOC_PL("some %l thing %%", "some %l thing %");
-	CHECK_DOC_PL("some %p thing %%", "some %p thing %");
+	/* We give a NULL doc, so replacements are empty */
+	CHECK_DOC_PL("some %d thing %%", "some  thing %");
+	CHECK_DOC_PL("some %e thing %%", "some  thing %");
+	CHECK_DOC_PL("some %f thing %%", "some  thing %");
+	CHECK_DOC_PL("some %l thing %%", "some  thing %");
+	CHECK_DOC_PL("some %p thing %%", "some  thing %");
 	/* Unknown placeholder, left as-is */
 	CHECK_DOC_PL("some %z thing %%", "some %z thing %");
 

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -1,4 +1,5 @@
 
+#include "main.h"
 #include "utils.h"
 
 #include "gtkcompat.h"
@@ -430,15 +431,47 @@ static void test_utils_get_initials(void)
 #undef CHECK_INITIALS
 }
 
+static void test_utils_replace_document_placeholders(void)
+{
+#define CHECK_DOC_PL(src, result) \
+	G_STMT_START {													\
+		gchar *r = utils_replace_document_placeholders(NULL, src);	\
+		g_assert_cmpstr(r, ==, result);								\
+		g_free(r);													\
+	} G_STMT_END
+
+	CHECK_DOC_PL("some thing", "some thing");
+	CHECK_DOC_PL("some %% thing", "some % thing");
+	/* a trailing % is kept */
+	CHECK_DOC_PL("some %% thing %", "some % thing %");
+	CHECK_DOC_PL("some %%f thing %%", "some %f thing %");
+	CHECK_DOC_PL("some %%f thing %%%", "some %f thing %%");
+	CHECK_DOC_PL("some %%f thing %%%%", "some %f thing %%");
+	CHECK_DOC_PL("some %%f thing %%%%%", "some %f thing %%%");
+	/* We give a NULL doc, so replacements are not made */
+	CHECK_DOC_PL("some %d thing %%", "some %d thing %");
+	CHECK_DOC_PL("some %e thing %%", "some %e thing %");
+	CHECK_DOC_PL("some %f thing %%", "some %f thing %");
+	CHECK_DOC_PL("some %l thing %%", "some %l thing %");
+	CHECK_DOC_PL("some %p thing %%", "some %p thing %");
+	/* Unknown placeholder, left as-is */
+	CHECK_DOC_PL("some %z thing %%", "some %z thing %");
+
+#undef CHECK_DOC_PL
+}
+
 int main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
+
+	main_init_headless();
 
 	UTIL_TEST_ADD("strv_join", test_utils_strv_new);
 	UTIL_TEST_ADD("strv_find_common_prefix", test_utils_strv_find_common_prefix);
 	UTIL_TEST_ADD("strv_find_lcs", test_utils_strv_find_lcs);
 	UTIL_TEST_ADD("strv_shorten_file_list", test_utils_strv_shorten_file_list);
 	UTIL_TEST_ADD("get_initals", test_utils_get_initials);
+	UTIL_TEST_ADD("replace_document_placeholders", test_utils_replace_document_placeholders);
 
 	return g_test_run();
 }


### PR DESCRIPTION
* Fix `%p` replacement in build (and print external) commands when no project is open (#4314)
* Fix replacing placeholders in replacements.  This happened for a long time, but in could cause fairly annoying issues if the replacement did contain a placeholder in an unexpected fashion, and that's usually unexpected with paths and alike.
* Support `%%` to insert a literal `%` in build formats.
* Use the same algorithm implementation for build, external print command and statusbar format strings.  This actually fixes a corner case in the statusbar implementation that would repeat part of the format if the format ended with `%`.
* Add test code for the algorithm.

---

If this is too many changes close to a release (although most of them are either legitimately useful, or smaller than they might look at first glance), I can leave out e.g. the `ui_statusbar_update()` changes that are not actually part of an original intended fix.  The only fix there is handling a trailing `%`, but it's not of huge importance, and is trivial to fix in the previous code.

But we need to fix `%p` before 2.1 at the very least.

## Hints for review

* in *ui_utils.c* (278d1901fe28bc6be7d368e4c5a6c056ec485511), check the diff ignoring whitespace changes.  A lot of it had little changes but has been unindented 1 level.
* in *utils.c*, maybe check the before and after rather than the diff itself, that looks way more confusing because of the few coincidentally identical lines, whereas the algorithm is just entirely different.