### PR TITLE
[config] SESSION_FILE ensure fallback consistency

### DIFF
--- a/src/keyfile.c
+++ b/src/keyfile.c
@@ -153,7 +153,7 @@ static gchar *get_keyfile_for_payload(ConfigPayload payload)
 					logged = TRUE;
 				}
 				g_free(file);
-				file = g_build_filename(app->configdir, PREFS_FILE, NULL);
+				file = get_keyfile_for_payload(PREFS);
 			}
 			return file;
 		case MAX_PAYLOAD:


### PR DESCRIPTION
Why?
There is a chance that the session handler will split into multiple locations.
How?
Ensure that SESSION_FILE uses the same logic as PREFS_FILE by calling get_keyfile_for_payload(PREFS)


Fixes https://github.com/geany/geany/issues/4640
Contributed under GPL-2.0-or-later