### PR TITLE
Move "Send Selection To" menu item to Edit menu

### DIFF
--- a/data/geany.glade
+++ b/data/geany.glade
@@ -315,6 +315,14 @@
       </object>
     </child>
     <child>
+      <object class="GtkMenuItem" id="send_selection_to3">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">_Send Selection to</property>
+        <property name="use-underline">True</property>
+      </object>
+    </child>
+    <child>
       <object class="GtkImageMenuItem" id="insert1">
         <property name="label" translatable="yes">I_nsert</property>
         <property name="visible">True</property>
@@ -7049,30 +7057,24 @@ Supported placeholders are:
                                     <signal name="activate" handler="on_smart_line_indent1_activate" swapped="no"/>
                                   </object>
                                 </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuItem" id="send_selection_to2">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">_Send Selection to</property>
+                            <property name="use-underline">True</property>
+                            <child type="submenu">
+                              <object class="GtkMenu" id="send_selection_to2_menu">
+                                <property name="can-focus">False</property>
                                 <child>
-                                  <object class="GtkSeparatorMenuItem" id="separator37">
-                                    <property name="visible">True</property>
+                                  <object class="GtkMenuItem" id="invisible13">
                                     <property name="can-focus">False</property>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkMenuItem" id="send_selection_to2">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">_Send Selection to</property>
+                                    <property name="label" translatable="yes">invisible</property>
                                     <property name="use-underline">True</property>
-                                    <child type="submenu">
-                                      <object class="GtkMenu" id="send_selection_to2_menu">
-                                        <property name="can-focus">False</property>
-                                        <child>
-                                          <object class="GtkMenuItem" id="invisible13">
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">invisible</property>
-                                            <property name="use-underline">True</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
                                   </object>
                                 </child>
                               </object>

--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -909,8 +909,8 @@ Sending text through custom commands
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can define several custom commands in Geany and send the current
-selection to one of these commands using the *Edit->Format->Send
-Selection to* menu or keybindings. The output of the command will be
+selection to one of these commands using the *Edit->Send Selection to*
+menu or keybindings. The output of the command will be
 used to replace the current selection. This makes it possible to use
 text formatting tools with Geany in a general way.
 

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -883,6 +883,8 @@ static void init_document_widgets(void)
 	add_doc_widget("insert_date1");
 	add_doc_widget("insert_alternative_white_space1");
 	add_doc_widget("menu_format1");
+	add_doc_widget("send_selecion_to2");
+	add_doc_widget("send_selecion_to3");
 	add_doc_widget("commands2");
 	add_doc_widget("menu_open_selected_file1");
 	add_doc_widget("page_setup1");
@@ -2621,6 +2623,7 @@ void ui_init(void)
 		GeanySharedMenu arr[] = {
 			{"commands2_menu", "commands2", "commands1"},
 			{"menu_format1_menu", "menu_format1", "menu_format2"},
+			{"send_selection_to2_menu", "send_selection_to2", "send_selection_to3"},
 			{"more1_menu", "more1", "search2"},
 			{NULL, NULL, NULL}
 		};


### PR DESCRIPTION
This is my suggestion: move the "Send Selection To" menu item into the Edit menu directly, next to the Format menu item.

An alternative implementation could be to move the Format menu item out of the Edit menu as top level item, as suggested in #4394.

<img width="853" height="629" alt="Screenshot_2025-08-30_14-37-58" src="https://github.com/user-attachments/assets/a4816688-f08d-4404-9464-9aac7e96aa93" />
<img width="858" height="625" alt="Screenshot_2025-08-30_14-38-31" src="https://github.com/user-attachments/assets/65c7f7ff-cd8e-4e32-aa3a-dae963e56db4" />
