### PR TITLE
Drop win32_open_browser()

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -89,17 +89,16 @@
 # define GEANY_DEFAULT_USE_NATIVE_DLGS	FALSE
 #endif
 #ifdef __APPLE__
-#define GEANY_DEFAULT_TOOLS_BROWSER		"open -a safari"
 #define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Helvetica Medium 12"
 #define GEANY_DEFAULT_FONT_MSG_WINDOW	"Menlo Medium 12"
 #define GEANY_DEFAULT_FONT_EDITOR		"Menlo Medium 12"
 #else
-/* Browser chosen by GTK */
-#define GEANY_DEFAULT_TOOLS_BROWSER		""
 #define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Sans 9"
 #define GEANY_DEFAULT_FONT_MSG_WINDOW	"Monospace 9"
 #define GEANY_DEFAULT_FONT_EDITOR		"Monospace 10"
 #endif
+/* Browser chosen by GTK */
+#define GEANY_DEFAULT_TOOLS_BROWSER		""
 #define GEANY_DEFAULT_TOOLS_PRINTCMD	"lpr"
 #define GEANY_DEFAULT_TOOLS_GREP		"grep"
 #define GEANY_DEFAULT_MRU_LENGTH		10

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1885,6 +1885,11 @@ void prefs_show_dialog(void)
 			NULL,
 			GTK_FILE_CHOOSER_ACTION_OPEN,
 			GTK_ENTRY(ui_lookup_widget(ui_widgets.prefs_dialog, "entry_browser")));
+#ifdef G_OS_WIN32
+		/* Browser isn't configurable on Windows, see utils_open_browser() */
+		gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "entry_browser"), FALSE);
+		gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "button_browser"), FALSE);
+#endif
 		ui_setup_open_button_callback(ui_lookup_widget(ui_widgets.prefs_dialog, "button_grep"),
 			NULL,
 			GTK_FILE_CHOOSER_ACTION_OPEN,

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1888,6 +1888,8 @@ void prefs_show_dialog(void)
 #ifdef G_OS_WIN32
 		/* Browser isn't configurable on Windows, see utils_open_browser() */
 		gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "entry_browser"), FALSE);
+		gtk_widget_set_tooltip_text(ui_lookup_widget(ui_widgets.prefs_dialog, "entry_browser"),
+			_("Not configurable on Windows (the system default browser is used)."));
 		gtk_widget_set_sensitive(ui_lookup_widget(ui_widgets.prefs_dialog, "button_browser"), FALSE);
 #endif
 		ui_setup_open_button_callback(ui_lookup_widget(ui_widgets.prefs_dialog, "button_grep"),

--- a/src/utils.c
+++ b/src/utils.c
@@ -78,7 +78,7 @@ void utils_open_browser(const gchar *uri)
 {
 #ifdef G_OS_WIN32
 	g_return_if_fail(uri != NULL);
-	win32_open_browser(uri);
+	gtk_show_uri_on_window(GTK_WINDOW(main_widgets.window), uri, GDK_CURRENT_TIME, NULL);
 #else
 	gchar *new_cmd, *argv[2] = { (gchar *) uri, NULL };
 

--- a/src/win32.c
+++ b/src/win32.c
@@ -77,30 +77,6 @@ gint win32_check_write_permission(const gchar *dir)
 }
 
 
-/* Just a simple wrapper function to open a browser window */
-void win32_open_browser(const gchar *uri)
-{
-	gint ret;
-	if (strncmp(uri, "file://", 7) == 0)
-	{
-		uri += 7;
-		if (strchr(uri, ':') != NULL)
-		{
-			while (*uri == '/')
-				uri++;
-		}
-	}
-	ret = (gint) ShellExecute(NULL, "open", uri, NULL, NULL, SW_SHOWNORMAL);
-	if (ret <= 32)
-	{
-		gchar *err = g_win32_error_message(GetLastError());
-		ui_set_statusbar(TRUE, _("Failed to open URI \"%s\": %s"), uri, err);
-		g_warning("ShellExecute failed opening \"%s\" (code %d): %s", uri, ret, err);
-		g_free(err);
-	}
-}
-
-
 static FILE *open_std_handle(DWORD handle, const char *mode)
 {
 	HANDLE lStdHandle;

--- a/src/win32.h
+++ b/src/win32.h
@@ -30,9 +30,6 @@
 
 G_BEGIN_DECLS
 
-void win32_open_browser(const gchar *uri);
-
-
 gint win32_check_write_permission(const gchar *dir);
 
 void win32_init_debug_code(void);


### PR DESCRIPTION
On Windows, I get

```
21:15:27: Failed to open URI "C:/Program Files/Geany/share/doc/geany/html/index.html#general-startup-preferences": The system cannot find the file specified.
```

when pressing the Help button from the Preferences dialog (probably because space isn't escaped). Escaping the URI should fix the problem.