### PR TITLE
[msgwindow] Fix Compiler jump to file

### DIFF
--- a/src/msgwindow.c
+++ b/src/msgwindow.c
@@ -1097,16 +1097,30 @@ void msgwin_parse_compiler_error_line(const gchar *string, const gchar *dir,
 	if (G_UNLIKELY(string == NULL))
 		return;
 
-	if (dir == NULL)
-		utf8_dir = utils_get_utf8_from_locale(build_info.dir);
-	else
+	if(dir)
+	{
 		utf8_dir = g_strdup(dir);
+		ft=filetypes[build_info.file_type_id];
+	}
+	else if(build_info.dir)
+	{
+		utf8_dir = utils_get_utf8_from_locale(build_info.dir);
+		ft=filetypes[build_info.file_type_id];
+	}
+	else if(document_get_current())
+	{
+		//fake a build info from the document.
+		GeanyDocument* doc=document_get_current();
+		gchar* doc_path =g_path_get_dirname(doc->real_path);
+		utf8_dir = utils_get_utf8_from_locale(doc_path);
+		g_free(doc_path);
+		ft = doc->file_type;
+	}
+
 	g_return_if_fail(utf8_dir != NULL);
 
 	trimmed_string = g_strdup(string);
 	g_strchug(trimmed_string); /* remove possible leading whitespace */
-
-	ft = filetypes[build_info.file_type_id];
 
 	/* try parsing with a custom regex */
 	if (!filetypes_parse_error_message(ft, trimmed_string, filename, line))


### PR DESCRIPTION
as noted in geany/geany#4609 if you write a red message to Compiler before any Build commands have run, it throws an assertion about 
```(geany:50197): Geany-CRITICAL **: 22:18:49.055: msgwin_parse_compiler_error_line: assertion 'utf8_dir != NULL' failed```
on click.

This adds a third option to msgwindow to try to guess the path from the current document, if it exists.

This is similar to existing logic msgwindow.c@913

This fixes geany/geany#4609 for anyone who uses Compiler outside of Build being activated. Allowing them to utilize Build's predefined error parsing logic.

Contributed under GNU GENERAL PUBLIC LICENSE Version 2