### PR TITLE
CI: Windows: Loosen SignPath action dependency

### DIFF
--- a/.github/workflows/windows-msys2-build.yml
+++ b/.github/workflows/windows-msys2-build.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: SignPath Signing
         id: sign-artifact
-        uses: signpath/github-action-submit-signing-request@v2.0
+        uses: signpath/github-action-submit-signing-request@v2
         # Only sign artifacts on tags
         if: matrix.build-tool == 'autotools' && (inputs.sign_artifacts || startsWith(github.ref, 'refs/tags/'))
         with:


### PR DESCRIPTION
Use v2 as recommended in their documentation, rather then the very specific v2.0.

This doesn't change anything currently as 2.0 is the latest version.

CC @giuspen @eht16 any reason why we used a specific pin?