### PR TITLE
saveactions: Fix mnemonic not activating the right widget

### DIFF
--- a/plugins/saveactions.c
+++ b/plugins/saveactions.c
@@ -1540,7 +1540,6 @@ GtkWidget *plugin_configure(GtkDialog *dialog)
 		persistent_radio = gtk_radio_button_new_with_mnemonic_from_widget(
 			GTK_RADIO_BUTTON(disabled_radio), _("Persistent Untitled Documents"));
 		pref_widgets.untitled_doc_persistent_radio = persistent_radio;
-		gtk_label_set_mnemonic_widget(GTK_LABEL(label), persistent_radio);
 		gtk_button_set_focus_on_click(GTK_BUTTON(persistent_radio), FALSE);
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(persistent_radio), enable_persistent_docs);
 		gtk_container_add(GTK_CONTAINER(inner_vbox), persistent_radio);


### PR DESCRIPTION
`label` is the *Directory to save files in* at this point, there's not reason it would activate an unrelated radio button (that can have its own mnemonic).  This also breaks focusing the expected widget, as the new target overrides the previously set one.