### PR TITLE
Use last document's directory as default save path

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -558,6 +558,7 @@ static void handle_switch_page(GeanyDocument *doc)
 	{
 		GtkEntry *filter_entry = GTK_ENTRY(ui_lookup_widget(main_widgets.window, "entry_tagfilter"));
 		const gchar *entry_text = gtk_entry_get_text(filter_entry);
+		const gchar *cwd_path = doc->real_path ? doc->real_path : doc->file_name;
 
 		sidebar_select_openfiles_item(doc);
 		ui_save_buttons_toggle(doc->changed);
@@ -578,8 +579,9 @@ static void handle_switch_page(GeanyDocument *doc)
 		document_check_disk_status(doc, TRUE);
 
 #ifdef HAVE_VTE
-		vte_cwd((doc->real_path != NULL) ? doc->real_path : doc->file_name, FALSE);
+		vte_cwd(cwd_path, FALSE);
 #endif
+		dialogs_set_default_dir(cwd_path);
 
 		g_signal_emit_by_name(geany_object, "document-activate", doc);
 	}

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -85,7 +85,24 @@ filesel_state = {
 };
 
 
+static gchar *default_save_dir;
+
+
 static gint filetype_combo_box_get_active_filetype(GtkComboBox *combo);
+
+
+/* sets the default directory for saving new files - no effect if NULL */
+void dialogs_set_default_dir(const gchar *filename) {
+	if (filename) {
+		if (default_save_dir)
+			g_free(default_save_dir);
+
+		if (g_file_test(filename, G_FILE_TEST_IS_DIR))
+			default_save_dir = g_strdup(filename);
+		else
+			default_save_dir = g_path_get_dirname(filename);
+	}
+}
 
 
 /* gets the ID of the current file filter */
@@ -698,6 +715,9 @@ static gboolean show_save_as_gtk(GeanyDocument *doc)
 								doc->file_type->extension, NULL);
 		else
 			fname = g_strdup(GEANY_STRING_UNTITLED);
+
+		if (default_save_dir)
+			gtk_file_chooser_set_current_folder(dialog, default_save_dir);
 
 		gtk_file_chooser_set_current_name(dialog, fname);
 

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -45,6 +45,8 @@ gboolean dialogs_show_input_numeric(const gchar *title, const gchar *label_text,
 gchar *dialogs_show_input(const gchar *title, GtkWindow *parent,
 	const gchar *label_text, const gchar *default_text);
 
+void dialogs_set_default_dir(const gchar *filename);
+
 
 #ifdef GEANY_PRIVATE
 

--- a/src/document.c
+++ b/src/document.c
@@ -2056,6 +2056,7 @@ gboolean document_save_file(GeanyDocument *doc, gboolean force)
 	gsize len;
 	gchar *locale_filename;
 	const GeanyFilePrefs *fp;
+	const gchar *cwd_path;
 
 	g_return_val_if_fail(doc != NULL, FALSE);
 
@@ -2172,9 +2173,11 @@ gboolean document_save_file(GeanyDocument *doc, gboolean force)
 
 		msgwin_status_add(_("File %s saved."), doc->file_name);
 		ui_update_statusbar(doc);
+		cwd_path = doc->real_path ? doc->real_path : doc->file_name;
 #ifdef HAVE_VTE
-		vte_cwd((doc->real_path != NULL) ? doc->real_path : doc->file_name, FALSE);
+		vte_cwd(cwd_path, FALSE);
 #endif
+		dialogs_set_default_dir(cwd_path);
 	}
 	g_free(locale_filename);
 


### PR DESCRIPTION
This is implemented in essentially the same way as the VTE's "follow path" feature. The goal is to reduce the amount of directory browsing that needs to happen in common use cases like adding a new file to a deeply nested directory.

Addresses issue #1492.