### PR TITLE
Use Consolas as the default font on Windows

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -81,21 +81,21 @@
 #ifdef G_OS_WIN32
 # define GEANY_DEFAULT_TOOLS_TERMINAL	"cmd.exe /Q /C %c"
 # define GEANY_DEFAULT_USE_NATIVE_DLGS	TRUE
+# define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Sans 9"
+# define GEANY_DEFAULT_FONT_MSG_WINDOW	"Consolas 9"
+# define GEANY_DEFAULT_FONT_EDITOR		"Consolas 10"
 #elif defined(__APPLE__)
 # define GEANY_DEFAULT_TOOLS_TERMINAL	"open -a terminal %c"
 # define GEANY_DEFAULT_USE_NATIVE_DLGS	TRUE
+# define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Helvetica Medium 12"
+# define GEANY_DEFAULT_FONT_MSG_WINDOW	"Menlo Medium 12"
+# define GEANY_DEFAULT_FONT_EDITOR		"Menlo Medium 12"
 #else
 # define GEANY_DEFAULT_TOOLS_TERMINAL	"xterm -e \"/bin/sh %c\""
 # define GEANY_DEFAULT_USE_NATIVE_DLGS	FALSE
-#endif
-#ifdef __APPLE__
-#define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Helvetica Medium 12"
-#define GEANY_DEFAULT_FONT_MSG_WINDOW	"Menlo Medium 12"
-#define GEANY_DEFAULT_FONT_EDITOR		"Menlo Medium 12"
-#else
-#define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Sans 9"
-#define GEANY_DEFAULT_FONT_MSG_WINDOW	"Monospace 9"
-#define GEANY_DEFAULT_FONT_EDITOR		"Monospace 10"
+# define GEANY_DEFAULT_FONT_SYMBOL_LIST	"Sans 9"
+# define GEANY_DEFAULT_FONT_MSG_WINDOW	"Monospace 9"
+# define GEANY_DEFAULT_FONT_EDITOR		"Monospace 10"
 #endif
 /* Browser chosen by GTK */
 #define GEANY_DEFAULT_TOOLS_BROWSER		""


### PR DESCRIPTION
By default, the monospaced font on Windows is Courier New which isn't exactly the nicest font for development because of the serifs (plus it is rendered extremely thin on HiDPI displays). I expect that the first thing everyone has to do on Windows is to change this font to something else.

Since Windows Vista, Microsoft seems to ship a "modern" sans-serif monospaced font called Consolas which looks as a much better font for coding.

The rest of the patch just moves existing font configuration for other platforms under a single ifdef/elif/else.

For more information about Courier New and Consolas, see

https://learn.microsoft.com/en-us/typography/font-list/consolas
https://learn.microsoft.com/en-us/typography/font-list/courier-new

This is how Courier New looks on a HiDPI machine with the default Geany configuration:
![Screenshot 2025-06-09 at 22 31 11](https://github.com/user-attachments/assets/1a4d2e95-1ce5-4ee3-8802-2867a4b339ea)

The same with Consolas:
![Screenshot 2025-06-09 at 22 32 37](https://github.com/user-attachments/assets/57cb014d-788d-4d07-9ea5-0b852b797ce2)

Am I right to assume that supporting Windows Vista is enough? Geany requires a 64bit system on Windows and even though there is some Windows XP version supporting it, it was never mainstream and maybe Geany doesn't even support it.
