### PR TITLE
Modify locate_sci_in_container() to only find document scintilla

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -296,7 +296,8 @@ gint document_get_notebook_page(GeanyDocument *doc)
 
 /*
  * Recursively searches a containers children until it finds a
- * Scintilla widget, or NULL if one was not found.
+ * Scintilla widget corresponding to an open document, or NULL if one was not
+ * found.
  */
 static ScintillaObject *locate_sci_in_container(GtkWidget *container)
 {
@@ -311,7 +312,9 @@ static ScintillaObject *locate_sci_in_container(GtkWidget *container)
 		if (IS_SCINTILLA(iter->data))
 		{
 			sci = SCINTILLA(iter->data);
-			break;
+			if (document_find_by_sci(sci))
+				break;
+			sci = NULL;
 		}
 		else if (GTK_IS_CONTAINER(iter->data))
 		{

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -98,6 +98,9 @@ static void on_notebook_switch_page(GtkNotebook *notebook,
 {
 	GeanyDocument *new;
 
+	if (gtk_notebook_get_n_pages(notebook) == 1)
+		return;
+
 	new = document_get_from_page(page_num);
 
 	/* insert the very first document (when adding the second document


### PR DESCRIPTION
Some plugins, such as Overview, place their own Scintilla inside the notebook in which case locate_sci_in_container() might find a scintilla widget not belonging to Geany.

Modify locate_sci_in_container() to also call document_find_by_sci() to verify whether the scintilla object belongs to Geany.

There seems to be some issue when there's a single notebook page (which also happens when adding files from a session) where we get a runtime error from document_get_from_page() called from on_notebook_switch_page() about NULL scintilla. I haven't investigated the exact reason but since the code inside on_notebook_switch_page() is only related to the MRU list which is kind of irrelevant for a single page, just skipping the rest of the function in this case fixes this issue.

Fixes https://github.com/geany/geany-plugins/issues/730
Fixes https://github.com/geany/geany-plugins/issues/1149
Fixes https://github.com/geany/geany-plugins/issues/1180