### PR TITLE
Add keybindindings to go to previous/next error indicator

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -3774,6 +3774,13 @@ Next message                                              Jumps to the line with
 Previous message                                          Jumps to the line with the previous message
                                                           in the Messages window.
 
+Next error indicator                                      Jumps to the next error indicator.
+                                                          Indicators are usually used to
+                                                          show compile errors or warnings, misspelled
+                                                          words or other hints.
+
+Previous error indicator                                  Jumps to the the previous error indicator.
+
 Find Usage                      Ctrl-Shift-E              Finds all occurrences of the current word
                                                           or selection (see note below) in all open
                                                           documents and displays them in the messages

--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -553,6 +553,10 @@ static void init_default_kb(void)
 		0, 0, "menu_nextmessage", _("Next Message"), "next_message1");
 	add_kb(group, GEANY_KEYS_SEARCH_PREVIOUSMESSAGE, NULL,
 		0, 0, "menu_previousmessage", _("Previous Message"), "previous_message1");
+	add_kb(group, GEANY_KEYS_SEARCH_NEXTERRORINDICATOR, NULL,
+		0, 0, "menu_nexterrorindicator", _("Next Error Indicator"), NULL);
+	add_kb(group, GEANY_KEYS_SEARCH_PREVIOUSERRORINDICATOR, NULL,
+		0, 0, "menu_previouserrorindicator", _("Previous Error Indicator"), NULL);
 	add_kb(group, GEANY_KEYS_SEARCH_FINDUSAGE, NULL,
 		GDK_KEY_e, GEANY_PRIMARY_MOD_MASK | GDK_SHIFT_MASK, "popup_findusage",
 		_("Find Usage"), "find_usage1");
@@ -1565,7 +1569,7 @@ static void cb_func_menu_help(G_GNUC_UNUSED guint key_id)
 
 static gboolean cb_func_search_action(guint key_id)
 {
-	GeanyDocument *doc = document_get_current();
+	GeanyDocument *doc;
 	ScintillaObject *sci;
 
 	/* these work without docs */
@@ -1578,6 +1582,7 @@ static gboolean cb_func_search_action(guint key_id)
 		case GEANY_KEYS_SEARCH_PREVIOUSMESSAGE:
 			on_previous_message1_activate(NULL, NULL); return TRUE;
 	}
+	doc = document_get_current();
 	if (!doc)
 		return TRUE;
 	sci = doc->editor->sci;
@@ -1600,6 +1605,10 @@ static gboolean cb_func_search_action(guint key_id)
 			on_find_usage1_activate(NULL, NULL); break;
 		case GEANY_KEYS_SEARCH_FINDDOCUMENTUSAGE:
 			on_find_document_usage1_activate(NULL, NULL); break;
+		case GEANY_KEYS_SEARCH_NEXTERRORINDICATOR:
+			search_find_next_error_indicator(sci); break;
+		case GEANY_KEYS_SEARCH_PREVIOUSERRORINDICATOR:
+			search_find_previous_error_indicator(sci); break;
 		case GEANY_KEYS_SEARCH_MARKALL:
 		{
 			gchar *text = NULL;

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -281,6 +281,10 @@ enum GeanyKeyBindingID
 												 * @since 2.0 (API 243) */
 	GEANY_KEYS_TOGGLE_MENUBAR,					/**< Keybinding.
 												 * @since 2.2 (API 251) */
+	GEANY_KEYS_SEARCH_NEXTERRORINDICATOR,		/**< Keybinding.
+												 * @since 2.2 (API 251) */
+	GEANY_KEYS_SEARCH_PREVIOUSERRORINDICATOR,	/**< Keybinding.
+												 * @since 2.2 (API 251) */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };
 

--- a/src/search.h
+++ b/src/search.h
@@ -128,6 +128,10 @@ gint search_find_prev(struct _ScintillaObject *sci, const gchar *str, GeanyFindF
 
 gint search_find_next(struct _ScintillaObject *sci, const gchar *str, GeanyFindFlags flags, GeanyMatchInfo **match_);
 
+void search_find_previous_error_indicator(struct _ScintillaObject *sci);
+
+void search_find_next_error_indicator(struct _ScintillaObject *sci);
+
 gint search_find_text(struct _ScintillaObject *sci, GeanyFindFlags flags, struct Sci_TextToFind *ttf, GeanyMatchInfo **match_);
 
 void search_find_again(gboolean change_direction);


### PR DESCRIPTION
This is useful to navigate between compiler errors but also other kinds of error indicators set in Geany, e.g. by plugins like SpellCheck.

Related to https://github.com/geany/geany-plugins/issues/1522.