### PR TITLE
prefs: Show indentation warning without a project

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -3176,6 +3176,20 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkVBox" id="label_indent_warning">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkFrame" id="frame27">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -1818,7 +1818,7 @@ void prefs_show_dialog(void)
 		gtk_label_set_use_markup(GTK_LABEL(label), TRUE);
 		gtk_misc_set_padding(GTK_MISC(label), 6, 0);
 		gtk_box_pack_start(GTK_BOX(ui_lookup_widget(ui_widgets.prefs_dialog,
-			"label_project_indent_warning")), label, FALSE, TRUE, 5);
+			"label_indent_warning")), label, FALSE, TRUE, 5);
 
 		/* add the clear icon to GtkEntry widgets in the dialog */
 		{


### PR DESCRIPTION
This got broken in #4099, the label was moved to the box that is shown only when a project is open, but this note applies to all cases.