### PR TITLE
doc: Fix default Windows IPC port

### DIFF
--- a/doc/geany.txt
+++ b/doc/geany.txt
@@ -2796,7 +2796,7 @@ number_non_ft_menu_items                 The maximum number of menu items in the
 number_exec_menu_items                   The maximum number of menu items in the      2            on restart
                                          execute section of the Build menu.
 **``socket`` group**
-socket_remote_cmd_port                   TCP port number to be used for inter         2            on restart
+socket_remote_cmd_port                   TCP port number to be used for inter         45937        on restart
                                          process communication (i.e. with other
                                          Geany instances, e.g. "Open with Geany").
                                          Only available on Windows, valid port


### PR DESCRIPTION
Use the real default value of `socket_remote_cmd_port`, which is controlled by the `SOCKET_WINDOWS_REMOTE_CMD_PORT` macro.