### PR TITLE
Show parsed file name in error messages related to invalid promises

### DIFF
--- a/ctags/main/promise.c
+++ b/ctags/main/promise.c
@@ -16,6 +16,7 @@
 #include "promise_p.h"
 #include "ptrarray.h"
 #include "debug.h"
+#include "read.h"
 #include "read_p.h"
 #include "trashbox.h"
 #include "xtag.h"
@@ -70,7 +71,8 @@ static bool havePromise (const struct promise *p)
 		if (p->lang == q->lang &&
 			p->startLine == q->startLine && p->startCharOffset == q->startCharOffset)
 		{
-			error (WARNING, "redundant promise: %s start(line: %lu, offset: %ld, srcline: %lu), end(line: %lu, offset: %ld)",
+			error (WARNING, "redundant promise when parsing %s: %s start(line: %lu, offset: %ld, srcline: %lu), end(line: %lu, offset: %ld)",
+			       getInputFileName (),
 			       q->lang != LANG_IGNORE? getLanguageName(q->lang): "*",
 			       q->startLine, q->startCharOffset, q->sourceLineOffset,
 			       q->endLine, q->endCharOffset);

--- a/ctags/main/read.c
+++ b/ctags/main/read.c
@@ -1239,9 +1239,9 @@ extern bool   pushNarrowedInputStream (
 	return true;
 
 fail:
-	error (WARNING, "Failed to push narrowed input stream: IO error or invalid offsets: "
+	error (WARNING, "Failed to push narrowed input stream when parsing %s: IO error or invalid offsets: "
 	       "start(line: %lu, offset: %ld, srcline: %lu), end(line: %lu, offset: %ld)",
-	       startLine, startCharOffset, sourceLineOffset, endLine, endCharOffset);
+	       getInputFileName (), startLine, startCharOffset, sourceLineOffset, endLine, endCharOffset);
 	mio_setpos (File.mio, &original);
 	return false;
 }


### PR DESCRIPTION
Possible solution for https://github.com/geany/geany/pull/4330#issuecomment-2974582727.