### PR TITLE
Make accelerators of hidden menubar menu items work on macOS

### DIFF
--- a/src/osx.c
+++ b/src/osx.c
@@ -86,6 +86,17 @@ static void on_new_window(GtkMenuItem *menuitem, G_GNUC_UNUSED gpointer user_dat
 }
 
 
+/* Since the menubar is hidden, gtk_widget_can_activate_accel() returns FALSE
+ * for all its menu items because they aren't on screen, and their accelerators
+ * don't get activated. Return TRUE from the menubar's can-activate-accel
+ * handler so accelerators of the (visible) global macOS menubar work. */
+static gboolean can_activate_accel(GtkWidget *widget, guint signal_id,
+	G_GNUC_UNUSED gpointer user_data)
+{
+	return TRUE;
+}
+
+
 void osx_ui_init(void)
 {
 	GtkWidget *item, *menu;
@@ -94,6 +105,7 @@ void osx_ui_init(void)
 	item = ui_lookup_widget(main_widgets.window, "menubar1");
 	gtk_widget_hide(item);
 	gtkosx_application_set_menu_bar(osx_app, GTK_MENU_SHELL(item));
+	g_signal_connect(item, "can-activate-accel", G_CALLBACK(can_activate_accel), NULL);
 
 	item = ui_lookup_widget(main_widgets.window, "menu_quit1");
 	gtk_widget_hide(item);


### PR DESCRIPTION
### Problem

On macOS, various keybindings silently do nothing even though clicking the
corresponding menu item works fine:

- Project Organizer's "Go to Anywhere" and the other goto keybindings
  (geany/geany-osx#61) — curiously, they *do* work while a menubar menu is open
- default zoom hotkeys `Cmd++`/`Cmd+-` on keyboard layouts where `+`/`-` are
  shifted keys (geany/geany-osx#32)
- Toggle Case of Selection, `Cmd+Option+U` (geany/geany-osx#52,
  geany/geany-osx#39)

### Root cause

On macOS the GTK menubar is hidden and handed to gtk-mac-integration
(`gtkosx_application_set_menu_bar()`). GTK however refuses to activate
accelerators of menu items that are not "onscreen":
`gtk_widget_real_can_activate_accel()` requires the widget to be drawable, and
the `can-activate-accel` check of every menu item chains up
item → menu → attach widget → menubar. With the menubar hidden, the check fails
at the last hop, so *every* accelerator attached to a menubar menu item by
`apply_kb_accel()` is dead. The Cocoa side can't pick these keys up either
because quartz accelerator handling is intentionally disabled (see ada459526).

Most keybindings are unaffected because they are dispatched with a real
callback from Geany's central `on_key_press_event()`. The broken ones are
exactly those where the menu item accelerator is the actual dispatch mechanism:

- Plugin keybindings registered without a callback that rely on menu item
  activation (Project Organizer's goto keybindings). This also explains the
  "works while the menu is open" mystery in geany/geany-osx#61: an open NSMenu
  handles the keystroke itself via the key equivalent gtk-mac-integration
  syncs onto the NSMenuItem and activates the GtkMenuItem directly, bypassing
  GDK/GTK key delivery entirely.
- Core keybindings whose combo Geany's own matcher cannot match, but GTK's
  accelerator machinery can:
  - `Cmd+Shift+=` for Zoom In: the event has `Shift` in its state so Geany's
    exact state comparison fails; GTK matches it because it computes Shift as
    *consumed* by producing `+`. (This is why the same combo works on Linux —
    via the menu accelerator, not via Geany's handler.)
  - `Cmd+Option+U` for Toggle Case: GDK-quartz treats Option as a keyboard
    *group*, so the event keyval is the Option-layer character (a dead key on
    US/German layouts), not `u`. GTK's accel matching compensates by stripping
    the group modifier and re-translating (`_gtk_translate_keyboard_accel_state()`),
    so the accelerator would match — if activation weren't blocked.

### Fix

Connect a `can-activate-accel` handler returning `TRUE` to the hidden menubar.
The signal uses the boolean-handled accumulator, so the handler overrides the
default "onscreen" check, and since the checks of all menubar menu items
terminate at the menubar widget, a single connection covers all menus,
including those added by plugins.

This does not resurrect the problem for which quartz accelerators were
disabled in ada459526 (accelerators firing from dialogs): the keybinding accel
group is attached only to the main window, and `gtk_window_activate_key()`
only consults accel groups of the toplevel that received the key event.

Fixes geany/geany-osx#61
Fixes geany/geany-osx#32
Fixes geany/geany-osx#52
Fixes geany/geany-osx#39

### Testing

Tested on macOS with:
- [x] Project Organizer "Go to Anywhere" keybinding (menu closed)
- [x] `Cmd+Shift+=` / `Cmd+-` zoom on a US layout
- [x] `Cmd+Option+U` Toggle Case
- [ ] Regression: with the Find dialog focused, `Cmd+V` pastes into the dialog
      entry, not the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVgutoKSw7RudG1sC5n3VA
