### PR TITLE
[windows] honor default eol on 0 len files

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -114,6 +114,19 @@ void utils_open_browser(const gchar *uri)
 /* taken from anjuta, to determine the EOL mode of the file */
 gint utils_get_line_endings(const gchar* buffer, gsize size)
 {
+	/* early exit for 0 len files. */
+	if(size==0)
+	{
+		if(file_prefs.default_eol_character >= 0 && file_prefs.default_eol_character < 3)
+		{
+			return file_prefs.default_eol_character;
+		}
+		else
+		{
+			return GEANY_DEFAULT_EOL_CHARACTER;
+		}
+	}
+
 	gsize i;
 	guint cr, lf, crlf, max_mode;
 	gint mode;


### PR DESCRIPTION
From #1950 Implement Option 3.

> Re-write the weighting so it defaults to file_prefs.default_eol_character, but leave the weighting in place.

Fixes #1950
This is contributed under GPL-2.0-or-later