### PR TITLE
Fix interactive search in color scheme dialog

### DIFF
--- a/src/highlighting.c
+++ b/src/highlighting.c
@@ -1345,6 +1345,20 @@ static void on_color_scheme_dialog_response(GtkWidget *dialog,
 }
 
 
+static gboolean color_scheme_search_equal_func(GtkTreeModel *model,
+	gint column, const gchar *key, GtkTreeIter *iter, gpointer data)
+{
+	gchar *desc;
+	gboolean match;
+
+	gtk_tree_model_get(model, iter, SCHEME_MARKUP, &desc, -1);
+	match = utils_utf8_substring_match(key, desc);
+	g_free(desc);
+
+	return ! match;
+}
+
+
 void highlighting_show_color_scheme_dialog(void)
 {
 	static GtkWidget *dialog = NULL;
@@ -1368,6 +1382,8 @@ void highlighting_show_color_scheme_dialog(void)
 	g_object_unref(store);
 	gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(tree), TRUE);
 	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(tree), FALSE);
+	gtk_tree_view_set_search_equal_func(GTK_TREE_VIEW(tree),
+		color_scheme_search_equal_func, NULL, NULL);
 
 	text_renderer = gtk_cell_renderer_text_new();
 	g_object_set(text_renderer, "wrap-mode", PANGO_WRAP_WORD, NULL);


### PR DESCRIPTION
To interactively search in the color scheme dialog's TreeView, we need to have the color scheme name in the tree model as is without markup.

Closes #4480.