### PR TITLE
Rename GEANY_KEYS_TOGGLE_MENUBAR to GEANY_KEYS_VIEW_TOGGLE_MENUBAR

### DIFF
--- a/src/keybindings.c
+++ b/src/keybindings.c
@@ -608,7 +608,7 @@ static void init_default_kb(void)
 		"menu_toggle_all_additional_widgets1");
 	add_kb(group, GEANY_KEYS_VIEW_FULLSCREEN, cb_func_menu_fullscreen,
 		GDK_KEY_F11, 0, "menu_fullscreen", _("Fullscreen"), "menu_fullscreen1");
-	add_kb(group, GEANY_KEYS_TOGGLE_MENUBAR, NULL,
+	add_kb(group, GEANY_KEYS_VIEW_TOGGLE_MENUBAR, NULL,
 		0, 0, "toggle_menubar", _("Toggle Menubar"), "menu_show_menubar1");
 	add_kb(group, GEANY_KEYS_VIEW_MESSAGEWINDOW, cb_func_menu_messagewindow,
 		0, 0, "menu_messagewindow", _("Toggle Messages Window"),
@@ -1669,7 +1669,7 @@ static gboolean cb_func_view_action(guint key_id)
 		case GEANY_KEYS_VIEW_ZOOMRESET:
 			on_normal_size1_activate(NULL, NULL);
 			break;
-		case GEANY_KEYS_TOGGLE_MENUBAR:
+		case GEANY_KEYS_VIEW_TOGGLE_MENUBAR:
 			on_toggle_menubar(NULL, NULL);
 			break;
 		default:

--- a/src/keybindings.h
+++ b/src/keybindings.h
@@ -279,7 +279,7 @@ enum GeanyKeyBindingID
 												 * @since 1.38 (API 240) */
 	GEANY_KEYS_PROJECT_NEW_FROM_FOLDER,			/**< Keybinding.
 												 * @since 2.0 (API 243) */
-	GEANY_KEYS_TOGGLE_MENUBAR,					/**< Keybinding.
+	GEANY_KEYS_VIEW_TOGGLE_MENUBAR,				/**< Keybinding.
 												 * @since 2.2 (API 251) */
 	GEANY_KEYS_COUNT	/* must not be used by plugins */
 };

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -1033,7 +1033,7 @@ void ui_menubar_show_hide(gboolean show)
 	GtkWidget *editor_separator_item = ui_lookup_widget(main_widgets.editor_menu, "show_menubar_separator1");
 	GtkWidget *editor_show_menubar_item = ui_lookup_widget(main_widgets.editor_menu, "show_menubar1");
 	GeanyKeyGroup *group = keybindings_get_core_group(GEANY_KEY_GROUP_VIEW);
-	GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_TOGGLE_MENUBAR);
+	GeanyKeyBinding *kb = keybindings_get_item(group, GEANY_KEYS_VIEW_TOGGLE_MENUBAR);
 
 	if (!show && kb->key == 0)
 		return;  /* don't allow hiding menubar when no keybinding set */


### PR DESCRIPTION
To make the naming consistent with  other key names.

See https://github.com/geany/geany-plugins/pull/1534