### PR TITLE
Move editor_goto_pos() to the end of document_new_file()

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -862,8 +862,6 @@ GeanyDocument *document_new_file(const gchar *utf8_filename, GeanyFiletype *ft, 
 	ui_document_show_hide(doc); /* update the document menu */
 
 	sci_set_line_numbers(doc->editor->sci, editor_prefs.show_linenumber_margin);
-	/* bring it in front, jump to the start and grab the focus */
-	editor_goto_pos(doc->editor, 0, FALSE);
 
 #ifdef USE_GIO_FILEMON
 	monitor_file_setup(doc);
@@ -878,6 +876,9 @@ GeanyDocument *document_new_file(const gchar *utf8_filename, GeanyFiletype *ft, 
 
 	msgwin_status_add(_("New file \"%s\" opened."),
 		DOC_FILENAME(doc));
+
+	/* bring it in front, jump to the start and grab the focus */
+	editor_goto_pos(doc->editor, 0, FALSE);
 
 	return doc;
 }


### PR DESCRIPTION
Within `editor_goto_pos()`, `document_show_tab()` is called which realizes the Scintilla widget.

This change:
1. Makes the code more similar to `document_open_file_full()` where `editor_goto_pos()` is called at the end as well.
2. Ensures that the editor is focused after creating a new file (which didn't get focused before).
3. Fixes the Overview plugin crash for when creating empty document made Geany crash after editor click.

To (3): I don't know how exactly this is fixed but when debugging the issue, I noticed that Scintilla's `realize()` gets called 3 times for new documents while only 2 times when opening existing documents (2 times makes sense - once for the editor widget, once for the overview view). After adding some traces, one `realize()` gets called when `editor_goto_pos()` is invoked and the other two after sending the `"document-new"` signal. I haven't investigated what exactly happens but since moving `editor_goto_pos()` fixes the problem and makes the code work more like `document_open_file_full()`, it's probably a "good" solution.

Fixes https://github.com/geany/geany-plugins/issues/1354 (by the means of magic)