### PR TITLE
Fixes for Forth

### DIFF
--- a/ctags/optlib/forth.c
+++ b/ctags/optlib/forth.c
@@ -46,12 +46,12 @@ extern parserDefinition* ForthParser (void)
 	static tagRegexTable ForthTagRegexTable [] = {
 		{"^[[:space:]]*\\\\.*", "",
 		"", "{exclusive}", NULL, false},
-		{"^:[[:space:]]+([^[:space:]]+)", "\\1",
-		"w", "{exclusive}", NULL, false},
-		{"^variable[[:space:]]+([^[:space:]]+)", "\\1",
-		"v", "{exclusive}{icase}", NULL, false},
-		{"^[[:alnum:]]+[[:space:]]+constant[[:space:]]+([^[:space:]]+)", "\\1",
-		"c", "{exclusive}{icase}", NULL, false},
+		{"(^|[[:space:]]+):[[:space:]]+([^[:space:]]+)", "\\2",
+		"w", NULL, NULL, false},
+		{"variable[[:space:]]+([^[:space:]]+)", "\\1",
+		"v", "{icase}", NULL, false},
+		{"constant[[:space:]]+([^[:space:]]+)", "\\1",
+		"c", "{icase}", NULL, false},
 	};
 
 	static selectLanguage selectors[] = { selectFortranOrForthByForthMarker, NULL };

--- a/scintilla/lexilla/lexers/LexForth.cxx
+++ b/scintilla/lexilla/lexers/LexForth.cxx
@@ -133,7 +133,7 @@ static void ColouriseForthDoc(Sci_PositionU startPos, Sci_Position length, int i
 				sc.SetState(SCE_FORTH_IDENTIFIER);
 			} else if (sc.ch == '{') {
 				sc.SetState(SCE_FORTH_LOCALE);
-			} else if (sc.ch == ':' && IsASCII(sc.chNext) && isspace(sc.chNext)) {
+			} else if (sc.ch == ':' && IsASCII(sc.chNext) && isspace(sc.chNext) && (sc.atLineStart || IsASpaceChar(sc.chPrev))) {
 				// highlight word definitions e.g.  : GCD ( n n -- n ) ..... ;
 				//                                  ^ ^^^
 				sc.SetState(SCE_FORTH_DEFWORD);


### PR DESCRIPTION
Tags weren't parsed if the code contained indentations. The ctags/optlib/forth.c version has been updated to the current version of the file from universal-ctags. 
Syntax highlighting has also been fixed when a colon was part of another word, such as "[:".