### PR TITLE
Fix project base path button when using native dialogs

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -508,7 +508,7 @@ static void on_project_properties_base_path_button_clicked(GtkWidget *button,
 			GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
 			NULL));
 
-	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT)
+	if (dialogs_file_chooser_run(dialog) == GTK_RESPONSE_ACCEPT)
 	{
 		gtk_entry_set_text(GTK_ENTRY(base_path_entry),
 			gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));


### PR DESCRIPTION
The button next to the

Project->Properties->Base path

entry doesn't work when using "platform-native" dialogs because of forgotten use of "universal dialog run" function. Fix that.