### PR TITLE
Run Windows installer workflow on new tags

### DIFF
--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -1,6 +1,9 @@
 name: Windows/MSYS2 Build
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - '*'
 
 jobs:
   msys2-mingw64:


### PR DESCRIPTION
Not sure how to test that without making an actual release, but should work according to https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions and https://github.com/orgs/community/discussions/25302