### PR TITLE
Vertical sidebar tabs

### DIFF
--- a/src/sidebar.c
+++ b/src/sidebar.c
@@ -1713,6 +1713,29 @@ static void on_sidebar_switch_page(GtkNotebook *notebook,
 }
 
 
+static void on_page_added(GtkNotebook *notebook, GtkWidget *child, guint page_num)
+{
+	GtkWidget *label = gtk_notebook_get_tab_label(notebook, child);
+	gtk_label_set_angle(GTK_LABEL(label), 90);
+
+	sidebar_tabs_show_hide(notebook, child, page_num, NULL);
+}
+
+
+static void rotate_all_tabs(void)
+{
+	GList *children = gtk_container_get_children(GTK_CONTAINER(main_widgets.sidebar_notebook));
+	GList *node;
+
+	for (node = children; node; node = node->next)
+	{
+		GtkWidget *label = gtk_notebook_get_tab_label(GTK_NOTEBOOK(main_widgets.sidebar_notebook), node->data);
+		gtk_label_set_angle(GTK_LABEL(label), 90);
+	}
+	g_list_free(children);
+}
+
+
 void sidebar_init(void)
 {
 	StashGroup *group;
@@ -1725,12 +1748,14 @@ void sidebar_init(void)
 	configuration_add_session_group(group, FALSE);
 	stash_group = group;
 
+	rotate_all_tabs();
+
 	/* Delay building documents treeview until sidebar font has been read and prefs are sanitized */
 	g_signal_connect(geany_object, "load-settings", on_load_settings, NULL);
 	g_signal_connect(geany_object, "save-settings", on_save_settings, NULL);
 
 	g_signal_connect(main_widgets.sidebar_notebook, "page-added",
-		G_CALLBACK(sidebar_tabs_show_hide), NULL);
+		G_CALLBACK(on_page_added), NULL);
 	g_signal_connect(main_widgets.sidebar_notebook, "page-removed",
 		G_CALLBACK(sidebar_tabs_show_hide), NULL);
 	/* tabs may have changed when sidebar is reshown */


### PR DESCRIPTION
I've been thinking whether it wouldn't be good to add a config option for having sidebar tab labels oriented vertically when placed on left/right. Currently, when using more tabs, they either
- have to be scrolled when placed at the top/bottom, or
- a lot of horizontal space is wasted when placed on the left/right

I think this new mode is a reasonable compromise giving space for more tabs and not wasting too much horizontal space (and I think other editors do something similar already so it wouldn't be too unexpected for users).

This patch is far from being complete, I'd just like some initial feedback regarding whether it's a good idea or not and whether there are any possible problems. There'd have to be a config option for this mode (to me, the simplest one is to add two more entries to the combo under Preferences->Interface->Notebook->Sidebar tabs such as `Left (vertical)`, `Right (vertical)`).

If you want to test this patch, update Preferences->Interface->Notebook->Sidebar to left/right first.

Some themes seem to add a bit too much padding to the tabs horizontally and some too little vertically so it might be necessary to do something about it in `geany.css`. I'm wondering if it's possible to do this only for this "vertical" mode, not affecting other tab modes. I've been thinking about setting a name for the notebook widget using `gtk_widget_set_name()` only for the vertical mode and clearing it for all other modes but I haven't tested yet if such a thing would work.

Thoughts?

The result would look something like this:

<img width="1438" height="1508" alt="Screenshot 2025-07-28 at 22 56 50" src="https://github.com/user-attachments/assets/5209cf05-2b03-4f20-8444-23f5b89f2b98" />
