### PR TITLE
Windows MSYS2 build to use new toolchain UCRT64

### DIFF
--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -1,6 +1,12 @@
 name: Windows/MSYS2 Build
 on:
   workflow_dispatch:
+    inputs:
+      sign_build:
+        description: 'Set to true to sign the build artifact.'
+        required: false
+        default: 'false'
+        type: boolean
 
 jobs:
   msys2-mingw64:
@@ -14,18 +20,18 @@ jobs:
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: UCRT64
           update: true
           install: |
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-autotools
-            mingw-w64-x86_64-gtk3
-            mingw-w64-x86_64-python-docutils
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-autotools
+            mingw-w64-ucrt-x86_64-gtk3
+            mingw-w64-ucrt-x86_64-python-docutils
             patch
             rsync
             unzip
             dos2unix
-            mingw-w64-x86_64-nsis
+            mingw-w64-ucrt-x86_64-nsis
       - name: GTK-Bundle
         run: |
           mkdir -p geany_build/bundle/geany-gtk
@@ -58,7 +64,8 @@ jobs:
           overwrite: true
           if-no-files-found: error
       - name: SignPath Signing
-        uses: signpath/github-action-submit-signing-request@v1.2
+        if: ${{ github.event.inputs.sign_build == 'true' }}
+        uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
@@ -68,6 +75,7 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: geany-signed
       - name: Upload Signed Artifact
+        if: ${{ github.event.inputs.sign_build == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: geany-signed

--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -7,6 +7,7 @@ on:
         required: false
         default: 'false'
         type: boolean
+  pull_request:
 
 jobs:
   msys2-mingw64:

--- a/scripts/gtk-bundle-from-msys2.sh
+++ b/scripts/gtk-bundle-from-msys2.sh
@@ -6,7 +6,7 @@
 # To be run within a MSYS2 shell. The extracted files will be
 # placed into the current directory.
 
-ABI=x86_64  # do not change, i686 is not supported any longer
+ABI="ucrt-x86_64"  # do not change, i686 is not supported any longer
 use_cache="no"
 make_zip="no"
 gtkv="3"
@@ -20,7 +20,7 @@ GTK_THEME_URL="https://github.com/geany/geany-osx/archive/refs/heads/master.zip"
 # Wine commands for 32bit and 64bit binaries (we still need 32bit for UnxUtils sort.exe)
 # Used only when "-x" is set
 EXE_WRAPPER_32="mingw-w64-i686-wine"
-EXE_WRAPPER_64="mingw-w64-x86_64-wine"
+EXE_WRAPPER_64="mingw-w64-ucrt-x86_64-wine"
 
 package_urls=""
 gtk3_dependency_pkgs=""
@@ -145,7 +145,7 @@ _getpkg() {
 	if [ "$use_cache" = "yes" ]; then
 		package_info=$(pacman -Qi mingw-w64-$ABI-$1)
 		package_version=$(echo "$package_info" | grep "^Version " | cut -d':' -f 2 | tr -d '[[:space:]]')
-		# use @(gz|xz|zst) to filter out signature files (e.g. mingw-w64-x86_64-...-any.pkg.tar.zst.sig)
+		# use @(gz|xz|zst) to filter out signature files (e.g. mingw-w64-ucrt-x86_64-...-any.pkg.tar.zst.sig)
 		ls $cachedir/mingw-w64-${ABI}-${1}-${package_version}-*.tar.@(gz|xz|zst) | sort -V | tail -n 1
 	else
 		case "$1" in


### PR DESCRIPTION
Windows MSYS2 build
- use new toolchain UCRT64
- be triggered also on PRs
- do not sign the artifact unless specified in the manually triggered workflow