### PR TITLE
added signing test part to the workflow

### DIFF
--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -56,3 +56,21 @@ jobs:
           retention-days: 3
           overwrite: true
           if-no-files-found: error
+      - name: SignPath Signing
+        uses: signpath/github-action-submit-signing-request@v1.2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'cherrytree'
+          signing-policy-slug: 'test-signing'
+          github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: geany-signed
+      - name: Upload Signed Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: geany-signed
+          path: geany-signed
+          retention-days: 3
+          overwrite: true
+          if-no-files-found: error

--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
-          project-slug: 'cherrytree'
+          project-slug: 'geany'
           signing-policy-slug: 'test-signing'
           github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
           wait-for-completion: true

--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -1,5 +1,9 @@
 name: Windows/MSYS2 Build
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - 'windows-signing-tests'
 
 jobs:
   msys2-mingw64:


### PR DESCRIPTION
requires:
creating a secret with name SIGNPATH_API_TOKEN and content -> I will send you an email privately with this token
and
creating variable with name SIGNPATH_ORGANIZATION_ID and content -> I will send you an email privately with this id (Geany organisation ID in SignPath)
and install https://github.com/apps/signpath ( Required for [source code and build policies](https://about.signpath.io/documentation/trusted-build-systems/github#define-policies-for-source-code-and-builds): Install the [SignPath GitHub App](https://github.com/apps/signpath) and allow access to the code repositories. )
After merge I will need you to kick the Action workflow https://github.com/geany/geany/actions/workflows/windows-msys2-build.yml manually pointing to the correct branch windows-signing-tests (default is master)
