### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -595,11 +595,11 @@ highlightingmappings.h and add the following things:
 1. In highlightingmappings.h:
 
    a. define ``highlighting_lexer_FOO`` to the Scintilla lexer ID for
-      this filtype, e.g. ``SCLEX_CPP``.
+      this filetype, e.g. ``SCLEX_CPP``.
    b. define the ``highlighting_styles_FOO`` array that maps Scintilla
       style states to style names in the configuration file.
    c. define ``highlighting_keywords_FOO`` to ``EMPTY_KEYWORDS`` if the
-      filtype has no keywords, or as an ``HLKeyword`` array mapping
+      filetype has no keywords, or as an ``HLKeyword`` array mapping
       the Scintilla keyword IDs to names in the configuration file.
    d. define ``highlighting_properties_FOO`` to ``EMPTY_PROPERTIES``, or
       as an array of ``HLProperty`` if the filetype requires some lexer
@@ -607,7 +607,7 @@ highlightingmappings.h and add the following things:
       normally be set in the ``[lexer_properties]`` section of the
       configuration file instead.
 
-   You may look at other filtype's definitions for some examples
+   You may look at other filetype's definitions for some examples
    (Ada, CSS or Diff being good examples).
 
 2. In highlighting.c:

--- a/NEWS
+++ b/NEWS
@@ -2334,7 +2334,7 @@ Geany 0.12 (October 10, 2007)
     * Added Class Builder plugin (thanks to Alexander Rodin).
     * Added Export plugin to export current file as HTML or LaTeX.
 
-    Keyboard shorcuts:
+    Keyboard shortcuts:
     * Common bash Ctrl-[a-z] keyboard shortcuts now work when the VTE is
       focused, and there is an 'enable_bash_keys' hidden preference.
     * Added 'Move document left' and 'Move document right' keybindings.
@@ -2473,7 +2473,7 @@ Geany 0.11 (May 21, 2007)
       in .gtkrc-2.0.
     * Add context actions to run custom commands on current selection
       or the current word below cursor.
-    * Add different auto indention modes.
+    * Add different auto indentation modes.
     * Improve replacing in rectangle selections.
     * Add custom commands to send selected text through some definable
       commands and replace the selection with the output.
@@ -2757,7 +2757,7 @@ Geany 0.5 (January 27, 2006)
           the current file (thanks to Nick Treleaven for this patch)
         * fixed some bugs when opening files with non UTF-8 filenames
         * updated included Scintilla to version 1.67
-        * improved auto indention, now "for (...) {" works, too
+        * improved auto indentation, now "for (...) {" works, too
         * added popup menu to sidebar lists, to quickly hide them
         * symbol list support for filetypes LaTeX and DocBook
         * added .cc, .hh and .hxx extension for filetype C++

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -574,7 +574,7 @@ If a document is saved via `Document->Save As...` then the filename is
 automatically inserted into the comment header replacing text like
 `untitled.ext` in the first 3 lines of the file. E.g. if a new ``.c``
 file is created using `File->New (with Template)` then the text `untitled.c`
-in line 2 would be replaced with the choosen file name on `Save As...`
+in line 2 would be replaced with the chosen file name on `Save As...`
 (this example assumes the default file templates being used).
 
 
@@ -2352,7 +2352,7 @@ Invert syntax highlighting colors
     Invert all colors, by default this makes white text on a black
     background.
 
-Show indendation guides
+Show indentation guides
     Show vertical lines to help show how much leading indentation there
     is on each line.
 
@@ -4751,7 +4751,7 @@ line_wrap_visuals
     * 2 -- Visual flag at begin of subline of a wrapped line. Subline is
       indented by at least 1 to make room for the flag.
 
-    Second argument: wether the visual flags to indicate a line is wrapped
+    Second argument: whether the visual flags to indicate a line is wrapped
     are drawn near the border or near the text. This is a bitmask of the values:
 
     * 0 -- Visual flags drawn near border
@@ -5396,7 +5396,7 @@ in Geany.
 
 The created backup copy file permissions are set to read-write only for
 the user. This should help to not create world-readable files on possibly
-unsecure destination directories like /tmp (especially useful
+insecure destination directories like /tmp (especially useful
 on multi-user systems).
 This applies only to non-Windows systems. On Windows, no explicit file
 permissions are set.

--- a/geany.nsi.in
+++ b/geany.nsi.in
@@ -439,7 +439,7 @@ Function un.onInit
 	${if} $Answer == "yes"
 		SetShellVarContext all
 	${else}
-		; check if the Geany has been installed with admin permisions
+		; check if the Geany has been installed with admin permissions
 		ReadRegStr $0 HKLM "${PRODUCT_UNINST_KEY}" "Publisher"
 		${if} $0 != ""
 			MessageBox MB_OK|MB_ICONSTOP "You need administrator privileges to uninstall Geany!" \

--- a/plugins/demoplugin.c
+++ b/plugins/demoplugin.c
@@ -148,7 +148,7 @@ static gboolean demo_init(GeanyPlugin *plugin, gpointer data)
 	 * GEANY_PLUING_REGISTER_FULL() or geany_plugin_set_data() by default (unless the data pointer
 	 * was set to non-NULL at compile time).
 	 * This is really only done for demoing PluginCallback. Actual plugins will use real custom
-	 * data and perhaps embed the GeanyPlugin or GeanyData pointer their if they also use
+	 * data and perhaps embed the GeanyPlugin or GeanyData pointer there if they also use
 	 * PluginCallback. */
 	geany_plugin_set_data(plugin, plugin, NULL);
 	return TRUE;

--- a/plugins/htmlchars.c
+++ b/plugins/htmlchars.c
@@ -402,7 +402,7 @@ static const gchar *get_entity(gchar *letter)
 
 	len = G_N_ELEMENTS(chars);
 
-	/* Ignore tags marking caracters as well as spaces*/
+	/* Ignore tags marking characters as well as spaces */
 	for (i = 7; i < len; i++)
 	{
 		if (utils_str_equal(chars[i][0], letter) &&
@@ -570,7 +570,7 @@ static void sc_fill_store(GtkTreeStore *store)
 }
 
 
-/* just inserts the HTML_NAME coloumn of the selected row at current position
+/* just inserts the HTML_NAME column of the selected row at current position
  * returns only TRUE if a valid selection(i.e. no category) could be found */
 static gboolean sc_insert(GtkTreeModel *model, GtkTreeIter *iter)
 {

--- a/plugins/saveactions.c
+++ b/plugins/saveactions.c
@@ -265,7 +265,7 @@ static void backupcopy_document_save_cb(GObject *obj, GeanyDocument *doc, gpoint
 	if ((dst = g_fopen(locale_filename_dst, "wb")) == NULL)
 #else
 	/* Use g_open() on non-Windows to set file permissions to 600 atomically.
-	 * On Windows, seting file permissions would require specific Windows API. */
+	 * On Windows, setting file permissions would require specific Windows API. */
 	fd_dst = g_open(locale_filename_dst, O_CREAT | O_WRONLY, S_IWUSR | S_IRUSR);
 	if (fd_dst == -1 || (dst = fdopen(fd_dst, "w")) == NULL)
 #endif
@@ -668,7 +668,7 @@ static gboolean load_all_persistent_docs_idle(gpointer data)
 
 static gboolean reload_persistent_docs_on_session_change_idle(gpointer data)
 {
-	/* remember and re-open document from originaly focused tab
+	/* remember and re-open document from originally focused tab
 	(after we mess selected tab with re-loaded untitled doc files) */
 	GeanyDocument *current_doc = document_get_current();
 

--- a/src/build.c
+++ b/src/build.c
@@ -2303,7 +2303,7 @@ static void assign_cmd(GeanyBuildCommand *type, guint id,
 }
 
 /* for the specified source load new format build menu items or try to make some sense of
- * old format setings, not done perfectly but better than ignoring them */
+ * old format settings, not done perfectly but better than ignoring them */
 void build_load_menu(GKeyFile *config, GeanyBuildSource src, gpointer p)
 {
 	GeanyFiletype *ft;

--- a/src/document.c
+++ b/src/document.c
@@ -1924,7 +1924,7 @@ static gchar *write_data_to_disk(const gchar *locale_filename,
 
 	if (file_prefs.use_safe_file_saving)
 	{
-		/* Use old GLib API for safe saving (GVFS-safe, but alters ownership and permissons).
+		/* Use old GLib API for safe saving (GVFS-safe, but alters ownership and permissions).
 		 * This is the only option that handles disk space exhaustion. */
 		if (g_file_set_contents(locale_filename, data, len, &error))
 			geany_debug("Wrote %s with g_file_set_contents().", locale_filename);
@@ -2891,7 +2891,7 @@ void document_set_encoding(GeanyDocument *doc, const gchar *new_encoding)
 
 
 /* own Undo / Redo implementation to be able to undo / redo changes
- * to the encoding or the Unicode BOM (which are Scintilla independet).
+ * to the encoding or the Unicode BOM (which are Scintilla independent).
  * All Scintilla events are stored in the undo / redo buffer and are passed through. */
 
 /* Clears an Undo or Redo buffer. */

--- a/src/documentprivate.h
+++ b/src/documentprivate.h
@@ -108,7 +108,7 @@ typedef struct GeanyDocumentPrivate
 	/* Whether it's temporarily protected (read-only and saving needs confirmation). Does
 	 * not imply doc->readonly as writable files can be protected */
 	gint			 protected;
-	/* Save pointer to info bars allowing to cancel them programatically (to avoid multiple ones) */
+	/* Save pointer to info bars allowing to cancel them programmatically (to avoid multiple ones) */
 	GtkWidget		*info_bars[NUM_MSG_TYPES];
 	/* Keyed Data List to attach arbitrary data to the document */
 	GData			*data;

--- a/src/encodings.c
+++ b/src/encodings.c
@@ -182,7 +182,7 @@ static gboolean encodings_charset_equals(const gchar *a, const gchar *b)
 		if (g_ascii_toupper(*a) == g_ascii_toupper(*b) &&
 			((is_alpha = g_ascii_isalpha(*a)) || g_ascii_isdigit(*a)))
 		{
-			/* either there was a real separator, or we need a implicit one (a chage from alpha to
+			/* either there was a real separator, or we need a implicit one (a change from alpha to
 			 * numeric or so) */
 			if (! need_sep || (was_alpha != is_alpha))
 			{

--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -594,7 +594,7 @@ static void set_character_classes(ScintillaObject *sci, guint ft_id)
 	SSM(sci, SCI_SETWORDCHARS, 0, (sptr_t) word);
 
 	/* setting wordchars resets character classes, so we have to set whitespaces after
-	 * wordchars, but we want wordchars to have precenence over whitepace chars */
+	 * wordchars, but we want wordchars to have precedence over whitepace chars */
 	whitespace = g_malloc0(strlen(whitespace_chars) + 1);
 	for (i = 0, j = 0; whitespace_chars[i] != 0; i++)
 	{

--- a/src/highlightingmappings.h
+++ b/src/highlightingmappings.h
@@ -30,7 +30,7 @@
 
 G_BEGIN_DECLS
 
-/* contains all filtypes informations in the form of:
+/* contains all filetypes information in the form of:
  *  - highlighting_lexer_LANG:		the SCI lexer
  *  - highlighting_styles_LANG:		SCI style/named style mappings.  The first
  * 									item is also used for the default style.

--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -795,7 +795,7 @@ static void load_recent_files(GKeyFile *config, GQueue *queue, const gchar *key)
 
 
 /*
- * Load session list from the given keyfile and return an array containg the file names
+ * Load session list from the given keyfile and return an array containing the file names
  * */
 GPtrArray *configuration_load_session_files(GKeyFile *config)
 {

--- a/src/navqueue.c
+++ b/src/navqueue.c
@@ -205,7 +205,7 @@ void navqueue_go_back(void)
 		/* see also https://github.com/geany/geany/pull/1537 */
 		g_warning("Attempted navigation when nothing is open");
 
-	/* return if theres no place to go back to */
+	/* return if there's no place to go back to */
 	if (g_queue_is_empty(navigation_queue) ||
 		nav_queue_pos >= g_queue_get_length(navigation_queue) - 1)
 		return;

--- a/src/plugindata.h
+++ b/src/plugindata.h
@@ -231,7 +231,7 @@ typedef struct GeanyProxyFuncs GeanyProxyFuncs;
 typedef struct GeanyPlugin
 {
 	PluginInfo	*info;	/**< Fields set in plugin_set_info(). */
-	GeanyData	*geany_data;	/**< Pointer to global GeanyData intance */
+	GeanyData	*geany_data;	/**< Pointer to global GeanyData instance */
 	GeanyPluginFuncs *funcs;	/**< Functions implemented by the plugin, set in geany_load_module() */
 	GeanyProxyFuncs	*proxy_funcs; /**< Hooks implemented by the plugin if it wants to act as a proxy
 									   Must be set prior to calling geany_plugin_register_proxy() */

--- a/src/pluginextension.h
+++ b/src/pluginextension.h
@@ -72,7 +72,7 @@ typedef struct
 	 * @param data User data passed during the @c plugin_extension_register()
 	 * call.
 	 *
-	 * @return Plugins should return @c TRUE if they impelment autocompletion
+	 * @return Plugins should return @c TRUE if they implement autocompletion
 	 * for the provided document, @c FALSE otherwise.
 	 *
 	 * @since 2.1

--- a/src/pluginutils.c
+++ b/src/pluginutils.c
@@ -187,7 +187,7 @@ void plugin_signal_connect(GeanyPlugin *plugin,
 typedef struct PluginSourceData
 {
 	Plugin		*plugin;
-	GList		list_link;	/* element of plugin->sources cointaining this GSource */
+	GList		list_link;	/* element of plugin->sources containing this GSource */
 	GSourceFunc	function;
 	gpointer	user_data;
 } PluginSourceData;

--- a/src/prefix.h
+++ b/src/prefix.h
@@ -50,7 +50,7 @@ G_BEGIN_DECLS
 #define br_prepend_prefix BR_NAMESPACE(br_prepend_prefix)
 
 #ifndef BR_NO_MACROS
-	/* These are convience macros that replace the ones usually used
+	/* These are convenience macros that replace the ones usually used
 	   in Autoconf/Automake projects */
 	#undef SELFPATH
 	#undef PREFIX

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -214,7 +214,7 @@ static gchar *spawn_get_program_name(const gchar *command_line, GError **error)
  *
  *  Unix:
  *     - the standard shell quoting and escaping rules are used, see @c g_shell_parse_argv()
- *     - as a consequence, an unqouted # at the start of an argument comments to the end of line
+ *     - as a consequence, an unquoted # at the start of an argument comments to the end of line
  *
  *  Windows:
  *     - leading carriage returns are skipped too
@@ -543,7 +543,7 @@ static gboolean spawn_async_with_pipes(const gchar *working_directory, const gch
 		}
 		else
 		{
-			/* quote the first token, to avoid Windows attemps to run two or more
+			/* quote the first token, to avoid Windows attempts to run two or more
 			   unquoted tokens as a program until an existing file name is found */
 			g_string_printf(command, "\"%s\"", program);
 		}
@@ -898,7 +898,7 @@ static gboolean spawn_timeout_read_cb(gpointer data)
 {
 	SpawnChannelData *sc = (SpawnChannelData *) data;
 
-	/* The solution for continuous empty G_IO_IN-s is to generate them outselves. :) */
+	/* The solution for continuous empty G_IO_IN-s is to generate them ourselves. :) */
 	return spawn_read_cb(sc->channel, G_IO_IN, data);
 }
 

--- a/src/stash.c
+++ b/src/stash.c
@@ -594,7 +594,7 @@ static void handle_spin_button(GtkWidget *widget, StashPref *entry,
 			gtk_spin_button_set_value(GTK_SPIN_BUTTON(widget), *setting);
 			break;
 		case PREF_UPDATE:
-			/* if the widget is focussed, the value might not be updated */
+			/* if the widget is focused, the value might not be updated */
 			gtk_spin_button_update(GTK_SPIN_BUTTON(widget));
 			*setting = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
 			break;

--- a/src/tagmanager/tm_tag.c
+++ b/src/tagmanager/tm_tag.c
@@ -136,7 +136,7 @@ static void tm_tag_destroy(TMTag *tag)
 void tm_tag_unref(TMTag *tag)
 {
 	/* be NULL-proof because tm_tag_free() was NULL-proof and we indent to be a
-	 * drop-in replacment of it */
+	 * drop-in replacement of it */
 	if (NULL != tag && g_atomic_int_dec_and_test(&tag->refcount))
 	{
 		tm_tag_destroy(tag);
@@ -288,7 +288,7 @@ void tm_tags_dedup(GPtrArray *tags_array, TMTagAttrType *sort_attributes, gboole
 }
 
 /*
- Sort an array of tags on the specified attribuites using the inbuilt comparison
+ Sort an array of tags on the specified attributes using the inbuilt comparison
  function.
  @param tags_array The array of tags to be sorted
  @param sort_attributes Attributes to be sorted on (int array terminated by 0)
@@ -417,7 +417,7 @@ static GPtrArray *merge(GPtrArray *big_array, GPtrArray *small_array,
 			cmpnum++;
 #endif
 			/* if the value in big_array after making the big step is still smaller
-			 * than the value in small_array, we can copy all the values inbetween
+			 * than the value in small_array, we can copy all the values in-between
 			 * into the result without making expensive string comparisons */
 			if (tm_tag_compare(&val1, &val2, sort_options) < 0)
 			{

--- a/src/tagmanager/tm_workspace.c
+++ b/src/tagmanager/tm_workspace.c
@@ -1046,7 +1046,7 @@ find_scope_members_tags (const GPtrArray *all, TMTag *type_tag, gboolean namespa
 	guint i;
 
 	if (depth == 10)
-		return NULL;  /* simple inheritence cycle avoidance */
+		return NULL;  /* simple inheritance cycle avoidance */
 
 	tags = g_ptr_array_new();
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -209,7 +209,7 @@ gboolean utils_is_opening_brace(gchar c, gboolean include_angles)
  * If it already exists, it will be overwritten.
  *
  * @warning Currently, this function uses g_file_replace_contents() to save
- * files which offers a reasonable balence between data safety during save
+ * files which offers a reasonable balance between data safety during save
  * and other factors such as handling symlinks, remote files, or platform-
  * dependent aspects. However, plugins with special requirements should
  * not rely on the exact implementation of this function and should rather
@@ -2065,7 +2065,7 @@ gchar **utils_strv_join(gchar **first, gchar **second)
 
 /* * Returns the common prefix in a list of strings.
  *
- * The size of the list may be given explicitely, but defaults to @c g_strv_length(strv).
+ * The size of the list may be given explicitly, but defaults to @c g_strv_length(strv).
  *
  * @param strv The list of strings to process.
  * @param strv_len The number of strings contained in @a strv. Can be -1 if it's terminated by @c NULL.
@@ -2101,7 +2101,7 @@ gchar *utils_strv_find_common_prefix(gchar **strv, gssize strv_len)
 
 /* * Returns the longest common substring in a list of strings.
  *
- * The size of the list may be given explicitely, but defaults to @c g_strv_length(strv).
+ * The size of the list may be given explicitly, but defaults to @c g_strv_length(strv).
  *
  * @param strv The list of strings to process.
  * @param strv_len The number of strings contained in @a strv. Can be -1 if it's terminated by @c NULL.
@@ -2176,7 +2176,7 @@ gchar *utils_strv_find_lcs(gchar **strv, gssize strv_len, const gchar *delim)
  * for dialogs which present the file list to the user, where the base name may result
  * in duplicates (showing the full path might be inappropriate).
  *
- * The algorthm strips the common prefix (e-g. the user's home directory) and
+ * The algorithm strips the common prefix (e-g. the user's home directory) and
  * replaces the longest common substring with an ellipsis ("...").
  *
  * @param file_names @array{length=file_names_len} The list of strings to process.
@@ -2225,7 +2225,7 @@ gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len)
 	}
 
 	/* Second: determine the longest common substring (lcs), that will be ellipsized. Again,
-	 * we look only for full path compnents so that we ellipsize between separators. This implies
+	 * we look only for full path components so that we ellipsize between separators. This implies
 	 * that the file name cannot be ellipsized which is desirable anyway.
 	 */
 	lcs = utils_strv_find_lcs(names, num, G_DIR_SEPARATOR_S"/");
@@ -2251,7 +2251,7 @@ gchar **utils_strv_shorten_file_list(gchar **file_names, gssize file_names_len)
 		{
 			const gchar *lcs_start = strstr(names[i], lcs);
 			const gchar *lcs_end = lcs_start + lcs_len;
-			/* Dir seperators are included in lcs but shouldn't be elipsized. */
+			/* Dir separators are included in lcs but shouldn't be elipsized. */
 			names[i] = g_strdup_printf("%.*s...%s", (int)(lcs_start - names[i] + 1), names[i], lcs_end - 1);
 		}
 	}


### PR DESCRIPTION
Mostly spotted by `codespell`.