### PR TITLE
Avoid introspecting widget hierarchy when obtaining doc from page

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -236,8 +236,6 @@ gboolean document_reload_prompt(GeanyDocument *doc, const gchar *forced_enc);
 
 void document_reload_config(GeanyDocument *doc);
 
-GeanyDocument *document_find_by_sci(ScintillaObject *sci);
-
 void document_show_tab(GeanyDocument *doc);
 void document_show_tab_idle(GeanyDocument *doc);
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -775,6 +775,8 @@ gint notebook_new_tab(GeanyDocument *this)
 	else
 		cur_page = 0;
 
+	/* used by document_get_from_notebook_child() */
+	g_object_set_data(G_OBJECT(vbox), "geany_document", this);
 	tabnum = gtk_notebook_insert_page_menu(GTK_NOTEBOOK(main_widgets.notebook), vbox,
 		ebox, NULL, cur_page);
 


### PR DESCRIPTION
This patch avoids widget hierarchy introspection to find GeanyDocument corresponding to a notebook tab widget by assigning it to the widget using g_object_set_data().

The previous method looking for the Scintilla widget would fail if the hierarchy contained another Scintilla widget coming e.g. from a plugin (such as the Overview plugin).

Replaces https://github.com/geany/geany/pull/4349

Fixes https://github.com/geany/geany-plugins/issues/730 
Fixes https://github.com/geany/geany-plugins/issues/1149 
Fixes https://github.com/geany/geany-plugins/issues/1180
