### PR TITLE
CI: show test logs on test failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,13 @@ jobs:
       - name: Run Tests
         run: |
           cd _build
-          make -j ${{ env.JOBS }} check
+          make -j ${{ env.JOBS }} check || {                            \
+            err="$?";                                                   \
+            echo "make exited with code $err" >&2;                      \
+            echo "Test suite logs:" >&2;                                \
+            find tests/ -name 'test-suite.log' -exec cat '{}' ';' >&2;  \
+            exit "${err:-1}";                                           \
+          }
 
       - name: Run distcheck
         run: |


### PR DESCRIPTION
As Autotools don't show the full error on test suite failure, manually show the relevant log files.  Example showing the result: https://github.com/geany/geany/actions/runs/15373890993/job/43256494593?pr=4303 (as this PR builds OK and thus don't show the difference)