### PR TITLE
german locale fix

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1268,7 +1268,7 @@ msgstr "Leerzeichen und Tabulatoren am Zeilenende entfernen"
 
 #: data/geany.glade:4673
 msgid "Removes trailing spaces and tabs at the end of lines"
-msgstr "Entfernt Leerzeichen und Tabulatoren am Ende einer Zeile"
+msgstr "Entfernt Leerzeichen und Tabulatoren am Ende jeder Zeile"
 
 #: data/geany.glade:4685 data/geany.glade:9538 src/keybindings.c:674
 msgid "Replace tabs with space"


### PR DESCRIPTION

The translation ```"Entfernt Leerzeichen und Tabulatoren am Ende einer Zeile"```

literally translates to ```"Removes spaces and tabs at the end of a line"```

which differs in meaning from the code and English original ```"Removes trailing spaces and tabs at the end of lines"```

The translation omits the plural for line, which makes it difficult to understand without context.

This fix replaces `a`/`einer` with `every`/`jeder` before `line` for the German translation.
